### PR TITLE
Fix/interface drawing on gpu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Live now uses its GPU renderer. Prefix setup removes the legacy
+  `-_ForceGdiBackend` line from `Options.txt` (step 5c). This removes the
+  Learn View and Splice view flicker and drops idle CPU to 1-2%. See
+  [the GPU renderer note](notes/ABLETON-WINE-GPU-RENDERER.md).
+- Fixed windows fighting an interactive resize below the app minimum
+  (Wine patch 0053). winex11 now exports the `WM_GETMINMAXINFO` minimum
+  as the X11 `PMinSize` hint, and the window manager stops the drag at
+  the minimum.
+
 - Fixed a Live crash when closing WebView2 plugin editors (issue 52, Wine
   patch 0045). `RevokeDragDrop` now rejects windows owned by another process,
   matching `RegisterDragDrop`. Fix by Giang Nguyen. See

--- a/WEBVIEW2-DIAGNOSIS.md
+++ b/WEBVIEW2-DIAGNOSIS.md
@@ -1,0 +1,213 @@
+# WebView2 Learn View flicker: diagnosis and fix plan
+
+2026-07-27. Covers the open-pane Learn View artifact reported on the
+production prefix: a grey cutout box over the pane, alternating with the
+rendered page at about 5 switches per second while the pane is open.
+
+## Status
+
+Resolved 2026-07-27, by a different route than the plan below: enabling
+Live's GPU renderer (removing `-_ForceGdiBackend` from `Options.txt`)
+eliminates the visible flicker on both the production 11.11 runtime and
+the 11.13 build of main. Measured: the 5 Hz reblit still fires but all
+30 of 30 pane frame captures hash identical, on both panes, at 200%
+scale, under WebView2 149. The WebView2 browser flags turned out to be
+bystanders: Live hardcodes `--disable-gpu --disable-gpu-compositing
+--disable-direct-composition` into its browser processes, verified from
+`/proc/<pid>/cmdline`. The maintainer confirmed the result in use, with
+idle CPU at 1-2%. Shipped on branch `fix/interface-drawing-on-gpu`
+together with Wine patch 0053 for the below-minimum resize fight the
+GPU renderer exposed. See `notes/ABLETON-WINE-GPU-RENDERER.md`.
+
+The diagnosis and plan below are preserved as written; steps 1 and 2 of
+the plan were executed and produced the finding above. The remaining
+steps did not run.
+
+## Production state
+
+- Launcher: `~/.local/bin/ableton-live`, prefix `~/.wine-ableton`.
+- Runtime: `~/.local/opt/wine-d2d1-nspa-11.11`, dist 2026.07.22.1,
+  wine 11.11 base, patches 0001 through 0043 plus pipeasio.
+- `learnheal.exe` is staged and launched. It does not resolve the
+  artifact on this setup.
+- WebView2 Evergreen runtime in the prefix: 149.0.4022.80, installed by
+  Microsoft's updater on 2026-07-24, after the runtime above was built
+  and after all Learn View testing. Chromium 149 uses delegated
+  compositing, a presentation path this stack was never tested against.
+
+## Why the artifact exists
+
+Patch 0041 made WebView2's DirectComposition frames visible by adding a
+keep-alive reblit into the target window. Chromium also paints its own
+stale software frame into the same window. Two writers, one window: the
+correct frame and the stale grey frame alternate at the reblit cadence,
+which is the 5 Hz flicker. `learnheal.exe` masks the race by forcing one
+re-render so both writers hold identical content. On the production
+setup (2x scale, WebView2 149) the frames never converge, so the mask
+fails and the race stays visible.
+
+`notes/ABLETON-WINE-LEARNVIEW-FLICKER.md` records the mechanism.
+`notes/ABLETON-WINE-WEBVIEW2-COMPOSITOR.md` states the conclusion: no
+timer or gate tuning escapes a two-writer conflict on one window.
+
+## History of prior claims
+
+- Patch 0041 plus learnheal shipped in 2026.07.21.2. The open-pane race
+  was negotiated, not fixed, and the notes of the time say so.
+- The issue 57 close-path work (the 0044 gate draft, then the win32u
+  dce.c cross-process visible-region fix) was verified on a test copy on
+  2026-07-25 and never shipped. It sits on the unpushed branch
+  `fixes/issue-57-crossproc-visrgn` (commit ccd0975). Production never
+  changed.
+- Patch 0041 also removed the old 3 second reblit suspension, which
+  turned a transient close-path artifact into a permanent one (issue 57).
+- A compositor backport, patches 0049 through 0051, was committed
+  2026-07-26 on branch `fix/d2d1-dcomp-giang17-webview2-compositor`
+  (commit 1da6b59), build-verified and audit-verified only. Set aside
+  on 2026-07-27: the plan below starts from `main` and does not use
+  that branch. The proper form of the same fix is a future base bump,
+  taken when the fork rolls the work into a `d2d1-dcomp-11.13`
+  refresh.
+
+## Upstream research (2026-07-27)
+
+giang17/wine, the base fork:
+
+- Every WebView2 cross-process compositing fix (2026-07-23 through
+  07-25) lives only on the `d2d1-dcomp-11.0` branch (head `324a7babe0`).
+  The `d2d1-dcomp-11.13` branch this project's base comes from was
+  snapshotted 2026-07-22, one day earlier, and contains none of it
+  (verified at file level in `dlls/dcomp/device.c`).
+- The fork documented and fixed three fight mechanisms that match this
+  artifact: a keep-alive timer reblit overwriting the host's painting
+  (`324a7babe010`, adds an unchanged-content hash gate,
+  `WINE_DCOMP_SKIP_UNCHANGED` and `WINE_DCOMP_HOST_RESTORE` opt-outs), a
+  ping-pong between root-swapchain presents and tree composites
+  described as visible flicker (`92847a5169be`, later simplified by
+  `5a3091953446`), and a comp child window z-fight producing a grey box
+  over the UI (`396042c48bb4`, the closest literal match to the cutout).
+  Patch 0041's reblit is the primitive analog of the fork's tree timer
+  and predates all three fixes. Patches 0049 through 0051 backport this
+  work onto the 11.13 base.
+- Fork issue 8 is the open risk: WebView2 149/150 promotes page content
+  into delegated compositing after 2 to 3 frames. The root swapchain
+  then carries only opaque punch frames; real content must travel as
+  IDCompositionTexture gated on D3D11 monitored fences. A reporter
+  running the fork's full fix series on 2026-07-25 still saw a grey
+  placeholder on runtimes 149.0.4022.98 and 150.0.4078.83, while runtime
+  109 rendered correctly. The production prefix runs 149.0.4022.80. The
+  compositor backport alone may therefore not fix the Learn View here.
+  https://github.com/giang17/wine/issues/8
+
+Wine upstream: no commits to `dlls/dcomp` since 2026-06-15, and nothing
+after wine-11.13 touching cross-process child rendering or DCE visible
+region caching. No help expected from a base bump alone.
+
+WebView2 on real Windows: the same failure class exists there
+(MicrosoftEdge/WebView2Feedback issue 5574, content painted but never
+presented to the host HWND). `--disable-gpu-compositing` via
+`WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` consistently eliminates it by
+bypassing the DirectComposition presentation route. Chromium never
+detects that its dcomp calls succeed without actual composition, so it
+never falls back on its own.
+
+## Fix plan
+
+Rewritten 2026-07-27. Supersedes the first plan of the same date, which
+built on the set-aside compositor backport branch. This plan starts
+from `main` (11.13 base, patches 0001 through 0048).
+
+Step 1, build the control and baseline it. `main` has never been
+built; the 11.13 bump exists only as patch metadata. Container build of
+`main` as-is, no new WebView2 patches, audit passing, installed to a
+test location only. Then two baselines with the same instruments:
+
+- Production 11.11 runtime, production launcher, production prefix:
+  xdmg damage signature over 30 seconds on the open Learn View
+  (expected: pane-rect stamps at about 5 Hz), frame captures hashed to
+  prove alternating content, dcompspy and hwndspy output, WebView2
+  version recorded.
+- The new 11.13 build on a reflink copy of the prefix, same scale,
+  same WebView2 149, same captures.
+
+Expected: the base bump alone does not move the artifact, since the
+two-writer race is in patch 0041, which is unchanged. The 11.13
+baseline is the control every later change is measured against, and
+the build is the base every later change ships on.
+
+Step 2, no-build experiments, in parallel on reflink copies:
+
+1. WebView2 version pin. Install a pre-149 fixed-version WebView2
+   runtime into a copy prefix and point Live at it with
+   `WEBVIEW2_BROWSER_EXECUTABLE_FOLDER`. If the flicker collapses to
+   the pre-149 behavior (fossil for a few seconds, then heals) or
+   better, the 2026-07-24 Evergreen update is confirmed as the
+   trigger and the pin is a shippable stopgap. Tradeoff to decide
+   before shipping: a pin freezes an old Chromium, which matters if
+   Learn View content ever loads remote pages.
+2. Browser-argument retest under 149. The recorded flag results
+   predate the 149 update, so their verdict is stale. One systematic
+   pass through `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` targeting
+   delegated compositing: `--disable-features=RemoveRedirectionBitmap`,
+   the delegated compositing feature disable, and
+   `--disable-gpu-compositing`. Low expectation (Live's browser
+   process sets its own flags), cheap to run, honest to retest.
+
+Step 3, close-path fixes rebased onto `main`, smallest first. Port the
+win32u dce.c cross-process visible-region fix from
+`fixes/issue-57-crossproc-visrgn` (xdmg-verified on 11.11; the code is
+identical on 11.13) and decide the 0044 parked-pane gate draft. Add
+build-audit fingerprint entries, renumber as needed. This closes
+issue 57 on the new base regardless of the open-pane outcome.
+
+Step 4, decision gate for the open-pane race, driven by Step 2
+measurements:
+
+- If the pin or the flags produce xdmg-zero and frame-stable captures
+  at the production scale: ship that, with the Evergreen guardrail
+  below. The compositing-model fix then arrives later as a clean base
+  bump when the fork rolls its 2026-07-23 through 07-25 WebView2 work
+  into a `d2d1-dcomp-11.13` refresh; asking the fork author for that
+  refresh is worth doing now, since it matches their stated branch
+  policy.
+- If neither works: stop and present the evidence before touching the
+  compositing layer. No local compositing work starts without an
+  explicit decision on it.
+
+Step 5, production verification. Install the chosen build to the
+production runtime directory with a rollback snapshot. Run the full
+regression protocol at the production scale: Learn View and
+documentation sidebar open, scroll, hover, close, reopen; both panes
+at once; Splice editor close (issue 52 regression check); resize
+stress; JUCE and SWAM regression checks. The evidence pack (xdmg logs,
+frame hashes, screenshots, WebView2 version) lands in the repository.
+The user confirms by eye last.
+
+Step 6, guardrails. The launcher records the prefix's WebView2 version
+at every start and warns when Evergreen changes it. Decide whether to
+pin WebView2 or let it float. Update issue 57 and open a public issue
+for the open-pane artifact with accurate status.
+
+## Verification standard
+
+The word fixed requires all of the following, with evidence files
+attached to the claim:
+
+- the change installed in the runtime the production launcher uses,
+- xdmg reports zero anomalous pane-rect damage stamps, open and closed,
+- frame captures hash-stable over the observation window,
+- on the production prefix, production launcher, production scale,
+- the prefix's WebView2 version recorded at test time.
+
+Anything less is reported as exactly what it is: patch written, patch
+built, verification pending, or verification failed. Interim reports
+name the exact paths exercised.
+
+## References
+
+- `notes/ABLETON-WINE-LEARNVIEW-FLICKER.md` (0041 mechanism and cause)
+- `notes/ABLETON-WINE-WEBVIEW2-COMPOSITOR.md` (backport and protocol,
+  in the `fix/d2d1-dcomp-giang17-webview2-compositor` worktree)
+- Issue 57 (close-path flicker, still open, accurate)
+- https://github.com/giang17/wine/issues/8
+- https://github.com/MicrosoftEdge/WebView2Feedback/issues/5574

