### PR TITLE
Fix Learn View/WebView2 pane corruption (stale mangled content + gray flashing)

### DIFF
--- a/patches/0035-dxgi-make-never-attributed-layered-dcomp-targets-dis.patch
+++ b/patches/0035-dxgi-make-never-attributed-layered-dcomp-targets-dis.patch
@@ -1,0 +1,208 @@
+From 0b6ee3cfeaf545e2c270aa1ca3d132bae5aa778a Mon Sep 17 00:00:00 2001
+From: dist <build@localhost>
+Date: Wed, 15 Jul 2026 09:52:27 +0200
+Subject: [PATCH] dxgi: make never-attributed layered dcomp targets displayable
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+On Windows a WS_EX_NOREDIRECTIONBITMAP DComp target window bypasses the
+layered redirection surface entirely: WS_EX_LAYERED is set but never given
+attributes, and DWM displays the composition visual directly.  Wine has no
+DWM; this dcomp stack emulates presentation with GDI blits into the window
+surface — but Wine also faithfully emulates 'layered without attributes is
+not displayed', so those blits never reach the screen.  WebView2's Learn
+View pane then shows the sibling Chrome_RenderWidgetHostHWND's stale
+software-fallback frame, drawn once at old geometry: the mangled band and
+flicker (XDamage-verified: zero X-side damage from correct-size blits;
+stripping WS_EX_LAYERED live healed the pane instantly).
+
+Three coupled fixes:
+- WM_WINE_DCOMP_SET_TARGET: strip never-attributed WS_EX_LAYERED from the
+  adopted target (both full and popup mode); restore it if the swapchain is
+  released while the window survives.  WS_EX_TRANSPARENT stays, so the
+  software fallback sibling can still paint if Chromium abandons GPU
+  compositing (transparent siblings do not clip each other).
+- WM_PAINT with a stale-size comp buffer: paint the last frame scaled to the
+  current client rect instead of validating without painting (patch 0030's
+  gate left black holes: BeginPaint validates, no later WM_PAINT comes).
+- dcomp_reblit_comp_buffer stale skip: leave the region invalidated so a
+  paint follows — closes the 0030-caveat cross-thread race between the
+  windowposchanged reblit and ResizeBuffers.
+
+Now the target window itself carries correct frames end-to-end, the fallback
+never shows through during active presentation, and every transient
+stale-size window converges on the next present.
+---
+ dlls/dxgi/factory.c   | 87 +++++++++++++++++++++++++++++++++++++++----
+ dlls/dxgi/swapchain.c | 10 +++++
+ 2 files changed, 89 insertions(+), 8 deletions(-)
+
+diff --git a/dlls/dxgi/factory.c b/dlls/dxgi/factory.c
+index 9906de8..1f097ee 100644
+--- a/dlls/dxgi/factory.c
++++ b/dlls/dxgi/factory.c
+@@ -446,6 +446,13 @@ static void dcomp_reblit_comp_buffer(HWND hwnd, const char *reason)
+             if (stale_count <= 5 || !(stale_count % 200))
+                 FIXME("Re-blit skipped (stale %ux%u buffer): hwnd %p reason=%s.\n",
+                         w, h, hwnd, reason);
++            /* The skipped blit was going to repair the window surface; leave
++             * the region invalid so WM_PAINT repaints it (scaled placeholder,
++             * see dcomp_target_wndproc) instead of stranding stale pixels.
++             * Closes the ResizeBuffers-vs-windowposchanged cross-thread race:
++             * whichever way it resolves, a paint follows and the next present
++             * lands correct pixels. */
++            InvalidateRect(hwnd, NULL, FALSE);
+             return;
+         }
+ 
+@@ -557,6 +564,42 @@ static void dcomp_restore_parent_clip(HWND hwnd)
+     }
+ }
+ 
++/* On Windows a WS_EX_NOREDIRECTIONBITMAP DComp target never uses the layered
++ * redirection surface: WS_EX_LAYERED is set but no attributes are ever given,
++ * and DWM shows the composition visual directly.  Wine has no DWM; this dcomp
++ * stack emulates presentation with GDI blits into the window surface.  But a
++ * never-attributed layered window is invisible by definition (the server marks
++ * it SWP_NOREDRAW, no displayable surface), so every present/reblit lands in a
++ * surface that is never shown — WebView2's Learn View pane then displays the
++ * sibling Chrome_RenderWidgetHostHWND's stale software fallback frame drawn
++ * at old geometry (mangled band + flicker) instead of the correct D3D frames.
++ * Strip WS_EX_LAYERED when adopting such a window as blit target so it becomes
++ * an ordinary child whose surface our blits actually reach.  WS_EX_TRANSPARENT
++ * is kept: transparent siblings do not clip each other, so the software
++ * fallback below can still paint if Chromium abandons GPU compositing (the
++ * DCOMP_STALE_TICKS machinery then keeps our reblits out of its way).
++ * Windows that DID get layered attributes (JUCE DropShadower shadows etc.)
++ * are real layered windows and are left alone. */
++static void dcomp_make_target_displayable(HWND hwnd)
++{
++    LONG ex_style = GetWindowLongW(hwnd, GWL_EXSTYLE);
++    COLORREF key;
++    BYTE alpha;
++    DWORD lw_flags;
++
++    if (!(ex_style & WS_EX_LAYERED))
++        return;
++    if (GetLayeredWindowAttributes(hwnd, &key, &alpha, &lw_flags))
++        return; /* attributed: a real layered window, not a DComp shell */
++
++    SetWindowLongW(hwnd, GWL_EXSTYLE, ex_style & ~WS_EX_LAYERED);
++    SetWindowPos(hwnd, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER
++            | SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
++    SetPropW(hwnd, L"__wine_dcomp_unlayered", (HANDLE)1);
++    FIXME("DComp: stripped never-attributed WS_EX_LAYERED from target %p (ex was %#lx).\n",
++            hwnd, (unsigned long)ex_style);
++}
++
+ /* Lightweight subclass for DComp popup windows (menus, tooltips).
+  * Only blocks WM_ERASEBKGND and re-blits composition content on WM_PAINT.
+  * NO timer, NO periodic Present â avoids dual-swapchain
+@@ -651,6 +694,7 @@ static LRESULT CALLBACK dcomp_popup_wndproc(HWND hwnd, UINT msg, WPARAM wparam,
+             RemovePropW(hwnd, L"__wine_dcomp_swapchain");
+             RemovePropW(hwnd, L"__wine_dcomp_comp_dc");
+             RemovePropW(hwnd, L"__wine_dcomp_comp_size");
++            RemovePropW(hwnd, L"__wine_dcomp_unlayered");
+             return result;
+         }
+     }
+@@ -686,18 +730,42 @@ static LRESULT CALLBACK dcomp_target_wndproc(HWND hwnd, UINT msg, WPARAM wparam,
+                             : DefWindowProcW(hwnd, msg, wparam, lparam);
+ 
+             BeginPaint(hwnd, &ps);
+-            if (comp_dc && dims
+-                    && dcomp_comp_buffer_current(hwnd, LOWORD(dims), HIWORD(dims)))
++            if (comp_dc && dims)
+             {
+                 unsigned int w = LOWORD(dims);
+                 unsigned int h = HIWORD(dims);
+-                BitBlt(ps.hdc, 0, 0, w, h, comp_dc, 0, 0, SRCCOPY);
++
++                if (dcomp_comp_buffer_current(hwnd, w, h))
++                {
++                    BitBlt(ps.hdc, 0, 0, w, h, comp_dc, 0, 0, SRCCOPY);
++                    {
++                        static unsigned int paint_count;
++                        ++paint_count;
++                        if (paint_count <= 5 || !(paint_count % 200))
++                            FIXME("WM_PAINT #%u: hwnd %p %ux%u, comp_dc=%p.\n",
++                                    paint_count, hwnd, w, h, comp_dc);
++                    }
++                }
++                else
+                 {
+-                    static unsigned int paint_count;
+-                    ++paint_count;
+-                    if (paint_count <= 5 || !(paint_count % 200))
+-                        FIXME("WM_PAINT #%u: hwnd %p %ux%u, comp_dc=%p.\n",
+-                                paint_count, hwnd, w, h, comp_dc);
++                    /* Stale-size buffer (mid create->resize dance): a 1:1 blit
++                     * would paint the misframed band (see
++                     * dcomp_comp_buffer_current), but painting nothing leaves a
++                     * black hole — BeginPaint has already validated the region
++                     * and no later WM_PAINT will repair it.  Scale the last
++                     * frame to the current client size as a placeholder; the
++                     * next present overwrites it with correct pixels. */
++                    RECT rc;
++                    static unsigned int paint_stale;
++
++                    GetClientRect(hwnd, &rc);
++                    SetStretchBltMode(ps.hdc, HALFTONE);
++                    StretchBlt(ps.hdc, 0, 0, rc.right, rc.bottom,
++                            comp_dc, 0, 0, w, h, SRCCOPY);
++                    ++paint_stale;
++                    if (paint_stale <= 5 || !(paint_stale % 200))
++                        FIXME("WM_PAINT #%u (stale %ux%u buffer): hwnd %p scaled to %ldx%ld.\n",
++                                paint_stale, w, h, hwnd, rc.right, rc.bottom);
+                 }
+             }
+             else
+@@ -824,6 +892,7 @@ static LRESULT CALLBACK dcomp_target_wndproc(HWND hwnd, UINT msg, WPARAM wparam,
+             RemovePropW(hwnd, L"__wine_dcomp_comp_size");
+             RemovePropW(hwnd, L"__wine_dcomp_last_present");
+             RemovePropW(hwnd, L"__wine_dcomp_idle_ticks");
++            RemovePropW(hwnd, L"__wine_dcomp_unlayered");
+             return result;
+         }
+     }
+@@ -970,6 +1039,7 @@ static LRESULT CALLBACK dcomp_swapchain_wndproc(HWND hwnd, UINT msg, WPARAM wpar
+                             InterlockedIncrement(&dcomp_subclassed_target_count);
+                             dcomp_update_active_prop();
+                             dcomp_popup_stack_push(target_hwnd);
++                            dcomp_make_target_displayable(target_hwnd);
+                             FIXME("DComp POPUP mode: target %p, orig wndproc %p, sc=%p, transient->%p (reblit timer 200ms).\n",
+                                     target_hwnd, orig, iface, popup_parent);
+                         }
+@@ -993,6 +1063,7 @@ static LRESULT CALLBACK dcomp_swapchain_wndproc(HWND hwnd, UINT msg, WPARAM wpar
+                             dcomp_update_active_prop();
+                             /* Main window: stack base for the first popup's transient anchor. */
+                             dcomp_popup_stack_push(target_hwnd);
++                            dcomp_make_target_displayable(target_hwnd);
+                             FIXME("DComp: subclassed target %p, orig wndproc %p, timer started, sc=%p.\n",
+                                     target_hwnd, orig, iface);
+                         }
+diff --git a/dlls/dxgi/swapchain.c b/dlls/dxgi/swapchain.c
+index 577ae1f..ea98801 100644
+--- a/dlls/dxgi/swapchain.c
++++ b/dlls/dxgi/swapchain.c
+@@ -300,6 +300,16 @@ static ULONG STDMETHODCALLTYPE d3d11_swapchain_Release(IDXGISwapChain4 *iface)
+                 KillTimer(t, DCOMP_POPUP_REBLIT_TIMER_ID);
+                 if (orig)
+                     SetWindowLongPtrW(t, GWLP_WNDPROC, (LONG_PTR)orig);
++                /* If adoption stripped never-attributed WS_EX_LAYERED (see
++                 * dcomp_make_target_displayable), give the surviving window
++                 * its style back — without a swapchain we no longer supply
++                 * its pixels, and the owner may re-target it. */
++                if (GetPropW(t, L"__wine_dcomp_unlayered"))
++                {
++                    SetWindowLongW(t, GWL_EXSTYLE,
++                            GetWindowLongW(t, GWL_EXSTYLE) | WS_EX_LAYERED);
++                    RemovePropW(t, L"__wine_dcomp_unlayered");
++                }
+                 RemovePropW(t, L"__wine_dcomp_orig_wndproc");
+                 RemovePropW(t, L"__wine_dcomp_comp_dc");
+                 RemovePropW(t, L"__wine_dcomp_comp_size");
+-- 
+2.51.0
+

