### PR TITLE
Fixes/webview2 drag drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Fixed fresh Live installs failing on the non-ASCII filenames in Live's Max content (issues 51 and 55). The C locale forced in 2026.07.21.2 for issue 36 reached Wine, which cannot create names like bp.µSeq.maxpat under a non-UTF-8 locale: Live 11's MSI rolled back with error 0x80070643, Live 12's installer looped a "Try again" dialog on MoveFile code 2. The installer scripts now force C.UTF-8, keeping the issue 36 fix and the filenames. Only a fresh run of the Ableton installer was affected, not existing installs.
+- winetricks failures now say what failed (issue 28). The quiet flag prefix setup passed to winetricks also silences its fatal-error message, so a failed step exited with no output while the installer claimed the details were above. The flag is gone; a failure now names the failing command and its exit status.
+
 ## 2026.07.23.1
 
 - Ableton Link support is now built in (notes/ABLETON-WINE-LINK.md). The installer ships ableton-linkd, a small native daemon built from the vendored Ableton Link SDK (Link 4.0, GPLv2 or later; the tarball ships in the kit as the corresponding source). It joins the Link session on your machine, holds the shared tempo and timeline across Live restarts, relays Start Stop Sync, and lets native Linux apps join the same session. The daemon is strictly passive: it never sets Live's tempo, and Live joins the session as its own peer. It is also the probe this stack never had: `ableton-linkd --probe 10` prints the peer count and the session tempo, and exits 0 only when it sees a peer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Closing a WebView2-based plugin editor no longer crashes Live (issue 52, Splice INSTRUMENT, Wine patch 0045; notes/ABLETON-WINE-WEBVIEW2-PLUGIN-CLOSE-CRASH.md). The WebView2 helper process registers a drag-and-drop handler on a child window it parents into Live's window tree; when the editor closes, Live's side revokes drag-and-drop on that window and Wine's ole32 released a pointer that is only valid in the helper process. RevokeDragDrop now rejects windows owned by other processes, the same rule RegisterDragDrop already applies. Fix by Giang Nguyen, ported from the wine base fork. Reproduced and verified without Splice using the new tools/webviewclose.c.
+
 - Fixed fresh Live installs failing on the non-ASCII filenames in Live's Max content (issues 51 and 55). The C locale forced in 2026.07.21.2 for issue 36 reached Wine, which cannot create names like bp.µSeq.maxpat under a non-UTF-8 locale: Live 11's MSI rolled back with error 0x80070643, Live 12's installer looped a "Try again" dialog on MoveFile code 2. The installer scripts now force C.UTF-8, keeping the issue 36 fix and the filenames. Only a fresh run of the Ableton installer was affected, not existing installs.
 - winetricks failures now say what failed (issue 28). The quiet flag prefix setup passed to winetricks also silences its fatal-error message, so a failed step exited with no output while the installer claimed the details were above. The flag is gone; a failure now names the failing command and its exit status.
 

--- a/notes/ABLETON-WINE-WEBVIEW2-PLUGIN-CLOSE-CRASH.md
+++ b/notes/ABLETON-WINE-WEBVIEW2-PLUGIN-CLOSE-CRASH.md
@@ -1,0 +1,70 @@
+# WebView2 plugin editors crash Live on close (issue 52, FIXED, patch 0045)
+
+## Symptom
+
+Closing a WebView2-based VST3 editor (reported with Splice INSTRUMENT,
+issue 52) takes Live down with its "serious program error" dialog. The
+editor itself renders and plays fine; only the close crashes.
+
+## Root cause
+
+A use-after-free in Wine-core ole32, not in this stack's dcomp/dxgi
+patches.
+
+- The WebView2 helper process (msedgewebview2) registers an OLE drop
+  target on its own `Chrome_WidgetWin_1` child window, which is
+  parented into the host's window tree. `RegisterDragDrop` stores the
+  `IDropTarget` as a raw pointer in the `OleDropTargetInterface`
+  window property — valid only in the registering process, but window
+  properties are visible system-wide.
+- On editor close, the host-side teardown revokes drag-and-drop on
+  every child window it can enumerate (JUCE's `HWNDComponentPeer`
+  does exactly this, and Splice INSTRUMENT behaves like a JUCE 8
+  host). That calls `RevokeDragDrop` on the helper-owned window from
+  Live's process.
+- Wine's `RevokeDragDrop` fetched the foreign raw pointer and called
+  `Release` on it in Live's address space: access violation on the
+  vtable dereference, in ole32, in Live's process. Live's crash
+  handler turns that into the "serious program error" dialog.
+
+`RegisterDragDrop` already rejects windows owned by other processes;
+`RevokeDragDrop` did not. Patch 0045 adds the same rejection
+(`DRAGDROP_E_INVALIDHWND`), after which teardown completes and the
+helper process revokes its own registration itself. Fix by Giang
+Nguyen (giang17/wine commit `fafb443f85e0`, found 2026-07-23 with a
+JUCE 8 WebView2 editor under yabridge, their issue 8); ported here.
+Not in the `d2d1-dcomp-11.11` base and not in upstream Wine as of
+2026-07-24 — re-check both on the issue 53 base bump to
+`d2d1-dcomp-11.13`, and drop 0045 once the base carries it.
+
+## Reproduction and verification, without Splice
+
+`tools/webviewclose.c` (build: `tools/build_webviewclose.sh`, needs
+`ABLETON_WINE_SOURCE` like the other PE tools) hosts a real WebView2
+controller in a fake Live-anatomy editor window (per-monitor-v2 main
+window, editor created in an UNAWARE thread DPI context, per
+fakeplugin.c) and tears it down in selectable orders:
+
+- `a` polite (IsVisible off, Close, Release, DestroyWindow),
+  `b` DestroyWindow with a live controller, `c` release without Close:
+  all complete clean on the unpatched runtime — plain teardown order
+  is not the trigger.
+- `e` JUCE-style: `RevokeDragDrop` over every enumerated descendant
+  before Close. On the unpatched runtime this reproduces issue 52
+  deterministically: `Chrome_WidgetWin_1` (owned by the helper
+  process) carries `OleDropTargetInterface`, and the revoke faults in
+  ole32 reading exactly that foreign pointer — the tool's exception
+  handler prints the faulting module and address.
+- `d` parks the editor under a hidden toplevel (Live's Learn View
+  close path, issue 57 companion).
+
+The report lands in `webviewclose-report.txt`; exit 3 means the
+exception handler fired.
+
+## Scope
+
+Any plugin whose editor embeds WebView2 and whose host-side teardown
+revokes drag-and-drop on enumerated children is affected the same way;
+Splice INSTRUMENT is just the first report. The guard is generic
+Wine-core hardening with no dcomp involvement, so it also covers
+plugin editors under other hosts on this runtime.

