### PR TITLE
Build ableton-linkd in source builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@
 
 - Closing a WebView2-based plugin editor no longer crashes Live (issue 52, Splice INSTRUMENT, Wine patch 0045; notes/ABLETON-WINE-WEBVIEW2-PLUGIN-CLOSE-CRASH.md). The WebView2 helper process registers a drag-and-drop handler on a child window it parents into Live's window tree; when the editor closes, Live's side revokes drag-and-drop on that window and Wine's ole32 released a pointer that is only valid in the helper process. RevokeDragDrop now rejects windows owned by other processes, the same rule RegisterDragDrop already applies. Fix by Giang Nguyen, ported from the wine base fork. Reproduced and verified without Splice using the new tools/webviewclose.c.
 
-- `build.sh` now creates `dist/ableton-linkd`. Installer packaging calls the
-  same Podman helper when that artifact is missing. The helper builds against
-  the vendored Ableton Link SDK.
+- `build.sh` now creates `dist/ableton-linkd`. Installer packaging calls the same Podman helper when that artifact is missing. The helper builds against the vendored Ableton Link SDK.
 - Fixed fresh Live installs failing on the non-ASCII filenames in Live's Max content (issues 51 and 55). The C locale forced in 2026.07.21.2 for issue 36 reached Wine, which cannot create names like bp.µSeq.maxpat under a non-UTF-8 locale: Live 11's MSI rolled back with error 0x80070643, Live 12's installer looped a "Try again" dialog on MoveFile code 2. The installer scripts now force C.UTF-8, keeping the issue 36 fix and the filenames. Only a fresh run of the Ableton installer was affected, not existing installs.
 - winetricks failures now say what failed (issue 28). The quiet flag prefix setup passed to winetricks also silences its fatal-error message, so a failed step exited with no output while the installer claimed the details were above. The flag is gone; a failure now names the failing command and its exit status.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Closing a WebView2-based plugin editor no longer crashes Live (issue 52, Splice INSTRUMENT, Wine patch 0045; notes/ABLETON-WINE-WEBVIEW2-PLUGIN-CLOSE-CRASH.md). The WebView2 helper process registers a drag-and-drop handler on a child window it parents into Live's window tree; when the editor closes, Live's side revokes drag-and-drop on that window and Wine's ole32 released a pointer that is only valid in the helper process. RevokeDragDrop now rejects windows owned by other processes, the same rule RegisterDragDrop already applies. Fix by Giang Nguyen, ported from the wine base fork. Reproduced and verified without Splice using the new tools/webviewclose.c.
 
+- `build.sh` now creates `dist/ableton-linkd`. Installer packaging calls the
+  same Podman helper when that artifact is missing. The helper builds against
+  the vendored Ableton Link SDK.
 - Fixed fresh Live installs failing on the non-ASCII filenames in Live's Max content (issues 51 and 55). The C locale forced in 2026.07.21.2 for issue 36 reached Wine, which cannot create names like bp.µSeq.maxpat under a non-UTF-8 locale: Live 11's MSI rolled back with error 0x80070643, Live 12's installer looped a "Try again" dialog on MoveFile code 2. The installer scripts now force C.UTF-8, keeping the issue 36 fix and the filenames. Only a fresh run of the Ableton installer was affected, not existing installs.
 - winetricks failures now say what failed (issue 28). The quiet flag prefix setup passed to winetricks also silences its fatal-error message, so a failed step exited with no output while the installer claimed the details were above. The flag is gone; a failure now names the failing command and its exit status.
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 all: build
 
-build:                        ## build Wine + PipeASIO in a container -> dist/
+build:                        ## build runtime and Link helper with Podman -> dist/
 	./build.sh
 
 install:                      ## install the built Wine tree + launcher (end user)

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 #
-#   ./build.sh                # build the relocatable tarball with podman
-#   ENGINE=docker ./build.sh  # or docker
+#   ./build.sh                # build the runtime and Link helper with Podman
 #   JOBS=8 ./build.sh         # limit parallelism
 #   INSTALL_PREFIX=/target/path/wine-d2d1-nspa-11.11 ./build.sh
