### PR TITLE
Add native fractional DPI support for Hyprland

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ It verifies itself, installs the runtime, detects the display scale, creates the
 
 #### Display scale
 
-`setup-prefix.sh` and the launcher auto-detect the display scale (GNOME, KDE, sway, Hyprland, X11 `Xft.dpi`); the launcher recalibrates the prefix DPI on every start. Unfortunately, switching monitors still needs a Live restart if those monitors have different DPIs. You can manually override the default scaling behaviours with `ABLETON_DPI_MODE`.
+`setup-prefix.sh` and the launcher auto-detect the display scale (GNOME, KDE, sway, Hyprland, X11 `Xft.dpi`); the launcher recalibrates the prefix DPI on every start. Hyprland with `xwayland:force_zero_scaling` enabled uses exact application-side DPI (`round(96 * scale)`) and does not require a per-executable DPI override. Other uncalibrated compositor/XWayland strategies preserve existing prefix values. Unfortunately, switching monitors still needs a Live restart if those monitors have different DPIs. You can manually override the default scaling behaviours with `ABLETON_DPI_MODE`.
 
 ### Other environment variables
 
@@ -128,7 +128,7 @@ Mostly unnecessary. But in case you need them:
 
 - `ABLETON_WINE_ROOT` runtime path (default `~/.local/opt/wine-d2d1-nspa-11.11`)
 - `ABLETON_WINEPREFIX` prefix path (default `~/.wine-ableton`)
-- `ABLETON_DPI_MODE` `auto` | `preserve` | `100` | `fractional`
+- `ABLETON_DPI_MODE` `auto` | `preserve` | `100` | `fractional` | `native` — `native` uses exact application-side DPI from the detected scale; `fractional` retains the legacy 192-DPI/IFEO policy
 - `ABLETON_THEME_MODE` `auto` | `dark` | `light` | `preserve` — the launcher syncs Live's light/dark theme key to the desktop scheme on every start; this overrides it
 - `ABLETON_LIVE_EXE` full path to a Live exe inside the prefix, when more than one edition/version is installed (default: the newest found)
 - `PIPEASIO_*` audio driver overrides, e.g. `PIPEASIO_PREFERRED_BUFFERSIZE=512` if you hear crackles; defaults live in `~/.config/pipeasio/config.ini`

--- a/scripts/ableton-live
+++ b/scripts/ableton-live
@@ -49,22 +49,37 @@ if ! pgrep -af "Ableton Live.*\.exe" 2>/dev/null | grep -q "ProgramData"; then
     /usr/bin/wineserver -k 2>/dev/null || true
 fi
 
-# Recalibrate prefix DPI to the detected scale before each launch: 1.0 -> LogPixels 96 + no IFEO;
-# 1.25 -> LogPixels 192 + IFEO=2; else preserve. ABLETON_DPI_MODE=100|fractional|preserve overrides.
+# Recalibrate prefix DPI before each launch. Hyprland with XWayland zero
+# scaling uses exact application-side DPI with no IFEO; legacy 100%/Mutter
+# policies remain available. ABLETON_DPI_MODE=100|fractional|native|preserve
+# overrides auto detection.
 if ! pgrep -af "Ableton Live.*\.exe" 2>/dev/null | grep "ProgramData" >/dev/null; then
     dpi_mode="${ABLETON_DPI_MODE:-auto}"
-    if [ "$dpi_mode" = auto ]; then
-        dpi_lib="$HOME/.local/share/ableton-wine/detect-scale.sh"
-        dpi_mode=preserve
-        if [ -r "$dpi_lib" ]; then
-            . "$dpi_lib"
+    dpi_block="$dpi_mode"
+    dpi_scale_lib="$HOME/.local/share/ableton-wine/detect-scale.sh"
+    dpi_policy_lib="$HOME/.local/share/ableton-wine/dpi-policy.sh"
+    if [ "$dpi_mode" = auto ] || [ "$dpi_mode" = native ]; then
+        dpi_block=preserve
+        if [ -r "$dpi_scale_lib" ] && [ -r "$dpi_policy_lib" ]; then
+            . "$dpi_scale_lib"
+            . "$dpi_policy_lib"
             dpi_scale="$(ableton_detect_scale)" || dpi_scale=""
