### PR TITLE
Select Wine GLX for active NVIDIA displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Mostly unnecessary. But in case you need them:
 - `ABLETON_WINEPREFIX` prefix path (default `~/.wine-ableton`)
 - `ABLETON_DPI_MODE` `auto` | `preserve` | `100` | `fractional`
 - `ABLETON_THEME_MODE` `auto` | `dark` | `light` | `preserve` — the launcher syncs Live's light/dark theme key to the desktop scheme on every start; this overrides it
+- `ABLETON_OPENGL_BACKEND` `auto` | `preserve` | `egl` | `glx` — `auto` selects GLX when an NVIDIA GPU is actively driving a display, avoiding NVIDIA EGL/X11 pixel-format incompatibilities; other GPUs keep their existing backend
 - `ABLETON_LIVE_EXE` full path to a Live exe inside the prefix, when more than one edition/version is installed (default: the newest found)
 - `PIPEASIO_*` audio driver overrides, e.g. `PIPEASIO_PREFERRED_BUFFERSIZE=512` if you hear crackles; defaults live in `~/.config/pipeasio/config.ini`
 - `ENGINE=docker` for `build.sh` / `make-installer.sh`

--- a/scripts/ableton-live
+++ b/scripts/ableton-live
@@ -49,6 +49,41 @@ if ! pgrep -af "Ableton Live.*\.exe" 2>/dev/null | grep -q "ProgramData"; then
     /usr/bin/wineserver -k 2>/dev/null || true
 fi
 
+# NVIDIA's EGL/X11 path has no default-depth RGBA8 window format under Wine;
+# GLX does. Select it only for an active NVIDIA display (or explicit PRIME
+# offload), and leave every other host's existing backend untouched.
+if ! pgrep -af "Ableton Live.*\.exe" 2>/dev/null | grep "ProgramData" >/dev/null; then
+    opengl_mode="${ABLETON_OPENGL_BACKEND:-auto}"
+    opengl_backend=preserve
+    opengl_lib="$HOME/.local/share/ableton-wine/opengl-policy.sh"
+    if [ -r "$opengl_lib" ]; then
+        . "$opengl_lib"
+        if ! opengl_backend="$(ableton_resolve_opengl_backend "$opengl_mode")"; then
+            echo "ableton-live: ABLETON_OPENGL_BACKEND must be auto, preserve, egl, or glx" >&2
+            opengl_backend=preserve
+        fi
+    elif [ "$opengl_mode" != auto ] && [ "$opengl_mode" != preserve ]; then
+        echo "ableton-live: OpenGL backend policy library is missing — keeping the current backend" >&2
+    fi
+    cur_use_egl="$(awk '/^\[Software\\\\Wine\\\\X11 Driver\]/{f=1;next} /^\[/{f=0} f&&/"UseEGL"=/{gsub(/.*="/,""); gsub(/".*/,""); print; exit}' "$WINEPREFIX/user.reg" 2>/dev/null || true)"
+    case "$opengl_backend" in
+        glx)
+            if [ "$cur_use_egl" != N ]; then
+                if [ "$opengl_mode" = glx ]; then
+                    echo "ableton-live: selecting Wine's GLX backend (explicit override)" >&2
+                else
+                    echo "ableton-live: active NVIDIA display — selecting Wine's GLX backend" >&2
+                fi
+                "$WINE_ROOT/bin/wine" reg add 'HKCU\Software\Wine\X11 Driver' /v UseEGL /t REG_SZ /d N /f >/dev/null 2>&1
+            fi ;;
+        egl)
+            if [ "$cur_use_egl" != Y ]; then
+                echo "ableton-live: selecting Wine's EGL backend (explicit override)" >&2
+                "$WINE_ROOT/bin/wine" reg add 'HKCU\Software\Wine\X11 Driver' /v UseEGL /t REG_SZ /d Y /f >/dev/null 2>&1
+            fi ;;
+    esac
+fi
+
 # Recalibrate prefix DPI to the detected scale before each launch: 1.0 -> LogPixels 96 + no IFEO;
 # 1.25 -> LogPixels 192 + IFEO=2; else preserve. ABLETON_DPI_MODE=100|fractional|preserve overrides.
 if ! pgrep -af "Ableton Live.*\.exe" 2>/dev/null | grep "ProgramData" >/dev/null; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -119,10 +119,11 @@ fi
 install -m755 "$here/ableton-live" "$BIN/ableton-live"
 
 echo "== install detection libs -> ~/.local/share/ableton-wine =="
-# The launcher sources these on every start (DPI auto-calibration, light/dark theme sync).
+# The launcher sources these on every start (DPI, theme, and GPU policy).
 mkdir -p "$HOME/.local/share/ableton-wine"
 install -m644 "$here/detect-scale.sh" "$HOME/.local/share/ableton-wine/detect-scale.sh"
 install -m644 "$here/detect-theme.sh" "$HOME/.local/share/ableton-wine/detect-theme.sh"