--- a/notes/ABLETON-WINE-GPU-RENDERER-WEBVIEW2-DIAGNOSIS.md
+++ b/notes/ABLETON-WINE-GPU-RENDERER-WEBVIEW2-DIAGNOSIS.md
@@ -17,7 +17,7 @@ bystanders: Live hardcodes `--disable-gpu --disable-gpu-compositing
 `/proc/<pid>/cmdline`. The maintainer confirmed the result in use, with
 idle CPU at 1-2%. Shipped on branch `fix/interface-drawing-on-gpu`
 together with Wine patch 0053 for the below-minimum resize fight the
-GPU renderer exposed. See `notes/ABLETON-WINE-GPU-RENDERER.md`.
+GPU renderer exposed. See `ABLETON-WINE-GPU-RENDERER.md` (this directory).
 
 The diagnosis and plan below are preserved as written; steps 1 and 2 of
 the plan were executed and produced the finding above. The remaining
@@ -46,8 +46,8 @@ re-render so both writers hold identical content. On the production
 setup (2x scale, WebView2 149) the frames never converge, so the mask
 fails and the race stays visible.
 
-`notes/ABLETON-WINE-LEARNVIEW-FLICKER.md` records the mechanism.
-`notes/ABLETON-WINE-WEBVIEW2-COMPOSITOR.md` states the conclusion: no
+`ABLETON-WINE-LEARNVIEW-FLICKER.md` records the mechanism.
+`ABLETON-WINE-WEBVIEW2-COMPOSITOR.md` states the conclusion: no
 timer or gate tuning escapes a two-writer conflict on one window.
 
 ## History of prior claims
@@ -205,8 +205,8 @@ name the exact paths exercised.
 
 ## References
 
-- `notes/ABLETON-WINE-LEARNVIEW-FLICKER.md` (0041 mechanism and cause)
-- `notes/ABLETON-WINE-WEBVIEW2-COMPOSITOR.md` (backport and protocol,
+- `ABLETON-WINE-LEARNVIEW-FLICKER.md` (0041 mechanism and cause)
+- `ABLETON-WINE-WEBVIEW2-COMPOSITOR.md` (backport and protocol,
   in the `fix/d2d1-dcomp-giang17-webview2-compositor` worktree)
 - Issue 57 (close-path flicker, still open, accurate)
 - https://github.com/giang17/wine/issues/8

--- a/notes/ABLETON-WINE-GPU-RENDERER.md
+++ b/notes/ABLETON-WINE-GPU-RENDERER.md
@@ -61,6 +61,7 @@ panes across scale factors other than 200%.
 
 ## Related
 
+- [Diagnosis narrative](ABLETON-WINE-GPU-RENDERER-WEBVIEW2-DIAGNOSIS.md)
 - [Learn View flicker mechanism](ABLETON-WINE-LEARNVIEW-FLICKER.md)
 - [Patch 0053](../patches/0053-winex11-export-the-app-minimum-tracking-size-as-PMin.patch)
 - Resize trace from the diagnosis session:

--- a/notes/ABLETON-WINE-GPU-RENDERER.md
+++ b/notes/ABLETON-WINE-GPU-RENDERER.md
@@ -1,0 +1,68 @@
+# Live's GPU renderer: enablement and effects
+
+This note explains why the stack now runs Live's own GPU renderer, what
+that fixes, and how to verify it. Change date: 2026-07-27.
+
+## The change
+
+Remove the line `-_ForceGdiBackend` from every
+`drive_c/users/*/AppData/Roaming/Ableton/Live*/Preferences/Options.txt`
+in the prefix. `scripts/setup-prefix.sh` step 5c does this
+automatically. Live then uses its Direct2D/Direct3D 11 renderer instead
+of the GDI fallback.
+
+Wine patch 0053 accompanies the change: winex11 exports the app's
+`WM_GETMINMAXINFO` minimum tracking size as the X11 `PMinSize` hint, so
+the window manager clamps interactive resizes at Live's minimum.
+
+## What it fixes
+
+- The WebView2 pane flicker (Learn View, Splice view): with the GDI
+  renderer, Wine's DirectComposition keep-alive reblit (patch 0041) and
+  Chromium's stale software frame alternated in the pane at 5 Hz. With
+  the GPU renderer both painters hold identical content and the pane is
+  stable. Measured 2026-07-27 with xdmg and frame hashing: the 5 Hz
+  damage stamps still fire but 30 of 30 pane captures hash identical,
+  on both the wine-11.11 production runtime and the wine-11.13 build of
+  main.
+- Idle CPU drops to 1-2% (reported by the maintainer on the production
+  setup). The GDI renderer measured about 59% of one core mid-session.
+- Below-minimum interactive resize (patch 0053): without the PMinSize
+  hint, shrinking a window below Live's minimum (1610x1346 physical at
+  200% scale) made Live counter the grant mid-drag; the window grew at
+  the opposite edge and the configure storm could end in a spurious
+  maximize. With the hint the window manager stops the drag at the
+  minimum.
+
+## Why -_ForceGdiBackend existed
+
+Early setups (before the giang17 d2d1-dcomp base fork and before the
+file-dialog portal, patch 0031) hit blank file dialogs when Live's GPU
+renderer was on, and the flag was carried into the prefix as a
+requirement. Both reasons are gone: the base fork exists to make
+Direct2D rendering work, and file dialogs go through the XDG portal.
+The old machine-local docs that mark the flag as required are
+superseded by this note.
+
+## Verification
+
+1. `grep -r ForceGdiBackend "$WINEPREFIX"/drive_c/users/*/AppData/Roaming/Ableton/*/Preferences/Options.txt`
+   returns nothing.
+2. Open the Learn View and the Splice view. Both render their content
+   and stay stable.
+3. `xprop -id <live-x-window> WM_NORMAL_HINTS` shows
+   `program specified minimum size`.
+4. Drag a window edge below Live's minimum. The drag stops at the
+   minimum and the window does not fight the drag.
+
+Checks that still need a pass after longer real-world use: file dialogs
+under sustained work, plugin editor open/close (JUCE, SWAM), and both
+panes across scale factors other than 200%.
+
+## Related
+
+- [Learn View flicker mechanism](ABLETON-WINE-LEARNVIEW-FLICKER.md)
+- [Patch 0053](../patches/0053-winex11-export-the-app-minimum-tracking-size-as-PMin.patch)
+- Resize trace from the diagnosis session:
+  `~/Projects/Code/ableton/live-resize-trace-gpu-20260727.log`
+  (machine-local)

--- a/notes/ABLETON-WINE-LEARNVIEW-FLICKER.md
+++ b/notes/ABLETON-WINE-LEARNVIEW-FLICKER.md
@@ -1,5 +1,10 @@
 # Learn View stale rendering and automatic refresh
 
+Superseded 2026-07-27: enabling Live's GPU renderer removes the visible
+pane flicker described here. The mechanism analysis below remains
+accurate for the GDI renderer. See
+[the GPU renderer note](ABLETON-WINE-GPU-RENDERER.md).
+
 [`Patch 0041`](../patches/0041-dxgi-make-dcomp-presents-visible-on-webview2-s-unat.patch)
 makes WebView2 frames visible and keeps the latest frame on screen.
 `learnheal.exe`, added in release 2026.07.21.2, refreshes each settled Learn

--- a/patches/0053-winex11-export-the-app-minimum-tracking-size-as-PMin.patch
+++ b/patches/0053-winex11-export-the-app-minimum-tracking-size-as-PMin.patch
@@ -1,0 +1,63 @@
+Subject: winex11: export the app minimum tracking size as PMinSize
+ hints
+
+USER on Windows clamps an interactive resize at the size a window
+returns through WM_GETMINMAXINFO, so a drag stops at the app minimum.
+winex11 exported no PMinSize hint for resizable windows, so the window
+manager granted below-minimum sizes during a grab, the app countered
+with its minimum mid-drag, and the window manager re-applied each
+counter anchored at the grabbed edge. On Live 12 with the GPU renderer
+this produced a visible fight below the 1610x1346 minimum: the window
+grew away from the drag, and the configure storm could race the
+_NET_WM_STATE rewrite into a spurious maximize (trace
+live-resize-trace-gpu-20260727.log, t=36821.7). Patch 0042's
+config-rounding alias absorbs the app's one-pixel band counters by
+design and cannot absorb below-minimum clamps.
+
+set_size_hints now sends WM_GETMINMAXINFO to resizable managed windows
+and exports ptMinTrackSize as PMinSize. The window manager then clamps
+the grab at the app minimum and the below-minimum regime is
+unreachable. A zeroed MINMAXINFO is passed; an app that does not
+handle the message leaves it untouched and no PMinSize is exported,
+which preserves the previous behaviour for such windows. set_size_hints
+runs at window creation and on every configure sync, so a minimum that
+changes with the app layout is re-exported, and the pending-state
+deduplication in window_set_wm_normal_hints keeps identical hints from
+being resent.
+
+Verified on Live 12.4.5b7, GNOME/Xwayland at 200% scale: xprop reports
+"program specified minimum size: 1610 by 1346" on the Live toplevel, a
+below-minimum client resize request comes back clamped to the minimum
+width, and an interactive shrink stops at the minimum without a
+counter storm.
+
+diff --git a/dlls/winex11.drv/window.c b/dlls/winex11.drv/window.c
+index 4ccd2abf..fa7db89a 100644
+--- a/dlls/winex11.drv/window.c
++++ b/dlls/winex11.drv/window.c
+@@ -988,6 +988,25 @@ static void set_size_hints( struct x11drv_win_data *data, DWORD style )
+             size_hints->min_height = size_hints->max_height;
+             size_hints->flags |= PMinSize | PMaxSize;
+         }
++        else if (data->managed)
++        {
++            /* Resizable windows: export the app's WM_GETMINMAXINFO tracking
++             * minimum so the window manager clamps interactive resizes at it,
++             * as USER does on Windows.  Without this the WM grants below-min
++             * sizes during a grab, the app counters with its minimum mid-drag,
++             * and the two fight (Live's below-min resize storm).  A zeroed
++             * MINMAXINFO is passed; apps that don't handle the message leave
++             * it untouched and no PMinSize is exported. */
++            MINMAXINFO mmi;
++            memset( &mmi, 0, sizeof(mmi) );
++            send_message( data->hwnd, WM_GETMINMAXINFO, 0, (LPARAM)&mmi );
++            if (mmi.ptMinTrackSize.x > 0 && mmi.ptMinTrackSize.y > 0)
++            {
++                size_hints->min_width = mmi.ptMinTrackSize.x;
++                size_hints->min_height = mmi.ptMinTrackSize.y;
++                size_hints->flags |= PMinSize;
++            }
++        }
+     }
+ 
+     window_set_wm_normal_hints( data, size_hints );

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -11,7 +11,7 @@ narrative — 5 merge conflicts, three build breaks the clean rebase didn't
 catch, a build.sh/pipefail tooling gotcha — is in
 `notes/ABLETON-WINE-11.11-TO-11.13-BASE-BUMP.md`.
 
-The current Wine series contains 50 files, numbered 0001 through 0052.
+The current Wine series contains 51 files, numbered 0001 through 0053.
 Patches 0027 and 0044 are intentionally absent.
 
 ## Applying the series
@@ -146,3 +146,11 @@ Apply them in sequence with the rest of the series.
   `DT_NOPREFIX` (not equivalent: that shows a literal `&` instead of
   just hiding the underline) - fixed by gating the underscore draw on
   `DT_HIDEPREFIX` too.
+- `0053`: export the app's `WM_GETMINMAXINFO` tracking minimum as the
+  X11 `PMinSize` size hint for resizable managed windows. The window
+  manager then clamps interactive resizes at the app minimum, as USER
+  does on Windows. Without the hint, a grab below Live's minimum made
+  Live counter mid-drag and the window fought the drag (growth at the
+  opposite edge, occasional spurious maximize). Found 2026-07-27 while
+  enabling Live's GPU renderer. See
+  `notes/ABLETON-WINE-GPU-RENDERER.md`.

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -48,5 +48,6 @@ f4d4f0cecbc8a39bbaeb6faaf416d032ee934e7ed8420aa168b39b3c42f9dd58  0049-win32u-dr
 42ef7fda1f410aa351d61637e31452badd60085348ac7dab24e4a846da66135c  0050-win32u-invalidate-the-per-process-sys-color-cache-o.patch
 38eb5e1c43a521eea78308bfe1e2d1d662b287eca888660acc615819aa707d84  0051-win32u-include-the-non-client-area-in-setsyscolors.patch
 f278d870c0424748a9d7a7cd5a6e9feb0837900e6382f4ee9d7cfe214c0b9fd5  0052-win32u-hide-the-menu-bar-alt-key-mnemonic-underline.patch
+d32ac8ca55853e5488292d015e35a31d23744150e04af476742e781b58abc186  0053-winex11-export-the-app-minimum-tracking-size-as-PMin.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -168,6 +168,7 @@ STAMP_ONLY='
 0050|logic-only (per-process sys-color cache reset on WM_SYSCOLORCHANGE; no new string literal)
 0051|logic-only (RDW_FRAME added to the SetSysColors redraw flags; no new string literal)
 0052|logic-only (DT_HIDEPREFIX on the menu bar DrawTextW call; no new string literal)
+0053|logic-only (WM_GETMINMAXINFO minimum exported as PMinSize hints; no new string literal)
 '
 wide_pattern() {  # ascii string -> PCRE matching its UTF-16LE bytes
     printf '%s' "$1" | od -An -v -tx1 | tr -d '\n' | tr -s ' ' ' ' \

--- a/scripts/setup-prefix.sh
+++ b/scripts/setup-prefix.sh
@@ -183,7 +183,7 @@ check_mutter_knob() {  # warn when mutter's xwayland-native-scaling disagrees wi
 # advertised it. The idle CPU cost is back until the Wine-side fix lands; see
 # notes/ABLETON-WINE-APC-COALESCING.md.
 strip_options_txt() {
-    local line="-DontCombineAPCs" prefs f tmp
+    local line="$1" prefs f tmp
     shopt -s nullglob
     for prefs in "$WINEPREFIX"/drive_c/users/*/AppData/Roaming/Ableton/Live*/Preferences; do
         f="$prefs/Options.txt"
@@ -517,7 +517,14 @@ update-desktop-database "${XDG_DATA_HOME:-$HOME/.local/share}/applications" 2>/d
 "$WINESERVER" -w
 
 echo "== [5b/5] remove the 2026.07.18.1 Options.txt seed (issue #29) =="
-strip_options_txt
+strip_options_txt "-DontCombineAPCs"
+
+# -_ForceGdiBackend disables Live's GPU renderer. Early prefixes carried it
+# (inherited from pre-repo setups); with the d2d1 base fork Live's GPU
+# renderer works, removes the WebView2 pane flicker, and drops idle CPU.
+# See notes/ABLETON-WINE-GPU-RENDERER.md.
+echo "== [5c/5] remove -_ForceGdiBackend so Live uses its GPU renderer =="
+strip_options_txt "-_ForceGdiBackend"
 
 echo
 echo "OK: prefix ready at $WINEPREFIX"

--- a/tools/liveinject.c
+++ b/tools/liveinject.c
@@ -14,6 +14,7 @@
  *   newmidi              fg + Ctrl+Shift+T (insert MIDI track)
  *   ctrlf                Ctrl+F (focus browser search)
  *   ctrlaltp             Ctrl+Alt+P (toggle plug-in windows)
+ *   ctrlalt7             Ctrl+Alt+7 (toggle Learn View)
  *   ctrlq                Ctrl+Q (quit)
  *   type <text>          type ascii text (unicode events)
  *   key <enter|down|up|left|right|esc|tab|f1>
@@ -41,6 +42,21 @@ static void send_vk( WORD vk, BOOL up )
     Sleep( 40 );
 }
 static void tap( WORD vk ) { send_vk( vk, FALSE ); send_vk( vk, TRUE ); }
+
+/* Scancode variant: Live's shortcut handling ignores plain-VK synthetic
+ * input for some chords (Ctrl+Alt+7); hardware scancodes get through. */
+static void send_sc( WORD vk, BOOL up )
+{
+    INPUT in;
+    memset( &in, 0, sizeof(in) );
+    in.type = INPUT_KEYBOARD;
+    in.ki.wScan = MapVirtualKeyA( vk, MAPVK_VK_TO_VSC );
+    in.ki.dwFlags = KEYEVENTF_SCANCODE | (up ? KEYEVENTF_KEYUP : 0);
+    SendInput( 1, &in, sizeof(in) );
+    Sleep( 40 );
+}
+
+static void tap_sc( WORD vk ) { send_sc( vk, FALSE ); send_sc( vk, TRUE ); }
 
 static void type_text( const char *s )
 {
@@ -182,6 +198,14 @@ void mainCRTStartup( void )
         tap( 'P' );
         send_vk( VK_MENU, TRUE );
         send_vk( VK_CONTROL, TRUE );
+    }
+    else if (!lstrcmpA( a1, "ctrlalt7" ))
+    {
+        send_sc( VK_CONTROL, FALSE );
+        send_sc( VK_MENU, FALSE );
+        tap_sc( '7' );
+        send_sc( VK_MENU, TRUE );
+        send_sc( VK_CONTROL, TRUE );
     }
     else if (!lstrcmpA( a1, "clearmods" ))
     {   /* release possibly-stuck modifiers */


### PR DESCRIPTION
So after a maddening few days struggling with WebView2 artifacting and flickering, I'm pleased to share that the fix was very simple.

Early in the development of this project, I wrote off GPU support entirely for simplicity's sake. I was solving for larger issues with Live that (until now! :fire:) were almost universal experiences when trying to get Live 12 running via Wine: the UI click targets not lining up with the UI itself, Live crashing or suffering violent, seizure-inducing full screen flickering on the main window and/or modals, inability to resize at all, massive misalignment on DEs with fractional scaling, etc.

But not all of these were caused by the GPU, and regardless of whether the larger issues were caused by the GPU or not, all of these problems were fixed before I published the project. It now turns out that we are good to go with GPU support, and as such the fix for the flicker and much (not all) of the UI instability around the Splice and Learn views is resolved entirely by removing `-_ForceGdiBackend` from `Options.txt`, allowing Live to switch to its Direct2D/D3D11 renderer.

On Windows, apps like Live and Chromium (which draws the WebView2 panes) don't put pixels on screen themselves. They hand finished frames to the Windows compositor, DirectComposition, and Windows puts them on screen. Wine has no real version of that compositor. This Wine fork fills the gap on a timer that copies the latest WebView2 frame into the pane window so the content stays visible.

But this hack is a hack that also sucks: Chromium _also_ paints its own software frame into the same window. With Live on the old GDI renderer, the two frames held different pictures, one current and one stale, so the pane switched between them about 5 times a second. That switching is the flicker, and the 5 Hz rate is exactly the copy timer. With Live on its GPU renderer, both painters end up drawing the same picture rather than mangling it. The switching still happens, but you can no longer see it.

One additional side effect that's so awesome to share: Measured with `XDamage` capture and frame hashing on both the 11.11 production runtime and the 11.13 build of main, at 200% scale, on WebView2 `149,` and confirmed in use: **Idle CPU also drops to 1-2%.** So good.

We also update the Prefix setup (step 5c) to remove the old Options.txt line from existing prefixes.

Turning the GPU renderer on exposed one more bug, which this PR also fixes. When you drag-resize a window on Windows, the system asks the app for its minimum size and stops the drag there. Wine never told the Linux window manager what Live's minimum size is, so the window manager happily made the window smaller than Live allows. Live pushed back mid-drag with its minimum size, the window manager applied that push at the edge you were holding, and the window grew away from your drag, sometimes ending with the window suddenly maximizing itself. Patch `0053` makes Wine pass the app's minimum size to the window manager as the standard X11 `PMinSize` hint, so the drag now just stops at Live's minimum, the same behaviour as on Windows.

Also adds `liveinject ctrlalt7` (scancode injection), used during diagnosis. 
You can find my full, frantic notes at `notes/WEBVIEW2-DIAGNOSIS.md` and the breakthrough at `notes/ABLETON-WINE-GPU-RENDERER.md`.