--- a/patches/0045-ole32-reject-RevokeDragDrop-for-windows-owned-by-oth.patch
+++ b/patches/0045-ole32-reject-RevokeDragDrop-for-windows-owned-by-oth.patch
@@ -1,0 +1,64 @@
+From 841f721f6c2c0bbca759cf1f1a08d2a346517f41 Mon Sep 17 00:00:00 2001
+From: dist <build@localhost>
+Date: Fri, 24 Jul 2026 15:58:19 +0200
+Subject: [PATCH 45/45] ole32: reject RevokeDragDrop for windows owned by other
+ processes
+
+RegisterDragDrop stores the drop target in the OleDropTargetInterface
+window property as a raw pointer that is only valid in the registering
+process. Window properties are visible system-wide, so RevokeDragDrop
+from another process fetches the foreign pointer and releases it,
+crashing on the vtable dereference.
+
+Issue 52: closing the Splice INSTRUMENT VST3 editor crashes Live. The
+WebView2 helper process registers a drop target on its own
+Chrome_WidgetWin_1 child window inside Live's window tree. On close,
+the editor teardown in Live's process revokes drag and drop on every
+enumerated child window and hits the foreign pointer. Reproduced
+without Splice with tools/webviewclose.c variant e: the host-side
+RevokeDragDrop faults in ole32 reading the exact address the helper
+process registered.
+
+RegisterDragDrop already rejects windows owned by other processes;
+apply the same check in RevokeDragDrop. The revoke then returns
+DRAGDROP_E_INVALIDHWND and teardown completes. The helper process
+still revokes its own registration itself.
+
+Ported from giang17/wine commit fafb443f85e0 (Giang Nguyen,
+2026-07-23). Not in the d2d1-dcomp-11.11 base and not in upstream Wine
+as of 2026-07-24. Re-check on the issue 53 base bump.
+---
+ dlls/ole32/ole2.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/dlls/ole32/ole2.c b/dlls/ole32/ole2.c
+index 36838628..3b645868 100644
+--- a/dlls/ole32/ole2.c
++++ b/dlls/ole32/ole2.c
+@@ -627,6 +627,7 @@ HRESULT WINAPI RegisterDragDrop(HWND hwnd, LPDROPTARGET pDropTarget)
+  */
+ HRESULT WINAPI RevokeDragDrop(HWND hwnd)
+ {
++  DWORD pid = 0;
+   HANDLE map;
+   IStream *stream;
+   IDropTarget *drop_target;
+@@ -640,6 +641,15 @@ HRESULT WINAPI RevokeDragDrop(HWND hwnd)
+     return DRAGDROP_E_INVALIDHWND;
+   }
+ 
++  /* block revoke for other processes windows; the stored drop target
++   * pointer is only valid in the registering process */
++  GetWindowThreadProcessId(hwnd, &pid);
++  if (pid != GetCurrentProcessId())
++  {
++    FIXME("revoke for another process windows is disabled\n");
++    return DRAGDROP_E_INVALIDHWND;
++  }
++
+   /* no registration data */
+   if (!(map = get_droptarget_handle(hwnd)))
+     return DRAGDROP_E_NOTREGISTERED;
+-- 
+2.55.0
+

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -40,5 +40,6 @@ aa03b731a6785ee258d2fa75b29a526da33cc369f324c576d91f5b0ba884e669  0040-win32u-sc
 ace143ecd744e35417b6b549429cfee855d5d24d2b4241eda4fdb4b4248bb5eb  0041-dxgi-make-dcomp-presents-visible-on-webview2-s-unat.patch
 25e0bc84e188be5507c869ca63671ac66201e17564f18349b6490b560d5fa685  0042-winex11-alias-sub-scale-WM-config-rounding-instead-o.patch
 b8daff7e64239577a0563db6321826f47557503bbc458006a277191d2350c796  0043-shell32-reveal-explorer-select-targets-through-the-X.patch