-            case "$dpi_scale" in
-                1)    dpi_mode=100 ;;
-                1.25) dpi_mode=fractional ;;
-                "")   ;;
-                *)    echo "ableton-live: scale $dpi_scale detected, but only 100%/125% are calibrated — keeping current DPI values (set ABLETON_DPI_MODE to force)" >&2 ;;
-            esac
+            if [ -n "$dpi_scale" ]; then
+                if [ "$dpi_mode" = native ]; then
+                    dpi_value="$(ableton_scale_to_dpi "$dpi_scale")" || dpi_value=""
+                    if [ "$dpi_value" = 96 ]; then dpi_block=100
+                    elif [ -n "$dpi_value" ]; then dpi_block="native:$dpi_value"
+                    fi
+                elif resolved="$(ableton_resolve_dpi_policy "$dpi_scale")"; then
+                    dpi_block="$resolved"
+                else
+                    echo "ableton-live: scale $dpi_scale detected, but this compositor/XWayland strategy is not calibrated — keeping current DPI values" >&2
+                fi
+            elif [ "$dpi_mode" = native ]; then
+                echo "ableton-live: ABLETON_DPI_MODE=native needs a detectable display scale — keeping current DPI values" >&2
+            fi
+        elif [ "$dpi_mode" = native ]; then
+            echo "ableton-live: native DPI policy library is missing — keeping current DPI values" >&2
         fi
     fi
     # The dpiAwareness IFEO is keyed on the exe name, so it follows the discovered install.
@@ -75,7 +90,7 @@ if ! pgrep -af "Ableton Live.*\.exe" 2>/dev/null | grep "ProgramData" >/dev/null
     fi
     # Read current values from the registry files directly (no wineserver spin-up).
     cur_lp="$(awk '/^\[Control Panel\\\\Desktop\]/{f=1;next} /^\[/{f=0} f&&/"LogPixels"=dword:/{gsub(/.*dword:/,""); gsub(/\r/,""); print; exit}' "$WINEPREFIX/user.reg" 2>/dev/null || true)"
-    case "$dpi_mode" in
+    case "$dpi_block" in
         100)
             if [ "${cur_lp:-00000060}" != 00000060 ] || [ -n "$cur_ifeo" ]; then
                 echo "ableton-live: display at 100% — recalibrating prefix DPI (LogPixels 96, no IFEO)" >&2
@@ -88,11 +103,21 @@ if ! pgrep -af "Ableton Live.*\.exe" 2>/dev/null | grep "ProgramData" >/dev/null
                 "$WINE_ROOT/bin/wine" reg add 'HKCU\Control Panel\Desktop' /v LogPixels /t REG_DWORD /d 192 /f >/dev/null 2>&1
                 [ -z "$dpi_ifeo" ] || "$WINE_ROOT/bin/wine" reg add "$dpi_ifeo" /v dpiAwareness /t REG_DWORD /d 2 /f >/dev/null 2>&1
             fi ;;
+        native:*)
+            native_dpi="${dpi_block#native:}"
+            want_lp="$(ableton_dpi_to_dword "$native_dpi")"
+            if [ "${cur_lp:-00000060}" != "$want_lp" ] || [ -n "$cur_ifeo" ]; then
+                echo "ableton-live: native display scaling — recalibrating prefix DPI (LogPixels $native_dpi, no IFEO)" >&2
+                "$WINE_ROOT/bin/wine" reg add 'HKCU\Control Panel\Desktop' /v LogPixels /t REG_DWORD /d "$native_dpi" /f >/dev/null 2>&1
+                [ -z "$dpi_ifeo" ] || "$WINE_ROOT/bin/wine" reg delete "$dpi_ifeo" /v dpiAwareness /f >/dev/null 2>&1 || true
+            fi ;;
+        preserve) ;;
+        *) echo "ableton-live: invalid ABLETON_DPI_MODE '$dpi_mode' — keeping current DPI values" >&2 ;;
     esac
     # Warn if mutter's xwayland-native-scaling disagrees with the DPI set; never change it.
     if command -v gsettings >/dev/null 2>&1; then
         mutter_feats="$(gsettings get org.gnome.mutter experimental-features 2>/dev/null || true)"