-#                             # strict path-identity build; normally unnecessary —
+#                             # strict path-identity build; normally unnecessary
 #                             # the tarball self-locates (relocation gate proves it)
 set -euo pipefail
 here="$(cd "$(dirname "$0")" && pwd)"
@@ -17,15 +16,18 @@ JOBS="${JOBS:-$(nproc)}"
 # One tarball can serve any user and any $HOME. 
 INSTALL_PREFIX="${INSTALL_PREFIX:-/opt/wine-d2d1-nspa-11.11}"
 
-command -v "$ENGINE" >/dev/null || { echo "!! '$ENGINE' not found (set ENGINE=docker?)"; exit 1; }
+command -v "$ENGINE" >/dev/null || {
+    echo "!! Podman command '$ENGINE' not found; install Podman or set ENGINE" >&2
+    exit 1
+}
 
-echo "== [0/3] verify vendored inputs against pinned checksums =="
+echo "== [0/4] verify vendored inputs against pinned checksums =="
 ( cd vendor && sha256sum -c wine-base.sha256 pipeasio.sha256 pipewire-sdk.sha256 ntsync-uapi.sha256 link.sha256 )
 
-echo "== [1/3] build container image ($IMAGE) =="
+echo "== [1/4] build container image ($IMAGE) =="
 $ENGINE build -t "$IMAGE" -f Containerfile .
 
-echo "== [2/3] build Wine + PipeASIO in the container (JOBS=$JOBS) =="
+echo "== [2/4] build Wine + PipeASIO in the container (JOBS=$JOBS) =="
 mkdir -p dist
 relabel=""
 if [ -f /sys/fs/selinux/enforce ]; then relabel=",Z"; fi
@@ -37,7 +39,10 @@ $ENGINE run --rm \
     "$IMAGE" \
     /src/scripts/container-build.sh
 
-echo "== [3/3] done — artifacts in dist/ =="
+echo "== [3/4] build ableton-linkd with the configured Podman image =="
+ENGINE="$ENGINE" IMAGE="$IMAGE" ./scripts/build-ableton-linkd.sh
+
+echo "== [4/4] done: artifacts in dist/ =="
 ls -lh dist/
 echo
 echo "Next:  ./scripts/install.sh   then   ./scripts/setup-prefix.sh"