+13317f863d0243d23800cbaa06088c86be0bc739fa5e477fe287531b221b2fc4  0045-ole32-reject-RevokeDragDrop-for-windows-owned-by-oth.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -70,6 +70,7 @@ extras="$(cd "$root/patches" && ls 00*.patch pipeasio/*.patch 2>/dev/null | grep
 # titles and notes/); a gap is fine if documented here, a dropped patch is not.
 declare -A SERIES_GAPS=(
     [0027]="retired 2026-07-14 — gitignore housekeeping, no artifact effect"
+    [0044]="reserved 2026-07-24 for the issue 57 parked-pane reblit gate; entry harmless once 0044 lands"
 )
 seq_expect=1
 for f in $(awk '{print $2}' "$SERIES" | grep -v '^pipeasio/' | sort); do
@@ -125,6 +126,7 @@ FINGERPRINTS='
 0039|ascii|lib/wine/x86_64-unix/winex11.so|is mapped, refusing to make it managed
 0043|ascii|lib/wine/x86_64-unix/comdlg32.so|org.freedesktop.portal.OpenURI
 0043|ascii|lib/wine/x86_64-windows/shell32.dll|__wine_portal_show_item
+0045|ascii|lib/wine/x86_64-windows/ole32.dll|revoke for another process windows is disabled
 pipeasio/0001|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-clamp-sample-rate
 pipeasio/0002|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-midi-timebase
 '

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,8 +3,9 @@
 # Does not touch the Wine prefix: that is setup-prefix.sh.
 set -euo pipefail
 # readelf and sha256sum output is parsed below; localised output breaks the
-# checks (issue #36).
-export LC_ALL=C
+# checks (issue #36). C.UTF-8, never plain C: wine cannot create non-ASCII
+# filenames under a non-UTF-8 locale (issues #51, #55).
+export LC_ALL=C.UTF-8
 here="$(cd "$(dirname "$0")" && pwd)"
 root="$(cd "$here/.." && pwd)"
 

--- a/scripts/make-installer.sh
+++ b/scripts/make-installer.sh
@@ -4,7 +4,9 @@
 # Repackaging only; Wine is not rebuilt.
 set -euo pipefail
 # ldd and sha256sum output is parsed below; localised output breaks the checks.
-export LC_ALL=C
+# C.UTF-8, never plain C: wine cannot create non-ASCII filenames under a
+# non-UTF-8 locale (issues #51, #55).
+export LC_ALL=C.UTF-8
 here="$(cd "$(dirname "$0")" && pwd)"
 root="$(cd "$here/.." && pwd)"
 cd "$root"

--- a/scripts/setup-prefix.sh
+++ b/scripts/setup-prefix.sh
@@ -289,7 +289,8 @@ else
     kit_root_or_die
     export W_CACHE_OVERRIDE=""            # unused
     export WINETRICKS_LATEST_VERSION_CHECK=disabled
-    export WINETRICKS_SUPER_QUIET=1
+    # Never set WINETRICKS_SUPER_QUIET: it silences w_die, so a fatal
+    # winetricks error exits with no message at all (issue #28).
     # Use the bundled payload cache if present (mfc42 downloads if not vendored).
     tmpc=""
     if [ -d "$root/vendor/winetricks-cache" ]; then

--- a/scripts/setup-run-header.sh
+++ b/scripts/setup-run-header.sh
@@ -16,8 +16,11 @@
 [ -n "${BASH_VERSION:-}" ] || exec bash "$0" "$@"
 set -euo pipefail
 # Tool output is parsed below (sha256sum, readelf, ldd); localised output
-# breaks the checks (issue #36).
-export LC_ALL=C
+# breaks the checks (issue #36). C.UTF-8, never plain C: wine inherits this
+# environment, and under a non-UTF-8 locale it cannot create the non-ASCII
+# filenames Live's Max content ships, which kills the Ableton installer
+# (issues #51, #55). glibc 2.35+, the floor checked below, always has C.UTF-8.
+export LC_ALL=C.UTF-8
 
 VERSION="@VERSION@"
 PAYLOAD_SHA="@PAYLOAD_SHA@"