--- a/patches/0036-server-dxgi-clip-adopted-dcomp-blit-targets-out-of-a.patch
+++ b/patches/0036-server-dxgi-clip-adopted-dcomp-blit-targets-out-of-a.patch
@@ -1,0 +1,169 @@
+From a2e191a5fd1503ea82a97034bf20f7b11831e5b0 Mon Sep 17 00:00:00 2001
+From: Janosch Tepesch <janosch@tepesch.dev>
+Date: Wed, 15 Jul 2026 12:22:44 +0200
+Subject: [PATCH] server, dxgi: clip adopted dcomp blit targets out of ancestor
+ rendering
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Ableton Live repaints its main view ~20x/s through a cache DC obtained
+without DCX_CLIPCHILDREN (SYSRGN probe: full client rect).  On Windows
+that is harmless: the WebView2 Learn View child has
+WS_EX_NOREDIRECTIONBITMAP, so DWM composites its DComp visual above the
+toplevel redirection surface and ancestor paints under it never reach
+the screen.  Wine emulates the visual with GDI blits into the shared
+toplevel X surface (from the WebView2 GPU process), so Live's unclipped
+paints and window-surface flushes overwrote the pane with placeholder
+gray; the dcomp reblit timer suspends 3s after the last present, leaving
+the pane overlap permanently gray (measured: pixel probes flip
+content->gray at Live's paint-rect boundary, exactly its damage rect,
+and stay gray once reblits suspend).
+
+Emulate the DWM occlusion at both levels the host writes through:
+
+- get_visible_region: always subtract visible descendants having
+  WS_EX_NOREDIRECTIONBITMAP without WS_EX_LAYERED, whatever DCX flags
+  the DC was opened with.  That ex-style combination exists exactly
+  while dxgi has a swapchain adopted on the window (WS_EX_LAYERED is
+  stripped at adoption; the window dies with the swapchain otherwise).
+- get_surface_region: punch the same hole into the toplevel's window
+  surface, like pixel-format children: the surface flush pushes the
+  dirty BOUNDING RECT, so without the hole a stale DIB region over the
+  pane gets re-pushed on every nearby flush even with all paints
+  clipped (the pane content itself is painted direct-to-X by another
+  process and never lands in this DIB).
+- dxgi adoption: nudge the toplevel with an async FRAMECHANGED
+  SetWindowPos — update_surface_region only runs in the surface
+  owner's process, so the cross-process ex-style change would
+  otherwise not refresh the host's surface clip until its next
+  incidental window move.
+
+Siblings are not affected, so the software-fallback path for abandoned
+swapchains keeps painting.
+---
+ dlls/dxgi/factory.c | 17 ++++++++++++
+ server/window.c     | 65 +++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 82 insertions(+)
+
+diff --git a/dlls/dxgi/factory.c b/dlls/dxgi/factory.c
+index 1f097ee..4c5adc3 100644
+--- a/dlls/dxgi/factory.c
++++ b/dlls/dxgi/factory.c
+@@ -598,6 +598,23 @@ static void dcomp_make_target_displayable(HWND hwnd)
+     SetPropW(hwnd, L"__wine_dcomp_unlayered", (HANDLE)1);
+     FIXME("DComp: stripped never-attributed WS_EX_LAYERED from target %p (ex was %#lx).\n",
+             hwnd, (unsigned long)ex_style);
++
++    /* The ex-style change makes the server clip this window out of ancestor
++     * DC visible regions AND the toplevel's window-surface region (DWM visual
++     * emulation, see server clip_composited_descendants).  The surface region
++     * is only recomputed by the surface owner's process in apply_window_pos —
++     * this code runs in the swapchain owner's process (e.g. WebView2's GPU
++     * process), whose update_surface_region call skips WND_OTHER_PROCESS.
++     * Nudge the toplevel: cross-thread SetWindowPos is routed to the owner
++     * thread via WM_WINE_SETWINDOWPOS, so the host app recomputes its surface
++     * clip and DCEs immediately instead of on its next incidental move. */
++    {
++        HWND toplevel = GetAncestor(hwnd, GA_ROOT);
++        if (toplevel && toplevel != hwnd)
++            SetWindowPos(toplevel, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE
++                    | SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOOWNERZORDER
++                    | SWP_FRAMECHANGED | SWP_ASYNCWINDOWPOS);
++    }
+ }
+ 
+ /* Lightweight subclass for DComp popup windows (menus, tooltips).
+diff --git a/server/window.c b/server/window.c
+index 6bff48e..1a17d34 100644
+--- a/server/window.c
++++ b/server/window.c
+@@ -1216,6 +1216,55 @@ static struct region *clip_children( struct window *parent, struct window *last,
+ }
+ 
+ 
++/* clip out visible descendants that are adopted DComp blit targets, i.e. windows
++ * with WS_EX_NOREDIRECTIONBITMAP and no WS_EX_LAYERED.  On Windows such windows
++ * display a DWM-composited DComp/DXGI visual that always covers ancestor
++ * rendering: GDI painted "under" them by an ancestor through a DC without
++ * DCX_CLIPCHILDREN is never visible on screen.  Wine emulates the visual with
++ * GDI blits into the shared toplevel surface (dlls/dxgi dcomp emulation), so
++ * ancestor paints must be kept out of the target's area or they overwrite the
++ * emulated visual on every ancestor redraw (Ableton Live repaints its main view
++ * ~20x/s through an unclipped cache DC right across its WebView2 Learn View
++ * pane; the dcomp reblit timer suspends after 3s idle, leaving the pane gray).
++ * The ex-style combination tracks adoption exactly: dxgi strips the
++ * never-attributed WS_EX_LAYERED when adopting a target and restores it on
++ * swapchain release, so unadopted shells keep normal semantics.  Unlike
++ * clip_children this must not skip WS_EX_TRANSPARENT windows - adopted targets
++ * are deliberately transparent so Chromium's software-fallback sibling can
++ * still paint over them when GPU compositing is abandoned; sibling clipping is
++ * likewise deliberately left alone here for that reason (ancestors only). */
++static struct region *clip_composited_descendants( struct window *parent, struct region *region,
++                                                   int offset_x, int offset_y )
++{
++    struct window *ptr;
++    struct region *tmp = create_empty_region();
++
++    if (!tmp) return NULL;
++    LIST_FOR_EACH_ENTRY( ptr, &parent->children, struct window, entry )
++    {
++        if (!(ptr->style & WS_VISIBLE)) continue;
++        if ((ptr->ex_style & (WS_EX_NOREDIRECTIONBITMAP | WS_EX_LAYERED)) == WS_EX_NOREDIRECTIONBITMAP)
++        {
++            set_region_rect( tmp, &ptr->visible_rect );
++            if (ptr->win_region && !intersect_window_region( tmp, ptr ))
++            {
++                free_region( tmp );
++                return NULL;
++            }
++            offset_region( tmp, offset_x, offset_y );
++            if (!(region = subtract_region( region, region, tmp ))) break;
++        }
++        else if (!(region = clip_composited_descendants( ptr, region,
++                                                         offset_x + ptr->client_rect.left,
++                                                         offset_y + ptr->client_rect.top )))
++            break;
++        if (is_region_empty( region )) break;
++    }
++    free_region( tmp );
++    return region;
++}
++
++
+ /* set the region to the client rect clipped by the window rect, in parent-relative coordinates */
+ static void set_region_client_rect( struct region *region, struct window *win )
+ {
+@@ -1289,6 +1338,15 @@ static struct region *get_visible_region( struct window *win, unsigned int flags
+         if (!clip_children( win, NULL, region, win->client_rect.left, win->client_rect.top )) goto error;
+     }
+ 
++    /* always clip adopted DComp targets in the subtree, they render above us like a DWM visual
++     * (DCX_CLIPCHILDREN handles direct subtrees, but not those under WS_EX_TRANSPARENT children) */
++
++    if (!is_region_empty( region ))
++    {
++        if (!clip_composited_descendants( win, region, win->client_rect.left, win->client_rect.top ))
++            goto error;
++    }
++
+     /* clip siblings of ancestors */
+ 
+     offset_x = win->window_rect.left;
+@@ -1394,6 +1452,13 @@ static struct region *get_surface_region( struct window *win )
+ 
+     if (!clip_pixel_format_children( win, clip, region, offset_x, offset_y )) goto error;
+ 
++    /* also punch out adopted DComp targets: the window surface flush pushes the
++     * dirty BOUNDING RECT, so without a surface-clip hole a stale surface region
++     * over the target gets re-pushed to screen on every nearby flush even though
++     * DC-level clipping keeps everyone from painting it (the dcomp emulation
++     * paints the target directly from another process, bypassing this surface) */
++    if (!clip_composited_descendants( win, region, offset_x, offset_y )) goto error;
++
+     free_region( clip );
+     return region;
+ 
+-- 
+2.51.0
+

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -31,4 +31,5 @@ d057c2e41a0b9646b0e139869f143328f3b4e9603abd77b8fd860f9a585ceab8  0031-comdlg32-
 a01b91a917004d0b2a69bb101a29fcd681c0cea9951fdc0ae787e21d4ff703d3  0032-libusb-1.0-add-host-USB-bridge-for-Push-2.patch
 6bd2836da3679670bc7f012f741f5a36c26490c5586298eea932c8375160437a  0033-ntdll-let-WINE_DISABLE_UNIX_MOUNT_REPARSE-turn-off-m.patch
 692c00a0a3544c2df21ce4014173340ed1c028e9f27aae47a6b0422046db45a0  0034-winex11-flush-XdndStatus-replies-before-the-source-s.patch
+2d34c89001381de46ddfabc1235ca9c67d11692f994fcbf063974c16d0266142  0035-dxgi-make-never-attributed-layered-dcomp-targets-dis.patch
 b34e6f293f457cb1f3352ed1e72691013bfe82c173cbd5ddbecf880905858bd1  wineasio/0001-asio-keep-backend-sample-rate-instead-of-ASE_NoClock.patch

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -32,4 +32,5 @@ a01b91a917004d0b2a69bb101a29fcd681c0cea9951fdc0ae787e21d4ff703d3  0032-libusb-1.
 6bd2836da3679670bc7f012f741f5a36c26490c5586298eea932c8375160437a  0033-ntdll-let-WINE_DISABLE_UNIX_MOUNT_REPARSE-turn-off-m.patch
 692c00a0a3544c2df21ce4014173340ed1c028e9f27aae47a6b0422046db45a0  0034-winex11-flush-XdndStatus-replies-before-the-source-s.patch
 2d34c89001381de46ddfabc1235ca9c67d11692f994fcbf063974c16d0266142  0035-dxgi-make-never-attributed-layered-dcomp-targets-dis.patch
+4aef3dbe13c10bc5e9baec43f96a932446dd64e05477775884d0070e7af7048f  0036-server-dxgi-clip-adopted-dcomp-blit-targets-out-of-a.patch
 b34e6f293f457cb1f3352ed1e72691013bfe82c173cbd5ddbecf880905858bd1  wineasio/0001-asio-keep-backend-sample-rate-instead-of-ASE_NoClock.patch

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -149,6 +149,7 @@ STAMP_ONLY='
 0029|logic-only (menu bar +4px arithmetic)
 0030|literal __wine_dcomp_swapchain pre-exists in base — not distinctive
 0034|logic-only (XdndStatus reply flush; adds no string literal)
+0036|logic-only (server: ancestor visible-region clip for adopted dcomp targets; no string literal)
 '
 wide_pattern() {  # ascii string -> PCRE matching its UTF-16LE bytes
     printf '%s' "$1" | od -An -v -tx1 | tr -d '\n' | tr -s ' ' ' ' \

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -119,6 +119,7 @@ FINGERPRINTS='
 0031|wide|lib/wine/x86_64-windows/comdlg32.dll|FileDialogPortal
 0032|ascii|lib/wine/x86_64-windows/libusb-1.0.dll|libusb_submit_transfer
 0033|ascii|lib/wine/x86_64-unix/ntdll.so|WINE_DISABLE_UNIX_MOUNT_REPARSE
+0035|wide|lib/wine/x86_64-windows/dxgi.dll|__wine_dcomp_unlayered
 wineasio/0001|ascii|lib/wine/x86_64-unix/wineasio64.dll.so|wineasio-clamp-sample-rate
 '
 # wineasio's code is in the unix .so; the PE wineasio64.dll is a codeless fake module.


### PR DESCRIPTION
Fixes the intermittent Learn View rendering defect documented in `notes/ABLETON-WINE-LEARNVIEW-FLICKER.md`. The initial hypothesis in that note (style-only mitigation) turned out to be necessary but not sufficient — there are two coupled defects, each fixed by one patch.

## Root cause 1 — patch 0035: the D3D target is never displayable

WebView2's `Intermediate D3D Window` carries `WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_NOREDIRECTIONBITMAP` and never receives layered attributes. On Windows, `WS_EX_NOREDIRECTIONBITMAP` bypasses layered redirection — DWM shows the DComp visual directly. Wine has no DWM: the dcomp stack emulates presentation with GDI blits into the window surface, but a never-attributed layered window is never displayed (wineserver marks it `SWP_NOREDRAW`), so every present/reblit landed in a surface that could not reach the screen — the pane showed Chromium's stale software-fallback sibling at old geometry (the mangled band).

**Fix:** strip the never-attributed `WS_EX_LAYERED` at swapchain adoption, restore on release (`__wine_dcomp_unlayered` prop). `WS_EX_TRANSPARENT` is kept so the software fallback still paints when Chromium abandons GPU compositing (the patch-0025 sidebar path is preserved). Also closes the patch-0030 black-hole window: WM_PAINT now paints a HALFTONE-scaled placeholder while the comp buffer is stale-gated instead of validating without painting.

## Root cause 2 — patch 0036: ancestors paint over the emulated visual

With the target displayable, a second defect surfaces: Live repaints its main view ~20x/s through a cache DC obtained **without** `DCX_CLIPCHILDREN` (SYSRGN probe shows the full client rect). Harmless on Windows — DWM composites the visual *above* the redirection surface. In Wine's shared-surface model those unclipped paints overwrite the pane (last-writer-wins), and once the reblit timer suspends 3 s after the last present, the pane overlap stays gray permanently. Measured live: pixel probes flip content→gray exactly at Live's damage-rect boundary, at the 200 ms reblit cadence.

**Fix:** emulate the DWM occlusion at both levels the host writes through — `get_visible_region` always subtracts visible descendants having `WS_EX_NOREDIRECTIONBITMAP` without `WS_EX_LAYERED` (exactly the adopted-target state), `get_surface_region` punches the same hole into the toplevel's window surface (the flush pushes the dirty *bounding* rect), and adoption nudges the toplevel with an async `FRAMECHANGED` SetWindowPos since the surface region is only recomputed in the surface owner's process.

## Scope guards / regression notes

- Siblings are deliberately unaffected: the software-fallback path for abandoned swapchains keeps painting (doc sidebar behavior preserved).
- JUCE DropShadower windows are layered **with** attributes → never match; SWAM-style d3d hwnd targets lack `WS_EX_NOREDIRECTIONBITMAP` → never match.
- Unadopted WebView2 shells keep stock semantics (the style strip only happens at dcomp adoption).

## Verification

Live 12.4.5b7, WoW64 container build, `WINEDEBUG=+dxgi,+dcomp` traces plus X-side probes: SYSRGN of every DC variant on Live's toplevel excludes exactly the pane rect after adoption; pane pixels stay on lesson content through reblit suspension and splitter resizes. Build audit passes with the two new entries (0035 has a binary fingerprint, `dxgi.dll` wide `__wine_dcomp_unlayered`).

## Known cosmetic residue (intentionally out of scope)

Because ancestors no longer paint under the visual, closing the pane leaves its rect on the last blitted frame until the host repaints it (mouse-over or a window resize heals it). We have a candidate follow-up for an explicit teardown reveal, but it needs more validation — kept out to keep this PR focused on the corruption fix. Happy to also upstream the SYSRGN diagnostic tool (`clipprobe.c`) used to prove root cause 2 if you want it in `tools/`.