--- a/scripts/build-ableton-linkd.sh
+++ b/scripts/build-ableton-linkd.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Build the persistent native Ableton Link peer in the Podman build image.
+# Relative output paths resolve from the repository root.
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+cd "$root"
+
+ENGINE="${ENGINE:-podman}"
+IMAGE="${IMAGE:-ableton-wine-build:22.04}"
+output="${1:-$root/dist/ableton-linkd}"
+case "$output" in
+    /*) ;;
+    *) output="$root/$output" ;;
+esac
+out_dir="$(dirname "$output")"
+out_name="$(basename "$output")"
+
+command -v "$ENGINE" >/dev/null || {
+    echo "!! need $ENGINE to build ableton-linkd" >&2
+    exit 1
+}
+( cd vendor && sha256sum -c link.sha256 )
+mkdir -p "$out_dir"
+"$ENGINE" image inspect "$IMAGE" >/dev/null 2>&1 || {
+    echo "!! build image $IMAGE is missing: run ./build.sh first" >&2
+    exit 1
+}
+
+# The container writes into a disposable directory. The wrapper validates the
+# candidate and copies it into a host-owned temporary file. It then renames the
+# file atomically.
+# Failed builds preserve the existing output. The final file belongs to the
+# user who runs this wrapper.
+build_dir="$(mktemp -d "$out_dir/.ableton-linkd.build.XXXXXX")"
+install_tmp=""
+cleanup()
+{
+    rm -rf "$build_dir"
+    [ -z "$install_tmp" ] || rm -f "$install_tmp"
+}
+trap cleanup EXIT
+install_tmp="$(mktemp "$out_dir/.${out_name}.install.XXXXXX")"
+
+relabel=""
+if [ -f /sys/fs/selinux/enforce ]; then relabel=",Z"; fi
+"$ENGINE" run --rm \
+    -v "$root:/src:ro$relabel" \
+    -v "$build_dir:/out:rw$relabel" \
+    "$IMAGE" \
+    /src/tools/build_ableton-linkd.sh /out/ableton-linkd
+
+[ -x "$build_dir/ableton-linkd" ] || {
+    echo "!! ableton-linkd build did not produce a candidate" >&2
+    exit 1
+}
+"$build_dir/ableton-linkd" --help >/dev/null 2>&1 || {
+    echo "!! built ableton-linkd does not run on this host" >&2
+    exit 1
+}
+install -m755 "$build_dir/ableton-linkd" "$install_tmp"
+mv -fT -- "$install_tmp" "$output"
+install_tmp=""
+echo "built $output"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -78,9 +78,9 @@ for required in \
     lib/wine/x86_64-unix/pipeasio.dll.so; do
     [ -s "$candidate/$required" ] || { echo "!! package is missing $required" >&2; exit 1; }
 done
-# ableton-linkd (native Ableton Link session anchor) is not part of the runtime
-# tree: the kit carries it in bin/, a repo checkout carries the pack-time build
-# in dist/. Its user unit ships next to the install scripts.
+# ableton-linkd (persistent native Ableton Link peer) is not part of the runtime
+# tree. The kit carries it in bin/, and a repository checkout reads it from
+# dist/. Its user unit ships next to the install scripts.
 linkd=""
 for f in "$here/../bin/ableton-linkd" "$root/dist/ableton-linkd"; do
     if [ -f "$f" ]; then linkd="$f"; break; fi
@@ -112,10 +112,10 @@ if command -v readelf >/dev/null && command -v strings >/dev/null; then
             echo "!! PipeASIO is not linked to host libpipewire-0.3.so.0" >&2
             exit 1
         }
-    # ableton-linkd must resolve against host C-runtime sonames only:
-    # -static-libstdc++ -static-libgcc keep libstdc++/libgcc_s out of
-    # DT_NEEDED (same loader-cleanliness rule as PipeASIO). Anything else,
-    # above all a shared libstdc++, means the pack-time flags were lost.
+    # ableton-linkd must resolve against host C-runtime sonames only.
+    # -static-libstdc++ and -static-libgcc keep libstdc++ and libgcc_s out of
+    # DT_NEEDED. Any other dependency means the required static-link flags
+    # were omitted.
     linkd_needed="$(readelf -d "$linkd" | sed -n 's/.*Shared library: \[\(.*\)\]/\1/p')"
     for so in $linkd_needed; do
         case "$so" in

--- a/scripts/make-installer.sh
+++ b/scripts/make-installer.sh
@@ -50,28 +50,9 @@ dist/cabextract-static --version >/dev/null 2>&1 || \
     { echo "!! dist/cabextract-static does not run on this host" >&2; exit 1; }
 echo "   cabextract-static: $(dist/cabextract-static --version 2>&1 | head -1)"
 
-echo "== [2/5] ableton-linkd (Ableton Link session anchor, from the vendored SDK) =="
-( cd vendor && sha256sum -c link.sha256 )
+echo "== [2/5] ableton-linkd (persistent Ableton Link peer, from the vendored SDK) =="
 if [ ! -x dist/ableton-linkd ]; then
-    command -v "$ENGINE" >/dev/null || { echo "!! need $ENGINE to build ableton-linkd" >&2; exit 1; }
-    relabel=""
-    if [ -f /sys/fs/selinux/enforce ]; then relabel=",Z"; fi
-    # Header-only SDK (include/ + asio-standalone); -static-libstdc++ -static-libgcc
-    # keep DT_NEEDED to host C-runtime sonames: install.sh gates exactly that.
-    $ENGINE run --rm \
-        -v "$root:/src:ro$relabel" \
-        -v "$root/dist:/out:rw$relabel" \
-        "$IMAGE" bash -ec '
-            mkdir -p /work/link && cd /work/link
-            tar -I zstd -xf /src/vendor/link-4.0.tar.zst
-            g++ -O2 -std=c++17 -Wall -Wno-multichar \
-                -I include -I modules/asio-standalone/asio/include \
-                -DLINK_PLATFORM_UNIX=1 -DLINK_PLATFORM_LINUX=1 \
-                -static-libstdc++ -static-libgcc \
-                /src/tools/ableton-linkd.cpp -o ableton-linkd \
-                -lpthread -latomic
-            strip ableton-linkd
-            install -m755 ableton-linkd /out/ableton-linkd'
+    ENGINE="$ENGINE" IMAGE="$IMAGE" ./scripts/build-ableton-linkd.sh
 fi
 dist/ableton-linkd --help >/dev/null 2>&1 || \
     { echo "!! dist/ableton-linkd does not run on this host" >&2; exit 1; }

--- a/tools/build_ableton-linkd.sh
+++ b/tools/build_ableton-linkd.sh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
-# Build ableton-linkd (native Ableton Link session anchor + probe) from the
-# vendored Link SDK: extracts vendor/link-4.0.tar.zst to a temp dir and
-# compiles against THAT, so the build proves the vendored source is
-# sufficient and never touches a checked-out ableton-link clone.
+# Build ableton-linkd from the vendored Ableton Link SDK. The script extracts
+# vendor/link-4.0.tar.zst to a temporary directory and compiles only against
+# that archive, proving that the vendored source is sufficient.
 # Header-only C++17 + asio; static libstdc++/libgcc keep the shipped
 # binary's DT_NEEDED to host libc/libm/libpthread/libatomic sonames only.
-set -e
+# An optional output path lets the caller select the destination.
+set -euo pipefail
 cd "$(dirname "$0")"
 VENDOR=../vendor
 TARBALL=$VENDOR/link-4.0.tar.zst
+OUTPUT="${1:-ableton-linkd}"
+case "$OUTPUT" in
+    /*) ;;
+    *) OUTPUT="$PWD/$OUTPUT" ;;
+esac
 
 [ -f "$TARBALL" ] || { echo "!! $TARBALL missing (vendored Ableton Link SDK)" >&2; exit 1; }
+[ -d "$(dirname "$OUTPUT")" ] || {
+    echo "!! output directory does not exist: $(dirname "$OUTPUT")" >&2
+    exit 1
+}
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
@@ -25,6 +34,9 @@ g++ -std=c++17 -O2 -Wall -Wno-multichar \
   -DLINK_PLATFORM_UNIX=1 -DLINK_PLATFORM_LINUX=1 \
   -I "$SDK/include" -I "$SDK/modules/asio-standalone/asio/include" \
   -static-libstdc++ -static-libgcc \
-  -o ableton-linkd ableton-linkd.cpp \
+  -o "$WORK/ableton-linkd" ableton-linkd.cpp \
   -lpthread -latomic
-echo "built ableton-linkd"
+strip "$WORK/ableton-linkd"
+"$WORK/ableton-linkd" --help >/dev/null
+install -m755 "$WORK/ableton-linkd" "$OUTPUT"
+echo "built $OUTPUT"


### PR DESCRIPTION
Make build.sh produce the native Link helper required by install.sh. Installer packaging reuses a runnable artifact or calls the same Podman helper.

The wrapper validates a new binary before replacing the existing one. The invoking user owns the final file.