--- a/tools/build_webviewclose.sh
+++ b/tools/build_webviewclose.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Build webviewclose.exe like build_learnheal.sh: real PE via clang, Wine
+# headers + import libs, no CRT. Needs ole32 for COM init and the WebView2
+# SDK header (Microsoft license — fetched into a cache dir, not committed).
+set -e
+cd "$(dirname "$0")"
+SRC="${ABLETON_WINE_SOURCE:-}"
+[ -n "$SRC" ] || { echo "!! set ABLETON_WINE_SOURCE to the wine-d2d1-nspa source tree (with build-wow64/)" >&2; exit 1; }
+BLD=$SRC/build-wow64
+INC=$SRC/include
+U=$BLD/dlls/user32/x86_64-windows
+K=$BLD/dlls/kernel32/x86_64-windows
+N=$BLD/dlls/ntdll/x86_64-windows
+O=$BLD/dlls/ole32/x86_64-windows
+
+# WebView2 SDK header: fetch once into ./webview2-sdk/ (2.6 MB, from the
+# public Microsoft.Web.WebView2 nupkg; EventToken.h is our 3-line stub).
+SDK=./webview2-sdk
+if [ ! -f "$SDK/WebView2.h" ]; then
+    mkdir -p "$SDK"
+    V=1.0.2903.40
+    curl -sL -o "$SDK/wv2.nupkg" \
+      "https://api.nuget.org/v3-flatcontainer/microsoft.web.webview2/$V/microsoft.web.webview2.$V.nupkg"
+    python3 -c "import zipfile; z=zipfile.ZipFile('$SDK/wv2.nupkg'); \
+open('$SDK/WebView2.h','wb').write(z.read('build/native/include/WebView2.h'))"
+    rm "$SDK/wv2.nupkg"
+    printf '#pragma once\ntypedef struct EventRegistrationToken { __int64 value; } EventRegistrationToken;\n' \
+      > "$SDK/EventToken.h"
+    echo "fetched WebView2.h $V"
+fi
+
+RES=$(clang -print-resource-dir)
+clang -target x86_64-windows-gnu -fuse-ld=lld --no-default-config \
+  -fno-stack-protector -mno-stack-arg-probe -nostdlib -nostdinc \
+  -Wall -O2 \
+  -isystem "$RES/include" -I "$INC" -I "$BLD/include" -I "$INC/msvcrt" -I "$SDK" \
+  -D__WINESRC__ \
+  -Wl,--subsystem,console -Wl,-e,mainCRTStartup \
+  -o webviewclose.exe webviewclose.c \
+  -L "$U" -L "$K" -L "$N" -L "$O" \
+  -luser32 -lkernel32 -lntdll -lole32
+echo "built webviewclose.exe"

--- a/tools/build_webviewclose.sh
+++ b/tools/build_webviewclose.sh
@@ -19,8 +19,10 @@ SDK=./webview2-sdk
 if [ ! -f "$SDK/WebView2.h" ]; then
     mkdir -p "$SDK"
     V=1.0.2903.40
+    SHA256=ef128016dd1e51c59178c827ed5b8aa3322c57afa8675d930f8109505542ad74
     curl -sL -o "$SDK/wv2.nupkg" \
       "https://api.nuget.org/v3-flatcontainer/microsoft.web.webview2/$V/microsoft.web.webview2.$V.nupkg"
+    echo "$SHA256  $SDK/wv2.nupkg" | sha256sum -c -
     python3 -c "import zipfile; z=zipfile.ZipFile('$SDK/wv2.nupkg'); \
 open('$SDK/WebView2.h','wb').write(z.read('build/native/include/WebView2.h'))"
     rm "$SDK/wv2.nupkg"