-        case "$dpi_mode" in
+        case "$dpi_block" in
             100)        case "$mutter_feats" in *xwayland-native-scaling*)
                             echo "ableton-live: warn — mutter xwayland-native-scaling is ON; the 100% set expects it OFF" >&2 ;; esac ;;
             fractional) case "$mutter_feats" in *xwayland-native-scaling*) ;; *)

--- a/scripts/dpi-policy.sh
+++ b/scripts/dpi-policy.sh
@@ -1,0 +1,81 @@
+# Sourceable display-DPI policy resolution. This file does not mutate a Wine
+# prefix: it converts a detected display scale and compositor strategy into a
+# calibrated block consumed by setup-prefix.sh and ableton-live.
+
+ableton_scale_to_dpi() {
+    awk -v scale="$1" 'BEGIN {
+        if (scale !~ /^[0-9]+([.][0-9]+)?$/ || scale <= 0) exit 1
+        printf "%d\n", int((scale * 96) + 0.5)
+    }'
+}
+
+ableton_dpi_to_dword() {
+    case "$1" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+    [ "$1" -gt 0 ] || return 1
+    printf '%08x\n' "$1"
+}
+
+ableton_desktop_kind() {
+    local desktop
+    desktop="${XDG_CURRENT_DESKTOP:-${XDG_SESSION_DESKTOP:-${DESKTOP_SESSION:-}}}"
+    desktop="$(printf '%s' "$desktop" | tr '[:upper:]' '[:lower:]')"
+    case "$desktop" in
+        *hyprland*|*omarchy*) echo hyprland ;;
+        *gnome*|*mutter*)     echo gnome ;;
+        *kde*|*plasma*)       echo kde ;;
+        *sway*)               echo sway ;;
+        *)
+            if [ -n "${HYPRLAND_INSTANCE_SIGNATURE:-}" ]; then
+                echo hyprland
+            else
+                echo unknown
+            fi ;;
+    esac
+}
+
+ableton_hyprland_force_zero_scaling() {
+    command -v hyprctl >/dev/null 2>&1 || return 1
+    [ -n "${HYPRLAND_INSTANCE_SIGNATURE:-}" ] || return 1
+    local out
+    out="$(timeout 5 hyprctl getoption xwayland:force_zero_scaling -j 2>/dev/null)" || return 1
+    printf '%s\n' "$out" | grep -Eq '"int"[[:space:]]*:[[:space:]]*1([^0-9]|$)'
+}
+
+# Print one calibrated block:
+#   100          -> LogPixels 96, no IFEO
+#   fractional   -> legacy Mutter policy: LogPixels 192, IFEO=2
+#   native:<dpi> -> application-side scaling at the exact compositor DPI,
+#                   no IFEO
+# Return 1 when the compositor/XWayland strategy is not calibrated.
+# Optional desktop and zero-scaling arguments make the resolver pure in tests.
+ableton_resolve_dpi_policy() {
+    local scale="$1" desktop="${2:-}" zero_scaling="${3:-}" dpi
+    dpi="$(ableton_scale_to_dpi "$scale")" || return 1
+    [ -n "$desktop" ] || desktop="$(ableton_desktop_kind)"
+
+    if [ "$desktop" = hyprland ]; then
+        if [ -z "$zero_scaling" ]; then
+            if ableton_hyprland_force_zero_scaling; then
+                zero_scaling=1
+            else
+                zero_scaling=0
+            fi
+        fi
+        if [ "$zero_scaling" = 1 ]; then
+            if [ "$dpi" -eq 96 ]; then
+                echo 100
+            else
+                echo "native:$dpi"
+            fi
+            return 0
+        fi
+    fi
+
+    case "$dpi" in
+        96)  echo 100 ;;
+        120) echo fractional ;;
+        *)   return 1 ;;
+    esac
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -122,6 +122,7 @@ echo "== install detection libs -> ~/.local/share/ableton-wine =="
 # The launcher sources these on every start (DPI auto-calibration, light/dark theme sync).
 mkdir -p "$HOME/.local/share/ableton-wine"
 install -m644 "$here/detect-scale.sh" "$HOME/.local/share/ableton-wine/detect-scale.sh"