+install -m644 "$here/opengl-policy.sh" "$HOME/.local/share/ableton-wine/opengl-policy.sh"
 
 # Record the kit version so a later installer can tell what it is updating
 # (the kit and the repo both carry VERSION at the root).

--- a/scripts/make-installer.sh
+++ b/scripts/make-installer.sh
@@ -54,7 +54,7 @@ cp -a "$tarball" "$tarball.sha256" "$kit/dist/"
 cp -a "dist/BUILD-INFO-${VERSION}.txt" "$kit/" 2>/dev/null || true
 mkdir -p "$kit/scripts"
 cp -a scripts/install.sh scripts/setup-prefix.sh scripts/uninstall.sh \
-      scripts/ableton-live scripts/detect-scale.sh scripts/detect-theme.sh \
+      scripts/ableton-live scripts/detect-scale.sh scripts/detect-theme.sh scripts/opengl-policy.sh \
       scripts/check-live-audio.sh "$kit/scripts/"
 cp -a desktop "$kit/desktop"
 cp -a vendor/winetricks vendor/winetricks-cache "$kit/vendor/"

--- a/scripts/opengl-policy.sh
+++ b/scripts/opengl-policy.sh
@@ -1,0 +1,35 @@
+# Sourceable Wine OpenGL-backend policy. NVIDIA's EGL X11 configs expose
+# RGBA8 on a 32-bit ARGB visual, which Wine intentionally does not advertise
+# for ordinary windows. Its GLX backend exposes compatible RGBA8/sRGB formats.
+
+ableton_nvidia_display_active() {
+    command -v nvidia-smi >/dev/null 2>&1 || return 1
+    local state
+    state="$(timeout 5 nvidia-smi --query-gpu=display_active --format=csv,noheader,nounits 2>/dev/null)" || return 1
+    printf '%s\n' "$state" | grep -Eiq '^[[:space:]]*(enabled|active|yes|1)([[:space:]]|$)'
+}
+
+# Print egl, glx, or preserve. The optional second argument (0/1) makes auto
+# resolution deterministic in tests; when omitted, inspect the live system.
+ableton_resolve_opengl_backend() {
+    local mode="${1:-auto}" nvidia_active="${2:-}"
+    case "$mode" in
+        egl|glx|preserve) printf '%s\n' "$mode"; return 0 ;;
+        auto) ;;
+        *) return 2 ;;
+    esac
+
+    if [ -z "$nvidia_active" ]; then
+        case "${__GLX_VENDOR_LIBRARY_NAME:-}" in
+            nvidia) nvidia_active=1 ;;
+        esac
+    fi
+    if [ -z "$nvidia_active" ] && [ "${__NV_PRIME_RENDER_OFFLOAD:-0}" = 1 ]; then
+        nvidia_active=1
+    fi
+    if [ -z "$nvidia_active" ]; then
+        if ableton_nvidia_display_active; then nvidia_active=1; else nvidia_active=0; fi
+    fi
+
+    if [ "$nvidia_active" = 1 ]; then echo glx; else echo preserve; fi
+}

--- a/scripts/setup-prefix.sh
+++ b/scripts/setup-prefix.sh
@@ -56,6 +56,9 @@ detect_display_scale() { ableton_detect_scale; }
 # Shared host light/dark-scheme detection (see detect-theme.sh).
 . "$here/detect-theme.sh"
 
+# Shared Wine OpenGL-backend policy (see opengl-policy.sh).
+. "$here/opengl-policy.sh"
+
 block_for_scale() {  # scale -> calibrated block name, fails on uncalibrated
     case "$1" in
         1|1.0)  echo 100 ;;
@@ -263,6 +266,31 @@ else
     echo "   host scheme not detectable — leaving the theme key as-is (the launcher retries on every start)"
 fi
 wine reg add 'HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize' /v EnableTransparency /t REG_DWORD /d 0 /f
+"$WINESERVER" -w
+
+echo "== [3c/5] OpenGL backend policy =="
+opengl_mode="${ABLETON_OPENGL_BACKEND:-auto}"
+if ! opengl_backend="$(ableton_resolve_opengl_backend "$opengl_mode")"; then
+    echo "!! ABLETON_OPENGL_BACKEND must be auto, preserve, egl, or glx" >&2
+    exit 2
+fi
+case "$opengl_backend" in
+  glx)
+    if [ "$opengl_mode" = glx ]; then
+      echo "   selecting Wine's GLX backend (explicit override)"
+    else
+      echo "   active NVIDIA display detected — selecting Wine's GLX backend"
+    fi
+    wine reg add 'HKCU\Software\Wine\X11 Driver' /v UseEGL /t REG_SZ /d N /f
+    ;;
+  egl)
+    echo "   selecting Wine's EGL backend (explicit override)"
+    wine reg add 'HKCU\Software\Wine\X11 Driver' /v UseEGL /t REG_SZ /d Y /f
+    ;;
+  preserve)
+    echo "   preserving Wine's current OpenGL backend"
+    ;;
+esac
 "$WINESERVER" -w
 
 echo "== [4/5] register packaged PipeASIO =="