--- a/tools/webviewclose.c
+++ b/tools/webviewclose.c
@@ -1,0 +1,424 @@
+/* webviewclose.c — reproducer for issue #52 (Live crashes when a WebView2
+ * plugin editor closes).
+ *
+ * Mirrors the anatomy fakeplugin.c established for Live 12's VST3 hosting:
+ *  - main window: overlapped, per-monitor-v2 (Live's IFEO dpiAwareness=2)
+ *  - "plugin editor" window created while the thread DPI context is UNAWARE
+ *    (the VST3-host trick), owned by the main window, WS_CAPTION|WS_SYSMENU
+ *    + WS_EX_TOOLWINDOW like Live's Vst3PlugWindow
+ * then hosts a windowed-mode WebView2 controller in the editor window and
+ * tears it down in a selectable order. A vectored exception handler reports
+ * the faulting address and module, so a crash names the guilty DLL instead
+ * of dying silently.
+ *
+ * Usage: webviewclose.exe <variant> [loader.dll path]
+ *   variant 'a' — polite: put_IsVisible(FALSE); Close(); Release; DestroyWindow
+ *   variant 'b' — abrupt: DestroyWindow(editor) with the controller alive,
+ *                 then Release without Close (what many plugin hosts do)
+ *   variant 'c' — release-only: Release all refs without Close, pump 3 s,
+ *                 then DestroyWindow
+ *   variant 'd' — park: hide + reparent the editor under a hidden helper
+ *                 toplevel (Live's Learn View close), pump 10 s, then exit
+ *   variant 'e' — JUCE-style: RevokeDragDrop on every descendant of the
+ *                 editor (HWNDComponentPeer teardown does exactly this),
+ *                 then Close/Release/DestroyWindow. Under Wine this hits
+ *                 ole32's cross-process RevokeDragDrop use-after-free when
+ *                 the WebView2 helper registered a drop target on its own
+ *                 parented-in Chrome_WidgetWin child (issue #52 suspect,
+ *                 cf. giang17/wine commit fafb443f85e)
+ * Default loader path: C:\ProgramData\Ableton\Live 12 Beta\Program\WebView2Loader.dll
+ *
+ * Writes webviewclose-report.txt (cwd) mirroring stdout. Exit code 0 = clean,
+ * 2 = a setup/teardown step failed, 3 = exception caught.
+ *
+ * Build: build_webviewclose.sh (fetches the public WebView2 SDK header, not
+ * committed here).
+ */
+
+#define COBJMACROS
+#include <windows.h>
+#include <objbase.h>
+#include <ole2.h>
+#include <stdarg.h>
+
+#include "WebView2.h"
+
+int _vsnprintf( char *buf, SIZE_T size, const char *fmt, va_list args ); /* ntdll */
+
+static HANDLE report = INVALID_HANDLE_VALUE;
+
+static void out( const char *fmt, ... )
+{
+    va_list ap;
+    char buf[1024];
+    int len;
+    DWORD n;
+
+    va_start( ap, fmt );
+    len = _vsnprintf( buf, sizeof(buf) - 2, fmt, ap );
+    va_end( ap );
+    if (len < 0) len = sizeof(buf) - 2;
+    buf[len] = '\n';
+    buf[len + 1] = 0;
+    WriteFile( GetStdHandle( STD_OUTPUT_HANDLE ), buf, len + 1, &n, NULL );
+    if (report != INVALID_HANDLE_VALUE)
+    {
+        WriteFile( report, buf, len + 1, &n, NULL );
+        FlushFileBuffers( report );
+    }
+}
+
+/* ---- crash reporting ----------------------------------------------------- */
+
+static LONG CALLBACK crash_handler( EXCEPTION_POINTERS *info )
+{
+    DWORD code = info->ExceptionRecord->ExceptionCode;
+    void *addr = info->ExceptionRecord->ExceptionAddress;
+    HMODULE mod = NULL;
+    WCHAR name[MAX_PATH] = {0};
+
+    /* only fatal ones; first-chance C++ exceptions (0xE06D7363) and RPC
+     * disconnects are business as usual for a closing browser stack */
+    if (code != EXCEPTION_ACCESS_VIOLATION && code != EXCEPTION_ILLEGAL_INSTRUCTION
+            && code != EXCEPTION_STACK_OVERFLOW && code != EXCEPTION_INT_DIVIDE_BY_ZERO)
+        return EXCEPTION_CONTINUE_SEARCH;
+
+    GetModuleHandleExW( GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
+                        | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                        (LPCWSTR)addr, &mod );
+    if (mod) GetModuleFileNameW( mod, name, MAX_PATH );
+
+    out( "!! EXCEPTION %08x at %I64x (module %S + %I64x)",
+         (unsigned int)code, (unsigned __int64)(ULONG_PTR)addr, name[0] ? name : L"<none>",
+         mod ? (unsigned __int64)((ULONG_PTR)addr - (ULONG_PTR)mod) : 0 );
+    if (code == EXCEPTION_ACCESS_VIOLATION)
+        out( "!!   %s at %I64x",
+             info->ExceptionRecord->ExceptionInformation[0] ? "write" : "read",
+             (unsigned __int64)info->ExceptionRecord->ExceptionInformation[1] );
+
+    if (report != INVALID_HANDLE_VALUE) CloseHandle( report );
+    ExitProcess( 3 );
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+/* ---- minimal COM completed-handlers -------------------------------------- */
+
+static ICoreWebView2Environment *g_env;
+static ICoreWebView2Controller *g_controller;
+static HRESULT g_env_hr = S_FALSE, g_ctl_hr = S_FALSE;
+static HWND g_editor;
+
+static HRESULT STDMETHODCALLTYPE handler_QI( void *iface, REFIID iid, void **out_iface )
+{
+    *out_iface = iface;   /* IUnknown + whichever handler IID: same object */
+    return S_OK;
+}
+static ULONG STDMETHODCALLTYPE handler_AddRef( void *iface )  { return 2; }
+static ULONG STDMETHODCALLTYPE handler_Release( void *iface ) { return 1; }
+
+static HRESULT STDMETHODCALLTYPE env_completed_Invoke(
+        ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *iface,
+        HRESULT hr, ICoreWebView2Environment *env )
+{
+    g_env_hr = hr;
+    g_env = env;
+    if (env) ICoreWebView2Environment_AddRef( env );
+    out( "env completed: hr=%08x env=%I64x", (unsigned int)hr, (unsigned __int64)(ULONG_PTR)env );
+    return S_OK;
+}
+
+static HRESULT STDMETHODCALLTYPE ctl_completed_Invoke(
+        ICoreWebView2CreateCoreWebView2ControllerCompletedHandler *iface,
+        HRESULT hr, ICoreWebView2Controller *controller )
+{
+    g_ctl_hr = hr;
+    g_controller = controller;
+    if (controller) ICoreWebView2Controller_AddRef( controller );
+    out( "controller completed: hr=%08x controller=%I64x",
+         (unsigned int)hr, (unsigned __int64)(ULONG_PTR)controller );
+    return S_OK;
+}
+
+static const ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandlerVtbl env_vtbl =
+{
+    (void *)handler_QI, (void *)handler_AddRef, (void *)handler_Release,
+    env_completed_Invoke,
+};
+static const ICoreWebView2CreateCoreWebView2ControllerCompletedHandlerVtbl ctl_vtbl =
+{
+    (void *)handler_QI, (void *)handler_AddRef, (void *)handler_Release,
+    ctl_completed_Invoke,
+};
+static ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler env_handler =
+    { (ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandlerVtbl *)&env_vtbl };
+static ICoreWebView2CreateCoreWebView2ControllerCompletedHandler ctl_handler =
+    { (ICoreWebView2CreateCoreWebView2ControllerCompletedHandlerVtbl *)&ctl_vtbl };
+
+/* ---- minimal IDropTarget (host-side registration, JUCE hosts have one) --- */
+
+static HRESULT STDMETHODCALLTYPE dt_QI( IDropTarget *iface, REFIID iid, void **out_iface )
+{
+    *out_iface = iface;
+    return S_OK;
+}
+static ULONG STDMETHODCALLTYPE dt_AddRef( IDropTarget *iface )  { return 2; }
+static ULONG STDMETHODCALLTYPE dt_Release( IDropTarget *iface ) { return 1; }
+static HRESULT STDMETHODCALLTYPE dt_DragEnter( IDropTarget *iface, IDataObject *obj,
+        DWORD state, POINTL pt, DWORD *effect ) { *effect = DROPEFFECT_NONE; return S_OK; }
+static HRESULT STDMETHODCALLTYPE dt_DragOver( IDropTarget *iface,
+        DWORD state, POINTL pt, DWORD *effect ) { *effect = DROPEFFECT_NONE; return S_OK; }
+static HRESULT STDMETHODCALLTYPE dt_DragLeave( IDropTarget *iface ) { return S_OK; }
+static HRESULT STDMETHODCALLTYPE dt_Drop( IDropTarget *iface, IDataObject *obj,
+        DWORD state, POINTL pt, DWORD *effect ) { *effect = DROPEFFECT_NONE; return S_OK; }
+
+static const IDropTargetVtbl dt_vtbl =
+{
+    dt_QI, dt_AddRef, dt_Release, dt_DragEnter, dt_DragOver, dt_DragLeave, dt_Drop,
+};
+static IDropTarget host_drop_target = { (IDropTargetVtbl *)&dt_vtbl };
+
+/* JUCE HWNDComponentPeer teardown revokes drag-drop on every descendant it
+ * can enumerate — including the WebView2 helper's own Chrome_WidgetWin
+ * children parented into the host tree. Log ownership so the report shows
+ * which windows carry a foreign drop-target registration. */
+static BOOL CALLBACK revoke_enum_proc( HWND hwnd, LPARAM lp )
+{
+    WCHAR cls[64] = {0};
+    DWORD pid = 0;
+    HANDLE marshalled = GetPropW( hwnd, L"WineMarshalledDropTarget" );
+    void *raw = GetPropW( hwnd, L"OleDropTargetInterface" );
+    HRESULT hr;
+
+    GetClassNameW( hwnd, cls, 64 );
+    GetWindowThreadProcessId( hwnd, &pid );
+    out( "  child %I64x class %S pid %u%s droptarget_prop=%I64x marshalled=%I64x",
+         (unsigned __int64)(ULONG_PTR)hwnd, cls, (unsigned int)pid,
+         pid == GetCurrentProcessId() ? " (ours)" : " (FOREIGN)",
+         (unsigned __int64)(ULONG_PTR)raw, (unsigned __int64)(ULONG_PTR)marshalled );
+
+    out( "  RevokeDragDrop(%I64x)...", (unsigned __int64)(ULONG_PTR)hwnd );
+    hr = RevokeDragDrop( hwnd );
+    out( "  RevokeDragDrop(%I64x) -> %08x", (unsigned __int64)(ULONG_PTR)hwnd, (unsigned int)hr );
+    return TRUE;
+}
+
+/* ---- window plumbing ------------------------------------------------------ */
+
+static LRESULT CALLBACK plain_wndproc( HWND hwnd, UINT msg, WPARAM wp, LPARAM lp )
+{
+    if (msg == WM_DESTROY && hwnd == g_editor)
+        out( "editor WM_DESTROY" );
+    return DefWindowProcW( hwnd, msg, wp, lp );
+}
+
+static void pump_ms( DWORD ms )
+{
+    DWORD end = GetTickCount() + ms;
+    MSG msg;
+
+    for (;;)
+    {
+        DWORD now = GetTickCount();
+        if ((int)(end - now) <= 0) break;
+        MsgWaitForMultipleObjects( 0, NULL, FALSE, end - now, QS_ALLINPUT );
+        while (PeekMessageW( &msg, NULL, 0, 0, PM_REMOVE ))
+        {
+            TranslateMessage( &msg );
+            DispatchMessageW( &msg );
+        }
+    }
+}
+
+typedef HRESULT (STDAPICALLTYPE *create_env_fn)(
+        PCWSTR browser_dir, PCWSTR user_data_dir, void *options,
+        ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *handler );
+
+int mainCRTStartup( void )
+{
+    char variant = 'a';
+    WCHAR loader_buf[MAX_PATH] =
+        L"C:\\ProgramData\\Ableton\\Live 12 Beta\\Program\\WebView2Loader.dll";
+    WCHAR *cmdline = GetCommandLineW();
+    WNDCLASSW wc = {0};
+    HWND main_win, helper = NULL;
+    HMODULE loader;
+    create_env_fn create_env;
+    WCHAR data_dir[MAX_PATH];
+    RECT rc;
+    HRESULT hr;
+    DPI_AWARENESS_CONTEXT prev_ctx;
+    int failed = 0;
+    DWORD t0;
+
+    report = CreateFileA( "webviewclose-report.txt", GENERIC_WRITE, FILE_SHARE_READ,
+                          NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL );
+    AddVectoredExceptionHandler( 1, crash_handler );
+    SetProcessDpiAwarenessContext( DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 );
+    OleInitialize( NULL );  /* JUCE/Live hosts are OLE-initialized STA */
+
+    /* crude arg parse: first token after the exe is the variant letter,
+     * optional second token a loader path */
+    {
+        WCHAR *p = cmdline;
+        int in_quote = 0;
+        while (*p && (in_quote || *p != L' ')) { if (*p == L'"') in_quote = !in_quote; p++; }
+        while (*p == L' ') p++;
+        if (*p) { variant = (char)*p; while (*p && *p != L' ') p++; while (*p == L' ') p++; }
+        if (*p)
+        {
+            int i = 0;
+            WCHAR quote = 0;
+            if (*p == L'"') quote = *p++;
+            while (*p && i < MAX_PATH - 1 && (quote ? *p != quote : *p != L' '))
+                loader_buf[i++] = *p++;
+            loader_buf[i] = 0;
+        }
+    }
+    out( "variant '%c', loader %S", variant, loader_buf );
+
+    wc.lpfnWndProc = plain_wndproc;
+    wc.hInstance = GetModuleHandleW( NULL );
+    wc.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+    wc.lpszClassName = L"WvcMain";
+    RegisterClassW( &wc );
+
+    main_win = CreateWindowExW( 0, L"WvcMain", L"webviewclose host",
+                                WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+                                80, 80, 900, 600, NULL, NULL, wc.hInstance, NULL );
+
+    /* the VST3-host trick: editor window born in an UNAWARE thread context */
+    prev_ctx = SetThreadDpiAwarenessContext( DPI_AWARENESS_CONTEXT_UNAWARE );
+    g_editor = CreateWindowExW( WS_EX_TOOLWINDOW, L"WvcMain", L"Fake plugin editor",
+                                WS_CAPTION | WS_SYSMENU | WS_VISIBLE,
+                                140, 140, 700, 480, main_win, NULL, wc.hInstance, NULL );
+    SetThreadDpiAwarenessContext( prev_ctx );
+
+    hr = RegisterDragDrop( g_editor, &host_drop_target );
+    out( "RegisterDragDrop(editor) -> %08x", (unsigned int)hr );
+
+    loader = LoadLibraryW( loader_buf );
+    if (!loader)
+    {
+        out( "!! LoadLibrary(WebView2Loader) failed, err %u", (unsigned int)GetLastError() );
+        return 2;
+    }
+    create_env = (create_env_fn)GetProcAddress( loader, "CreateCoreWebView2EnvironmentWithOptions" );
+    if (!create_env)
+    {
+        out( "!! no CreateCoreWebView2EnvironmentWithOptions export" );
+        return 2;
+    }
+
+    GetEnvironmentVariableW( L"TEMP", data_dir, MAX_PATH );
+    lstrcatW( data_dir, L"\\webviewclose-data" );
+
+    hr = create_env( NULL, data_dir, NULL, &env_handler );
+    out( "CreateCoreWebView2EnvironmentWithOptions -> %08x", (unsigned int)hr );
+    if (FAILED( hr )) return 2;
+
+    t0 = GetTickCount();
+    while (g_env_hr == S_FALSE && GetTickCount() - t0 < 15000) pump_ms( 50 );
+    if (!g_env) { out( "!! environment never arrived (hr=%08x)", (unsigned int)g_env_hr ); return 2; }
+
+    hr = ICoreWebView2Environment_CreateCoreWebView2Controller( g_env, g_editor, &ctl_handler );
+    out( "CreateCoreWebView2Controller -> %08x", (unsigned int)hr );
+    t0 = GetTickCount();
+    while (g_ctl_hr == S_FALSE && GetTickCount() - t0 < 15000) pump_ms( 50 );
+    if (!g_controller) { out( "!! controller never arrived (hr=%08x)", (unsigned int)g_ctl_hr ); return 2; }
+
+    GetClientRect( g_editor, &rc );
+    ICoreWebView2Controller_put_Bounds( g_controller, rc );
+    ICoreWebView2Controller_put_IsVisible( g_controller, TRUE );
+
+    {
+        ICoreWebView2 *wv = NULL;
+        if (SUCCEEDED( ICoreWebView2Controller_get_CoreWebView2( g_controller, &wv ) ) && wv)
+        {
+            ICoreWebView2_Navigate( wv, L"about:blank" );
+            ICoreWebView2_Release( wv );
+        }
+    }
+
+    out( "webview up; settling 3 s" );
+    pump_ms( 3000 );
+
+    out( "-- teardown variant '%c' --", variant );
+    switch (variant)
+    {
+    case 'a':
+        out( "put_IsVisible(FALSE)" );
+        ICoreWebView2Controller_put_IsVisible( g_controller, FALSE );
+        pump_ms( 200 );
+        out( "Close()" );
+        hr = ICoreWebView2Controller_Close( g_controller );
+        out( "Close -> %08x", (unsigned int)hr );
+        if (FAILED( hr )) failed = 1;
+        pump_ms( 500 );
+        out( "Release(controller)" );
+        ICoreWebView2Controller_Release( g_controller );
+        out( "Release(env)" );
+        ICoreWebView2Environment_Release( g_env );
+        pump_ms( 500 );
+        out( "DestroyWindow(editor)" );
+        DestroyWindow( g_editor );
+        break;
+
+    case 'b':
+        out( "DestroyWindow(editor) with live controller" );
+        DestroyWindow( g_editor );
+        pump_ms( 1000 );
+        out( "Release(controller) without Close" );
+        ICoreWebView2Controller_Release( g_controller );
+        out( "Release(env)" );
+        ICoreWebView2Environment_Release( g_env );
+        break;
+
+    case 'c':
+        out( "Release(controller) without Close, window kept" );
+        ICoreWebView2Controller_Release( g_controller );
+        ICoreWebView2Environment_Release( g_env );
+        out( "pumping 3 s" );
+        pump_ms( 3000 );
+        out( "DestroyWindow(editor)" );
+        DestroyWindow( g_editor );
+        break;
+
+    case 'd':
+        out( "parking: hide editor, reparent under hidden helper" );
+        helper = CreateWindowExW( 0, L"WvcMain", L"HiddenHelper",
+                                  WS_OVERLAPPEDWINDOW, /* never shown */
+                                  0, 0, 100, 100, NULL, NULL, wc.hInstance, NULL );
+        ICoreWebView2Controller_put_IsVisible( g_controller, FALSE );
+        ShowWindow( g_editor, SW_HIDE );
+        SetParent( g_editor, helper );
+        out( "parked; pumping 10 s (watch for stray blits/flicker)" );
+        pump_ms( 10000 );
+        break;
+
+    case 'e':
+        out( "JUCE-style teardown: RevokeDragDrop over all descendants" );
+        EnumChildWindows( g_editor, revoke_enum_proc, 0 );
+        out( "RevokeDragDrop(editor itself)..." );
+        hr = RevokeDragDrop( g_editor );
+        out( "RevokeDragDrop(editor) -> %08x", (unsigned int)hr );
+        out( "Close()" );
+        hr = ICoreWebView2Controller_Close( g_controller );
+        out( "Close -> %08x", (unsigned int)hr );
+        pump_ms( 500 );
+        ICoreWebView2Controller_Release( g_controller );
+        ICoreWebView2Environment_Release( g_env );
+        out( "DestroyWindow(editor)" );
+        DestroyWindow( g_editor );
+        break;
+
+    default:
+        out( "!! unknown variant" );
+        return 2;
+    }
+
+    out( "pumping 3 s post-teardown" );
+    pump_ms( 3000 );
+    out( failed ? "DONE (teardown step failed)" : "DONE clean" );
+    if (report != INVALID_HANDLE_VALUE) CloseHandle( report );
+    return failed ? 2 : 0;
+}


### PR DESCRIPTION
Fixes #52.
This creates Wine patch `0045`, and here we are porting `RevokeDragDrop` from `giang17/wine fafb443f85e0` to this fork and applying it. 

When the `WebView2` helper registers a drop target on a child window inside Live's window tree, the editor in Live's process will revoke drag and drop on it. `ole32` releases a pointer only valid in the helper process. 

This is not Splice specific, and is reproduceable with any `WebView2` window in Live. I've added a `tools/webviewclose.c` variant that crashes in unpatched environments, and handles things correctly in an environment running `0045`.

Patch `0044` is a forthcoming patch that I started earlier, and will fix #47 but is not ready yet.
We won't be able to make a build until `0044` is included. 