+install -m644 "$here/dpi-policy.sh" "$HOME/.local/share/ableton-wine/dpi-policy.sh"
 install -m644 "$here/detect-theme.sh" "$HOME/.local/share/ableton-wine/detect-theme.sh"
 
 # Record the kit version so a later installer can tell what it is updating

--- a/scripts/make-installer.sh
+++ b/scripts/make-installer.sh
@@ -54,7 +54,7 @@ cp -a "$tarball" "$tarball.sha256" "$kit/dist/"
 cp -a "dist/BUILD-INFO-${VERSION}.txt" "$kit/" 2>/dev/null || true
 mkdir -p "$kit/scripts"
 cp -a scripts/install.sh scripts/setup-prefix.sh scripts/uninstall.sh \
-      scripts/ableton-live scripts/detect-scale.sh scripts/detect-theme.sh \
+      scripts/ableton-live scripts/detect-scale.sh scripts/dpi-policy.sh scripts/detect-theme.sh \
       scripts/check-live-audio.sh "$kit/scripts/"
 cp -a desktop "$kit/desktop"
 cp -a vendor/winetricks vendor/winetricks-cache "$kit/vendor/"

--- a/scripts/setup-prefix.sh
+++ b/scripts/setup-prefix.sh
@@ -39,8 +39,10 @@ for t in cabextract; do
     command -v "$t" >/dev/null || echo "!! missing host tool '$t' (needed by winetricks) — install it (e.g. 'pacman -S cabextract' / 'apt install cabextract')"
 done
 
-# DPI blocks: 100% -> LogPixels=96 + no IFEO dpiAwareness; 125% -> LogPixels=192 + IFEO=2. auto applies
-# the detected block on a fresh prefix, preserves an existing one, refuses uncalibrated/undetectable scales.
+# DPI blocks: 100% -> LogPixels=96 + no IFEO; legacy Mutter fractional ->
+# LogPixels=192 + IFEO=2; Hyprland zero-scaling -> exact native DPI + no IFEO.
+# Auto applies the detected block on a fresh prefix, preserves an existing one,
+# and refuses uncalibrated/undetectable compositor strategies.
 # The dpiAwareness IFEO is keyed on the exe name, so it is applied per installed Live (any edition);
 # on a fresh prefix Live isn't installed yet — the launcher applies it on every start.
 ifeo_root='HKLM\Software\Microsoft\Windows NT\CurrentVersion\Image File Execution Options'
@@ -51,20 +53,13 @@ live_exe_names() {   # basenames of every Live exe installed in this prefix
 
 # Shared display-scale detection (see detect-scale.sh).
 . "$here/detect-scale.sh"
+. "$here/dpi-policy.sh"
 detect_display_scale() { ableton_detect_scale; }
 
 # Shared host light/dark-scheme detection (see detect-theme.sh).
 . "$here/detect-theme.sh"
 
-block_for_scale() {  # scale -> calibrated block name, fails on uncalibrated
-    case "$1" in
-        1|1.0)  echo 100 ;;
-        1.25)   echo fractional ;;
-        *)      return 1 ;;
-    esac
-}
-
-current_dpi_block() {  # what an EXISTING prefix holds: 100 | fractional | custom
+current_dpi_block() {  # existing prefix: 100 | fractional | native:<dpi> | custom
     local lp ifeo=absent name installs=0
     lp="$(wine reg query 'HKCU\Control Panel\Desktop' /v LogPixels 2>/dev/null \
           | awk '$1=="LogPixels"{gsub(/\r/,"",$3); print tolower($3)}')"   # reg output is CRLF
@@ -80,6 +75,8 @@ current_dpi_block() {  # what an EXISTING prefix holds: 100 | fractional | custo
         echo 100
     elif [ "$lp" = 0xc0 ] && { [ "$ifeo" = present ] || [ "$installs" -eq 0 ]; }; then
         echo fractional    # no Live installed yet: LogPixels alone decides; the launcher adds the IFEO
+    elif [ "$ifeo" = absent ]; then
+        printf 'native:%d\n' "$((lp))"
     else
         echo custom
     fi
@@ -120,11 +117,19 @@ case "$dpi_mode" in
   100|fractional)
     dpi_block="$dpi_mode"
     ;;
+  native)
+    if scale="$(detect_display_scale)" && dpi="$(ableton_scale_to_dpi "$scale")"; then
+        if [ "$dpi" -eq 96 ]; then dpi_block=100; else dpi_block="native:$dpi"; fi
+    else
+        echo "!! ABLETON_DPI_MODE=native needs a detectable, valid display scale" >&2
+        exit 2
+    fi
+    ;;
   preserve)
     ;;
   auto)
     if scale="$(detect_display_scale)"; then