--- a/scripts/setup-run-header.sh
+++ b/scripts/setup-run-header.sh
@@ -11,6 +11,7 @@
 # Environment:
 #   ABLETON_DPI_MODE    auto|preserve|100|fractional (overrides scale auto-detection)
 #   ABLETON_THEME_MODE  auto|dark|light|preserve (overrides the light/dark sync)
+#   ABLETON_OPENGL_BACKEND auto|preserve|egl|glx (overrides GPU backend selection)
 # Everything after the marker line is a tar archive; this header never changes it.
 [ -n "${BASH_VERSION:-}" ] || exec bash "$0" "$@"
 set -euo pipefail

--- a/tests/test-opengl-policy.sh
+++ b/tests/test-opengl-policy.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+. "$here/../scripts/opengl-policy.sh"
+
+failures=0
+check() {
+    local description="$1" expected="$2"
+    shift 2
+    local actual
+    if actual="$("$@")" && [ "$actual" = "$expected" ]; then
+        printf 'ok - %s\n' "$description"
+    else
+        printf 'not ok - %s (expected %s, got %s)\n' "$description" "$expected" "${actual:-<failure>}" >&2
+        failures=$((failures + 1))
+    fi
+}
+check_fails() {
+    local description="$1"
+    shift
+    if "$@" >/dev/null 2>&1; then
+        printf 'not ok - %s (unexpected success)\n' "$description" >&2
+        failures=$((failures + 1))
+    else
+        printf 'ok - %s\n' "$description"
+    fi
+}
+
+check 'auto uses GLX for active NVIDIA display' glx ableton_resolve_opengl_backend auto 1
+check 'auto preserves non-NVIDIA backend' preserve ableton_resolve_opengl_backend auto 0
+check 'auto honors the NVIDIA GLX vendor hint' glx env __GLX_VENDOR_LIBRARY_NAME=nvidia bash -c \
+    '. "$1"; ableton_resolve_opengl_backend auto' _ "$here/../scripts/opengl-policy.sh"
+check 'auto honors NVIDIA PRIME offload' glx env __NV_PRIME_RENDER_OFFLOAD=1 bash -c \
+    '. "$1"; ableton_resolve_opengl_backend auto' _ "$here/../scripts/opengl-policy.sh"
+check 'explicit EGL override' egl ableton_resolve_opengl_backend egl 1
+check 'explicit GLX override' glx ableton_resolve_opengl_backend glx 0
+check 'explicit preserve override' preserve ableton_resolve_opengl_backend preserve 1
+check_fails 'invalid backend is rejected' ableton_resolve_opengl_backend invalid 1
+
+[ "$failures" -eq 0 ]
+printf 'PASS: OpenGL backend policy tests\n'


### PR DESCRIPTION
## Summary

- detect an active NVIDIA display or explicit PRIME offload and select the Wine GLX backend
- preserve the existing backend for Intel, AMD, and unknown systems
- add `ABLETON_OPENGL_BACKEND=auto|preserve|egl|glx` as an escape hatch
- ship the policy through both repository and self-extracting installer paths
- add focused policy regression tests

## Why

On the tested RTX 5080 / NVIDIA 610.43.03 Wayland + XWayland system, Wine EGL exposes RGBA8 configs on a 32-bit ARGB visual. Wine intentionally does not advertise those as ordinary window formats when their visual depth differs from the X11 default, so Ableton BaseView receives zero matching window-capable pixel formats.

Wine GLX exposes compatible RGBA8 and sRGB formats on the same system. Selecting GLX resolves the failure without weakening the Wine visual-depth safety check or forcing a software renderer.

This is related to #16, but does not claim to fix its separate `steam-run` / NixOS library-selection problem.

## Validation

- real Ableton Live 12 launch through the modified launcher
- confirmed `libGLX_nvidia.so` and `libnvidia-glcore.so` loaded
- confirmed Live registered as a graphics process in `nvidia-smi pmon`
- `glchild.exe`: 8 formats; OpenGL 3.2, 3.3, and 4.1 core contexts pass
- BaseView sRGB and non-sRGB pixel-format selections pass
- empty probe stderr; no Mesa `driver (null)` warnings
- policy test suite passes all 8 cases
- shell syntax and `git diff --check` pass
- runtime build audit passes all 54 checks
- self-extracting installer builds, verifies, and contains the new policy file

## Scope

Automatic behavior changes only when NVIDIA is actively driving a display or PRIME render offload is explicitly enabled. Existing Wine backend configuration is preserved everywhere else.