-        if block="$(block_for_scale "$scale")"; then
+        if block="$(ableton_resolve_dpi_policy "$scale")"; then
             if [ "$fresh_prefix" -eq 1 ]; then
                 echo "   display scale $scale detected -> will apply the '$block' DPI block"
                 dpi_block="$block"
@@ -138,22 +143,22 @@ case "$dpi_mode" in
                 fi
             fi
         elif [ "$fresh_prefix" -eq 1 ]; then
-            echo "!! display scale $scale has no calibrated DPI block (only 100% and 125% are)" >&2
-            echo "!! rerun with an explicit ABLETON_DPI_MODE=100 or ABLETON_DPI_MODE=fractional" >&2
+            echo "!! display scale $scale has no calibrated policy for this compositor/XWayland strategy" >&2
+            echo "!! rerun with ABLETON_DPI_MODE=preserve, 100, fractional, or native" >&2
             exit 2
         else
             echo "!! display scale $scale has no calibrated DPI block — preserving existing prefix values"
         fi
     elif [ "$fresh_prefix" -eq 1 ]; then
         echo "!! cannot detect the display scale (non-GNOME desktop or headless session?)" >&2
-        echo "!! a fresh prefix needs an explicit ABLETON_DPI_MODE=100 or ABLETON_DPI_MODE=fractional" >&2
+        echo "!! a fresh prefix needs an explicit ABLETON_DPI_MODE=100, fractional, or native" >&2
         exit 2
     else
         echo "   cannot detect display scale; preserving existing prefix values"
     fi
     ;;
   *)
-    echo "!! ABLETON_DPI_MODE must be auto, preserve, 100, or fractional" >&2
+    echo "!! ABLETON_DPI_MODE must be auto, preserve, 100, fractional, or native" >&2
     exit 2
     ;;
 esac
@@ -239,6 +244,14 @@ case "$dpi_block" in
     done < <(live_exe_names)
     [ "$ifeo_set" -eq 1 ] || echo "   (Live not installed yet — the launcher sets its per-app DPI flag on first start)"
     check_mutter_knob fractional
+    ;;
+  native:*)
+    native_dpi="${dpi_block#native:}"
+    wine reg add 'HKCU\Control Panel\Desktop' /v LogPixels /t REG_DWORD /d "$native_dpi" /f
+    while IFS= read -r name; do
+        [ -n "$name" ] || continue
+        wine reg delete "$ifeo_root\\$name" /v dpiAwareness /f >/dev/null 2>&1 || true
+    done < <(live_exe_names)
     ;;
   preserve)
     echo "   preserving current LogPixels and dpiAwareness values"

--- a/scripts/setup-run-header.sh
+++ b/scripts/setup-run-header.sh
@@ -9,7 +9,7 @@
 #   --uninstall      remove the installed Wine, launcher, and menu entries
 #   --help           this text
 # Environment:
-#   ABLETON_DPI_MODE    auto|preserve|100|fractional (overrides scale auto-detection)
+#   ABLETON_DPI_MODE    auto|preserve|100|fractional|native (overrides scale auto-detection)
 #   ABLETON_THEME_MODE  auto|dark|light|preserve (overrides the light/dark sync)
 # Everything after the marker line is a tar archive; this header never changes it.
 [ -n "${BASH_VERSION:-}" ] || exec bash "$0" "$@"
@@ -214,17 +214,21 @@ bash "$kit/scripts/install.sh"
 # Seed ABLETON_DPI_MODE from the detected display scale; the launcher re-detects on every start.
 if [ -z "${ABLETON_DPI_MODE:-}" ]; then
     . "$kit/scripts/detect-scale.sh"
+    . "$kit/scripts/dpi-policy.sh"
     scale="$(ableton_detect_scale)" || scale=""
-    case "$scale" in
-        1)    export ABLETON_DPI_MODE=100;        say "-- display scale: 100% (auto-detected)" ;;
-        1.25) export ABLETON_DPI_MODE=fractional; say "-- display scale: 125% (auto-detected)" ;;
+    policy=""
+    [ -z "$scale" ] || policy="$(ableton_resolve_dpi_policy "$scale" || true)"
+    case "$policy" in
+        100)        export ABLETON_DPI_MODE=100;        say "-- display scale: 100% (auto-detected)" ;;
+        fractional) export ABLETON_DPI_MODE=fractional; say "-- display scale: 125% legacy fractional policy (auto-detected)" ;;
+        native:*)   export ABLETON_DPI_MODE=native;     say "-- display scale: $scale -> ${policy#native:} DPI native application scaling (auto-detected)" ;;
         *)
             if [ -d "$HOME/.wine-ableton" ]; then
                 export ABLETON_DPI_MODE=preserve
-                say "-- display scale: ${scale:-could not be detected}${scale:+ (only 100% and 125% are calibrated)}; keeping your existing display settings"
+                say "-- display scale: ${scale:-could not be detected}; compositor/XWayland strategy not calibrated, keeping your existing display settings"
             else
                 export ABLETON_DPI_MODE=100
-                say "-- display scale: ${scale:-could not be detected}${scale:+ (only 100% and 125% are calibrated)}; starting the new prefix at 100%"
+                say "-- display scale: ${scale:-could not be detected}; compositor/XWayland strategy not calibrated, starting the new prefix at 100%"
                 say "   (the launcher re-checks your display on every start, so this corrects itself)"
             fi ;;
     esac

--- a/tests/test-dpi-policy.sh
+++ b/tests/test-dpi-policy.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+. "$here/../scripts/dpi-policy.sh"
+
+failures=0
+check() {
+    local description="$1" expected="$2"
+    shift 2
+    local actual
+    if actual="$("$@")" && [ "$actual" = "$expected" ]; then
+        printf 'ok - %s\n' "$description"
+    else
+        printf 'not ok - %s (expected %s, got %s)\n' "$description" "$expected" "${actual:-<failure>}" >&2
+        failures=$((failures + 1))
+    fi
+}
+check_fails() {
+    local description="$1"
+    shift
+    if "$@" >/dev/null 2>&1; then
+        printf 'not ok - %s (unexpected success)\n' "$description" >&2
+        failures=$((failures + 1))
+    else
+        printf 'ok - %s\n' "$description"
+    fi
+}
+
+check 'Hyprland 1.00' 100 ableton_resolve_dpi_policy 1.00 hyprland 1
+check 'Hyprland 1.25' native:120 ableton_resolve_dpi_policy 1.25 hyprland 1
+check 'Hyprland 1.50' native:144 ableton_resolve_dpi_policy 1.50 hyprland 1
+check 'Hyprland 1.666667' native:160 ableton_resolve_dpi_policy 1.666667 hyprland 1
+check 'Hyprland normalized 1.67' native:160 ableton_resolve_dpi_policy 1.67 hyprland 1
+check 'Hyprland 1.75' native:168 ableton_resolve_dpi_policy 1.75 hyprland 1
+check 'Hyprland 2.00' native:192 ableton_resolve_dpi_policy 2.00 hyprland 1
+check 'GNOME legacy 1.25' fractional ableton_resolve_dpi_policy 1.25 gnome 0
+check 'unknown desktop 1.00' 100 ableton_resolve_dpi_policy 1 unknown 0
+check_fails 'Hyprland without zero scaling preserves 1.67' ableton_resolve_dpi_policy 1.67 hyprland 0
+check_fails 'unknown desktop preserves 1.67' ableton_resolve_dpi_policy 1.67 unknown 0
+check '160 registry DWORD' 000000a0 ableton_dpi_to_dword 160
+check '192 registry DWORD' 000000c0 ableton_dpi_to_dword 192
+check_fails 'invalid scale is rejected' ableton_scale_to_dpi invalid
+check_fails 'invalid DWORD is rejected' ableton_dpi_to_dword 16x
+
+[ "$failures" -eq 0 ]
+printf 'PASS: DPI policy tests\n'


### PR DESCRIPTION
## Summary

- add a pure, testable DPI policy resolver;
- detect Hyprland with `xwayland:force_zero_scaling` enabled;
- use exact application-side DPI (`round(96 * scale)`) without an IFEO override;
- apply the same policy during prefix setup and every launcher start; and
- retain the existing 100% and legacy 192-DPI fractional behavior for other desktops.

Unknown compositor/XWayland strategies continue to preserve existing prefix values.

## Why

At Hyprland scale `1.666667`, `detect-scale.sh` normalizes the scale to `1.67`, but the existing launcher treats it as uncalibrated and leaves a fresh prefix at 96 DPI. With `xwayland:force_zero_scaling=true`, Live should scale itself at the monitor's native logical DPI:

```text
round(96 * 1.666667) = 160
```

Testing also showed that Live becomes per-monitor aware without an executable-specific `dpiAwareness` override, so the native policy removes a stale IFEO value rather than adding one.

## Test system

- Arch Linux / Omarchy
- Hyprland 0.55.4
- `xwayland:force_zero_scaling=true`
- 3840x2160 at 159.75 Hz
- compositor scale `1.666667` (`detect-scale.sh`: `1.67`)
- NVIDIA GeForce RTX 5080, driver 610.43.03
- Wine runtime 11.11 from release `v2026.07.17.3`
- Ableton Live 12 Suite 12.4.3

## DPI candidate results

| LogPixels | IFEO | Result |
| ---: | ---: | --- |
| 96 | absent | Functional and coordinate-correct, but visibly underscaled |
| 160 | 2 | Crisp, correctly sized, and passed geometry/hit-test/manual checks |
| 160 | absent | Same DPI awareness and geometry; passed; selected policy |
| 192 | 2 | Functional, but approximately 20% oversized for a 1.666667 display |

For the selected candidate, Live and Learn View report 160 DPI. The tiled main window measured 1138x1278 logical and 1898x2130 physical, matching the compositor scale within rounding tolerance. Main-window and embedded-child hit tests resolved correctly.

The modified launcher was then tested end to end from a cloned 96-DPI/no-IFEO prefix. It automatically selected `native:160`, wrote `LogPixels=160`, kept IFEO absent, and reproduced the passing geometry and manual behavior.

## Validation

- `tests/test-dpi-policy.sh`: PASS for Hyprland 1.00, 1.25, 1.50, 1.666667/1.67, 1.75, and 2.00;
- GNOME 1.25 legacy 192-DPI policy: PASS;
- unknown desktop at 1.67 preserves values: PASS;
- dynamic registry DWORD formatting: PASS;
- all modified shell scripts pass `bash -n`;
- menus, cursor, edge clicks, tiling, and floating resize: PASS;
- runtime build audit: 54/54 checks PASS; and
- single-file installer assembly, extraction, embedded policy, and checksum: PASS.

## Scope and remaining testing

This PR enables only the verified Hyprland zero-scaling strategy. It does not yet enable the same native policy automatically on KDE, although the issue's KDE results point in the same direction.

External plugin windows, the native file portal, a multi-scale physical-monitor matrix, fullscreen cycling, and repeated launch/close soak testing still need broader tester coverage before this should leave draft status. Wine patches, release metadata, and vendored inputs are unchanged.

Refs #10
