### PR TITLE
Patch 0054: Language fallback for non-latin characters

### DIFF
--- a/notes/ABLETON-WINE-MENU-FONT-FALLBACK.md
+++ b/notes/ABLETON-WINE-MENU-FONT-FALLBACK.md
@@ -1,0 +1,164 @@
+# How the menu-bar font fallback works
+
+Issue #35 point 5: non-Latin menu text - a non-Latin locale, a
+translated menu, a non-Latin project or track name - rendered as tofu or
+nothing at all. Colour theming of the same chrome is a separate system,
+documented in `ABLETON-WINE-MENU-COLOR-THEMING.md`.
+
+## Why the substitution broke non-Latin text
+
+`sync_font_substitutes()` / `sync_metric_fonts()` (`scripts/ableton-live`,
+issue #32) symlink Live's own `AbletonSans*.ttf` faces into the prefix's
+Fonts directory and repoint `MS Shell Dlg`/`MS Shell Dlg 2` plus the
+`WindowMetrics` non-client `LOGFONT`s at whichever face is present, so
+the chrome matches Live's UI instead of stock Tahoma.
+
+Both faces are Latin-only - checked against their `cmap` tables: Basic
+Latin, Latin-1, Latin Extended-A/B, a few Greek symbols, and zero glyphs
+in Cyrillic, Arabic, Hebrew, Devanagari, Thai, CJK or Hangul.
+
+The substitution has a second, less obvious effect. Wine's built-in
+CJK-fallback population (`load_system_links`, `dlls/win32u/font.c`) is
+keyed by string-comparing the current `MS Shell Dlg` substitute against a
+fixed list - "Tahoma", "MS UI Gothic", "SimSun", "Gulim". Once the
+substitute is anything else, none of those match and the whole step
+silently does nothing.
+
+## The chain, and its actual consumer
+
+`sync_font_fallback()` registers Wine's general font-linking mechanism,
+`HKLM\Software\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink`,
+which works for any font name, with a six-entry chain:
+
+1. **Tahoma** - Wine's only bundled font with real non-Latin coverage
+   (104 Cyrillic + 162 Arabic glyphs).
+2. **Noto Sans CJK JP**, then **SC**, then **KR** - Live's own cuts from
+   `Resources/Fonts`. The JP cut alone advertises `ja ko zh-cn zh-tw
+   zh-hk`, so it is the one that answers in practice; the regional cuts
+   differ only in which glyph shape wins for shared Han characters.
+3. **Unifont-JP**, then **Unifont Upper** - Live's full-Unicode last
+   resort. Blocky and fixed-width, but never tofu.
+
+Registering that chain alone fixes **nothing**. win32u consults
+`SystemLink` only when selecting a whole font by charset
+(`can_select_face`, driven by the system ANSI codepage), never when
+rendering a glyph. `patches/0054-*.patch` adds the missing per-string
+consumer: `draw_menu_item` tests coverage with `NtGdiGetGlyphIndicesW`
+and, on a miss, walks the registered families for the first that covers
+the string. `calc_menu_item_size` measures with that same font, having
+previously sized `item->rect` with the original and clipped the wider
+fallback render ("オプション" truncating to "プショ").
+
+## The name a chain entry must use
+
+`load_system_links` resolves each entry with `find_face_from_filename`,
+which matches the **file basename and the family name together**, and
+the family win32u indexes a font under is `name` table **ID 1**. Get it
+wrong and the entry is dropped at load with a single `Unable to find
+file` trace line - no error, nothing visible except CJK text quietly
+rendering in whatever later entry does resolve.
+
+`fc-scan -f '%{family}'` reports the **ID 16** typographic name first,
+and Live's `NotoSansCJKjp-Regular.otf` carries `"Noto Sans CJK JP
+Regular"` in ID 1 with only the bare `"Noto Sans CJK JP"` in ID 16. So
+the entry named no family win32u knew, was dropped, and Japanese fell
+through Tahoma to Unifont - rendering, but blocky. `%{fullname}` tracks
+ID 1 for every font in this chain and is what the launcher uses.
+
+Proven causally in a prefix built with no host fonts at all, one
+variable changed:
+
+| registered family | result |
+|---|---|
+| `Noto Sans CJK JP` (ID 16) | `Unable to find file` |
+| `Noto Sans CJK JP Regular` (ID 1) | `Adding file C:\windows\fonts\NotoSansCJKjp-Regular.otf` |
+
+Two entries still fail where a host `fonts-noto-cjk` install displaces
+Live's `sc`/`kr` cuts in the font index (`insert_face_in_family_list
+Replacing original ... with Z:\usr\share\fonts\...`), so their basename
+no longer matches. Harmless - `jp` answers first.
+
+## Why the fonts come from Live, not a vendored copy
+
+Live ships Noto Sans CJK because its own UI is localized into Japanese
+and Chinese, so the files are present whenever Live is, and
+`sync_ui_font`'s auto path already returns early unless
+`Resources/Fonts` exists. Both weights are linked, so bold menu items
+get a real bold face. Reading known files directly with `fc-scan` -
+never asking the host's fontconfig for a *match* - is what makes the
+chain identical on every distro.
+
+An earlier revision vendored Noto Sans CJK v2.004 into the runtime
+(sha256-pinned `.ttc` files under `vendor/noto-cjk/`). Dropped: ~24 MB
+compressed on every release, a 40% larger runtime tarball, to replace a
+font already on disk. Live's is v1.004 against that v2.004 and the two
+differ by under 1% of pixels on the same string. Determinism was the
+argument, but Live's copy is pinned to the Live version and is not
+host-dependent either.
+
+## Known limitation: whole-string swap, not per-character
+
+Mixed-script text (an English label concatenated with a non-Latin track
+name) renders *entirely* in the fallback face. Real per-glyph fallback
+is a Uniscribe/DirectWrite-level feature that plain `DrawTextW` - what
+`draw_menu_item` calls - has never had.
+
+Tested 2026-07-28 before deciding whether to build the per-run version:
+`"Live マニュアルを表示..."` as one whole-string swap versus split into a
+Latin run and a CJK run, both measured against the real
+`NONCLIENTMETRICS` menu `LOGFONT`, produced visually indistinguishable
+output. Not worth a `menu.c` change on that evidence.
+
+## The chain was silently truncated at four entries
+
+`get_fallback_font_for_text` sized its candidate array `WCHAR names[4]`,
+so only the first four entries were ever tried, with no diagnostic. The
+chain is six, putting both Unifont entries out of reach - had the CJK
+candidates failed the result would have been tofu, not a Unifont
+fallback. Raised to 16, which covers any chain the launcher builds and
+leaves room for Wine's own longer built-in ones (stock `Lucida Sans
+Unicode` is nine).
+
+Verified end to end: with host CJK hidden, no Noto in the prefix, and a
+chain crafted so the only covering font sat at position five
+(`Tahoma, Arial, Courier New, Times New Roman, Unifont-JP`), Japanese
+rendered. Unreachable under the old cap.
+
+## Testing gotcha: Wine sees the host's fonts
+
+Wine exposes the **host's** installed fonts to the prefix via
+fontconfig, not just `drive_c/windows/Fonts`. Any A/B test of prefix
+fonts on a host carrying a same-named font silently renders the host
+copy in both arms. Three separate comparisons were lost to this.
+
+`FONTCONFIG_FILE` alone is **not** enough. Wine persists what it found
+into the prefix registry - `"Noto Sans CJK JP (TrueType)"="Z:\usr\share\
+fonts\opentype\noto\NotoSansCJK-Regular.ttc"` under
+`HKLM\Software\Microsoft\Windows NT\CurrentVersion\Fonts`, 936 such
+entries in one real prefix - and reads them back by path regardless of
+what fontconfig now reports. A prefix that has ever seen the host's
+fonts stays contaminated.
+
+To test in isolation, build a **fresh** prefix with `FONTCONFIG_FILE`
+already pointing at a config with no font directories, then confirm
+`grep -c 'usr.*share.*fonts' system.reg` is 0. `load_system_links` runs
+in any Wine process, so `wine notepad` is enough to trace a chain - no
+need to start Live.
+
+## File map
+
+| file | role |
+|---|---|
+| `scripts/ableton-live` | `sync_ui_font` links Live's faces into the prefix; `sync_font_fallback` registers the `SystemLink` chain |
+| `patches/0054-*.patch` | the per-string fallback consumer in `draw_menu_item`, `calc_menu_item_size` measuring with it, and the 16-entry candidate cap |
+
+## Debugging notes for whoever touches this next
+
+- `WINEDEBUG=+font` and grep `load_system_links`: each entry logs either
+  `Adding file` or `Unable to find file`. That line is the fastest way
+  to tell a naming problem from a rendering one.
+- `insert_face_in_family_list` shows which family each file is indexed
+  under - the authoritative answer for what a chain entry must name.
+- A chain entry that fails is silent in normal use. If non-Latin text
+  looks blocky rather than absent, it resolved to Unifont, which means
+  an earlier entry was dropped.

--- a/patches/0054-win32u-fall-back-to-a-linked-font-for-missing-glyph.patch
+++ b/patches/0054-win32u-fall-back-to-a-linked-font-for-missing-glyph.patch
@@ -1,0 +1,323 @@
+Subject: win32u: fall back to a linked font when the menu font is
+ missing a glyph
+
+The launcher substitutes Wine's stock win32 chrome font (menu bar, dropdowns,
+dialogs) with Ableton's own UI face (Ableton Sans/Ableton Sans Small), which
+covers Latin script only - checked directly via its cmap tables, zero glyphs
+anywhere in Cyrillic, Arabic, Hebrew, Devanagari, Thai, CJK, or Hangul. Any
+menu text needing a glyph outside that (a non-Latin locale, a Japanese
+project/track name, ...) was simply missing entirely: tofu boxes, or nothing
+at all.
+
+Wine's own font-linking (HKLM\...\FontLink\SystemLink, correctly populated
+by load_system_links - confirmed by trace) turns out to only ever be
+consulted during whole-font *selection* by system charset
+(can_select_face), never during glyph *rendering* - so registering a
+fallback family there fixes nothing on its own; the raw glyph lookup
+(freetype_get_glyph_index) only ever checks the one font actually selected,
+with no awareness of any linked fallback at all. This is the missing
+per-string consumer: if the currently selected font can't draw the item's
+text, walk its registered SystemLink fallback families (get_font_link_families,
+font.c - new, since find_gdi_font_link and the data it tracks were
+otherwise only reachable from within font.c) and temporarily select the
+first candidate that actually covers the text, sized and weighted to
+match, for the DrawTextW calls that follow.
+
+Measuring, not just drawing, needs to agree on which font is in play too:
+calc_menu_item_size sizes item->rect by measuring item->text with whatever
+font is already selected in hdc - the original (missing-glyph) font, not
+the fallback font just described. A fallback font's real glyphs are
+typically wider than the original font's notdef/tofu metrics, so
+item->rect ended up sized for the wrong font, and the DrawTextW call above
+then clipped the wider real render to fit - CJK menu items losing their
+first and last characters (menu bar, centered) or losing text off the
+right edge (popup items, left-aligned). Fixed by forward-declaring
+get_fallback_font_for_text and calling it in calc_menu_item_size the same
+way, before measuring instead of before drawing; both call sites already
+select the same plain (non-bold) menu font into hdc before their
+respective loops, so the two selections stay in lockstep.
+
+Whole-string swap, not per-character: text mixing scripts renders entirely
+in the fallback font rather than mixing faces mid-string. Real per-glyph
+fallback is a Uniscribe/DirectWrite-level feature that plain DrawTextW
+(what this file actually calls) has never had; implementing that properly
+is a much larger undertaking than this - this trades a rarer, minor
+font-consistency slip for the text actually rendering at all.
+
+Three bugs found and fixed along the way:
+- NtGdiExtGetObjectW returns the *resolved face's* full name (e.g.
+  "Ableton Sans Small Regular"), not the family name the SystemLink chain
+  is registered under ("Ableton Sans Small") - strip the known style
+  suffix and retry. Confirmed by tracing real Japanese menu text.
+- The item text passed in includes its raw '\t'-separated shortcut column
+  (see draw_menu_item); no font has an actual renderable glyph for a
+  literal tab, so it was being flagged as "missing" in every candidate
+  font tried, failing entries that were otherwise fully covered. Control
+  characters are no longer treated as glyphs needing coverage. Confirmed
+  by tracing real Japanese menu text.
+- font_missing_glyphs works per UTF-16 code unit, and a lone surrogate
+  half (0xD800-0xDFFF) is never in any font's cmap - not because the
+  glyph is missing, but because a surrogate half isn't a real character
+  on its own. Without a skip for it, any menu item holding a character
+  outside the BMP (an emoji in a Set name, say) reported "missing"
+  against the item's own font and every fallback candidate, always - a
+  guaranteed-to-fail check re-run on every single paint, in both
+  calc_menu_item_size and draw_menu_item. Surrogates get the same skip
+  control characters already get; whole-string fallback can't fix a lone
+  surrogate regardless of which font is picked, so there is nothing to
+  gain by still running the check for one.
+
+Verified live end to end: Japanese menu bar and dropdown text, including a
+previously-truncated settings label, renders in full.
+---
+ dlls/win32u/font.c           |  27 ++++++
+ dlls/win32u/menu.c           | 179 +++++++++++++++++++++++++++++++++++++++-
+ dlls/win32u/win32u_private.h |   1 +
+ 3 files changed, 205 insertions(+), 2 deletions(-)
+diff --git a/dlls/win32u/font.c b/dlls/win32u/font.c
+index dcc75e8..f1bebe6 100644
+--- a/dlls/win32u/font.c
++++ b/dlls/win32u/font.c
+@@ -1460,6 +1460,30 @@ static struct gdi_font_link *find_gdi_font_link( const WCHAR *name )
+     return NULL;
+ }
+ 
++/* Copies up to max SystemLink fallback family names registered for name into
++ * out, returns how many were copied. Plain accessor exposing what
++ * find_gdi_font_link tracks; callers do their own coverage testing and font
++ * creation through the public syscalls. */
++UINT get_font_link_families( const WCHAR *name, WCHAR out[][LF_FACESIZE], UINT max )
++{
++    struct gdi_font_link *font_link;
++    struct gdi_font_link_entry *entry;
++    UINT n = 0;
++
++    pthread_mutex_lock( &font_lock );
++    if ((font_link = find_gdi_font_link( name )))
++    {
++        LIST_FOR_EACH_ENTRY( entry, &font_link->links, struct gdi_font_link_entry, entry )
++        {
++            if (n >= max) break;
++            lstrcpynW( out[n], entry->family_name, LF_FACESIZE );
++            n++;
++        }
++    }
++    pthread_mutex_unlock( &font_lock );
++    return n;
++}
++
+ static struct gdi_font_family *find_family_from_font_links( const WCHAR *name, const WCHAR *subst,
+                                                             FONTSIGNATURE fs )
+ {
+diff --git a/dlls/win32u/menu.c b/dlls/win32u/menu.c
+index 1ff3403..a054d46 100644
+--- a/dlls/win32u/menu.c
++++ b/dlls/win32u/menu.c
+@@ -2006,6 +2006,11 @@ static void get_bitmap_item_size( struct menu_item *item, SIZE *size, HWND owner
+     }
+ }
+ 
++/* Defined below, needed here too: calc_menu_item_size must measure text with
++ * the same font draw_menu_item will actually render it in (see the call site
++ * further down for why). */
++static HFONT get_fallback_font_for_text( HDC hdc, const WCHAR *text, INT count );
++
+ /* Calculate the size of the menu item and store it in item->rect */
+ static void calc_menu_item_size( HDC hdc, struct menu_item *item, HWND owner, INT org_x, INT org_y,
+                                  BOOL menu_bar, struct menu *menu )
+@@ -2104,12 +2109,18 @@ static void calc_menu_item_size( HDC hdc, struct menu_item *item, HWND owner, IN
+     if (!(item->fType & MF_SYSMENU) && item->text)
+     {
+         LONG txt_height, txt_width;
+-        HFONT prev_font = NULL;
++        HFONT prev_font = NULL, fallback_font, prev_fallback_font = NULL;
+         RECT rc = item->rect;
+ 
+         if (item->fState & MFS_DEFAULT)
+              prev_font = NtGdiSelectFont( hdc, get_menu_font(TRUE) );
+ 
++        /* Measure with the font draw_menu_item will actually use: a fallback
++         * run is wider than the original's missing-glyph metrics, so sizing
++         * item->rect with the original clips the later render (issue #35). */
++        if ((fallback_font = get_fallback_font_for_text( hdc, item->text, -1 )))
++            prev_fallback_font = NtGdiSelectFont( hdc, fallback_font );
++
+         if (menu_bar)
+         {
+             txt_height = DrawTextW( hdc, item->text, -1, &rc, DT_SINGLELINE | DT_CALCRECT );
+@@ -2158,6 +2169,11 @@ static void calc_menu_item_size( HDC hdc, struct menu_item *item, HWND owner, IN
+             item->rect.right += 2 + txt_width;
+             item_height = max( item_height, max( txt_height + 2, menucharsize.cy + 4 ));
+         }
++        if (fallback_font)
++        {
++            NtGdiSelectFont( hdc, prev_fallback_font );
++            NtGdiDeleteObjectApp( fallback_font );
++        }
+         if (prev_font) NtGdiSelectFont( hdc, prev_font );
+     }
+     else if (menu_bar)
+@@ -2403,6 +2419,117 @@ got_bitmap:
+     NtGdiDeleteObjectApp( mem_hdc );
+ }
+ 
++/* TRUE if the font currently selected in hdc is missing a glyph anywhere in
++ * text. NtGdiGetGlyphIndicesW tests only the selected font, with no
++ * SystemLink awareness - exactly the per-font coverage test wanted here.
++ *
++ * Two kinds of code unit are skipped. Control characters, because item->text
++ * carries its '\t'-separated shortcut column and no font has a glyph for a
++ * tab. And UTF-16 surrogate halves, which are in no font's cmap because half
++ * a pair is not a character - without the skip a Set name holding an emoji
++ * fails every candidate on every paint, for a check that whole-string
++ * fallback could never satisfy anyway. */
++static BOOL font_missing_glyphs( HDC hdc, const WCHAR *text, INT count )
++{
++    WORD stack_buf[64], *buf = stack_buf;
++    BOOL missing = FALSE;
++    INT i;
++
++    if (count > (INT)ARRAY_SIZE(stack_buf) && !(buf = malloc( count * sizeof(*buf) )))
++        return FALSE;   /* can't check: leave the font alone rather than guess */
++
++    if (NtGdiGetGlyphIndicesW( hdc, text, count, buf, GGI_MARK_NONEXISTING_GLYPHS ) != GDI_ERROR)
++    {
++        for (i = 0; i < count; i++)
++        {
++            if (text[i] < ' ') continue;
++            if (text[i] >= 0xd800 && text[i] <= 0xdfff) continue;
++            if (buf[i] == 0xffff) { missing = TRUE; break; }
++        }
++    }
++    if (buf != stack_buf) free( buf );
++    return missing;
++}
++
++/* The launcher substitutes Ableton Sans onto the win32 chrome, and it is
++ * Latin-only, so any other script would render as nothing at all. win32u
++ * populates the SystemLink chain correctly but consults it only when
++ * selecting a whole font by charset, never when rendering a glyph, so the
++ * registered fallback sits unused. This is the missing per-string consumer:
++ * if the current font cannot draw text, try its registered families in turn
++ * (get_font_link_families, font.c) and return a temporary HFONT for the
++ * first that covers it, matching size and weight. Caller restores and
++ * deletes it. Returns 0 when the current font already covers the text.
++ *
++ * Whole-string, not per-glyph: real per-glyph fallback is a Uniscribe-level
++ * feature plain DrawTextW never had. Mixed-script text renders entirely in
++ * the fallback face - a cosmetic slip against rendering nothing. */
++static HFONT get_fallback_font_for_text( HDC hdc, const WCHAR *text, INT count )
++{
++    /* Sized to hold a whole SystemLink chain, not just its first few entries:
++     * get_font_link_families stops at this cap, so anything past it is
++     * silently never tried. A chain that registers per-region CJK faces
++     * ahead of a full-Unicode last resort (see scripts/ableton-live's
++     * sync_font_fallback) already reaches six, which put that last resort
++     * out of reach - the "safety net" this code documents was not actually
++     * wired up on that path. Confirmed by walking a real chain entry by
++     * entry against this same selection logic. */
++    WCHAR names[16][LF_FACESIZE];
++    HFONT cur_font, fallback = 0;
++    LOGFONTW lf;
++    UINT i, n;
++
++    if (count < 0) count = lstrlenW( text );
++    if (!count || !font_missing_glyphs( hdc, text, count )) return 0;
++
++    if (!(cur_font = NtGdiGetDCObject( hdc, NTGDI_OBJ_FONT ))) return 0;
++    if (!NtGdiExtGetObjectW( cur_font, sizeof(lf), &lf )) return 0;
++
++    n = get_font_link_families( lf.lfFaceName, names, ARRAY_SIZE(names) );
++    if (!n)
++    {
++        /* NtGdiExtGetObjectW returns the resolved face's full name ("Ableton
++         * Sans Small Regular"), not the family the chain is registered under.
++         * Strip the style suffix and retry. Char arrays rather than L"...":
++         * the unix .so builds against the host's 32-bit wchar_t, not Wine's
++         * 16-bit WCHAR (same idiom as tahoma_ttfW in font.c). */
++        static const WCHAR bold_italic[] = {' ','B','o','l','d',' ','I','t','a','l','i','c',0};
++        static const WCHAR regular_italic[] = {' ','R','e','g','u','l','a','r',' ','I','t','a','l','i','c',0};
++        static const WCHAR italic[] = {' ','I','t','a','l','i','c',0};
++        static const WCHAR bold[] = {' ','B','o','l','d',0};
++        static const WCHAR regular[] = {' ','R','e','g','u','l','a','r',0};
++        static const WCHAR *const suffixes[] = { bold_italic, regular_italic, italic, bold, regular };
++        WCHAR stripped[LF_FACESIZE];
++        UINT j;
++
++        for (j = 0; j < ARRAY_SIZE(suffixes) && !n; j++)
++        {
++            size_t face_len = lstrlenW( lf.lfFaceName );
++            size_t suf_len = lstrlenW( suffixes[j] );
++            if (face_len <= suf_len) continue;
++            if (wcsnicmp( lf.lfFaceName + face_len - suf_len, suffixes[j], suf_len )) continue;
++            lstrcpynW( stripped, lf.lfFaceName, face_len - suf_len + 1 );
++            n = get_font_link_families( stripped, names, ARRAY_SIZE(names) );
++        }
++    }
++    for (i = 0; i < n; i++)
++    {
++        HFONT candidate, prev;
++        BOOL covers;
++
++        lstrcpynW( lf.lfFaceName, names[i], LF_FACESIZE );
++        if (!(candidate = NtGdiHfontCreate( &lf, sizeof(lf), 0, 0, NULL ))) continue;
++
++        prev = NtGdiSelectFont( hdc, candidate );
++        covers = !font_missing_glyphs( hdc, text, count );
++        NtGdiSelectFont( hdc, prev );
++
++        if (covers) { fallback = candidate; break; }
++        NtGdiDeleteObjectApp( candidate );
++    }
++    return fallback;
++}
++
+ /* Draw a single menu item */
+ static void draw_menu_item( HWND hwnd, struct menu *menu, HWND owner, HDC hdc,
+                             struct menu_item *item, BOOL menu_bar, UINT odaction )
+@@ -2676,7 +2803,7 @@ static void draw_menu_item( HWND hwnd, struct menu *menu, HWND owner, HDC hdc,
+     if (item->text)
+     {
+         int i;
+-        HFONT prev_font = 0;
++        HFONT prev_font = 0, fallback_font, prev_fallback_font = 0;
+         /* Real Windows hides these mnemonic underlines until Alt is pressed
+          * (the WM_UPDATEUISTATE/UISF_HIDEACCEL "keyboard cues" system) - not
+          * implemented anywhere in this Wine tree (confirmed: no handling of
+@@ -2697,6 +2824,12 @@ static void draw_menu_item( HWND hwnd, struct menu *menu, HWND owner, HDC hdc,
+              prev_font = NtGdiSelectFont(hdc, get_menu_font( TRUE ));
+         }
+ 
++        /* see get_fallback_font_for_text: no-op (0) for the overwhelming
++         * common case of plain Latin text already covered by the current
++         * (possibly just-swapped-to-bold-above) font */
++        if ((fallback_font = get_fallback_font_for_text( hdc, item->text, -1 )))
++            prev_fallback_font = NtGdiSelectFont( hdc, fallback_font );
++
+         if (menu_bar)
+         {
+             if (item->hbmpItem)
+@@ -2746,6 +2879,11 @@ static void draw_menu_item( HWND hwnd, struct menu *menu, HWND owner, HDC hdc,
+             DrawTextW( hdc, item->text + i + 1, -1, &rect, format );
+         }
+ 
++        if (fallback_font)
++        {
++            NtGdiSelectFont( hdc, prev_fallback_font );
++            NtGdiDeleteObjectApp( fallback_font );
++        }
+         if (prev_font) NtGdiSelectFont( hdc, prev_font );
+     }
+ 
+diff --git a/dlls/win32u/win32u_private.h b/dlls/win32u/win32u_private.h
+index 1b8e7fd..15a460a 100644
+--- a/dlls/win32u/win32u_private.h
++++ b/dlls/win32u/win32u_private.h
+@@ -120,6 +120,7 @@ extern NTSTATUS send_hardware_input( HWND hwnd, UINT flags, const INPUT *input,
+ extern UINT draw_nc_menu_bar( HDC hdc, RECT *rect, HWND hwnd );
+ extern void end_menu( HWND hwnd );
+ extern HMENU get_menu( HWND hwnd );
++extern UINT get_font_link_families( const WCHAR *name, WCHAR out[][LF_FACESIZE], UINT max );
+ extern UINT get_menu_bar_height( HWND hwnd, UINT width, INT org_x, INT org_y );
+ extern BOOL get_menu_info( HMENU handle, MENUINFO *info );
+ extern INT get_menu_item_count( HMENU handle );

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -11,8 +11,8 @@ narrative — 5 merge conflicts, three build breaks the clean rebase didn't
 catch, a build.sh/pipefail tooling gotcha — is in
 `notes/ABLETON-WINE-11.11-TO-11.13-BASE-BUMP.md`.
 
-The current Wine series contains 52 files, numbered 0001 through 0055.
-Patches 0027, 0044, and 0054 are intentionally absent.
+The current Wine series contains 54 files, numbered 0001 through 0056.
+Patches 0027 and 0044 are intentionally absent.
 
 ## Applying the series
 
@@ -154,8 +154,16 @@ Apply them in sequence with the rest of the series.
   opposite edge, occasional spurious maximize). Found 2026-07-27 while
   enabling Live's GPU renderer. See
   `notes/ABLETON-WINE-GPU-RENDERER.md`.
-- `0054`: reserved for the language-fallback font work on PR 77. No
-  patch file is shipped.
+- `0054`: fall back to a linked font for a glyph missing from the
+  launcher's Ableton Sans menu-bar substitute (issue 35). Wine consults
+  the `SystemLink` chain only when selecting a whole font by charset,
+  never when rendering a glyph. `draw_menu_item` now tests per-string
+  coverage with `NtGdiGetGlyphIndicesW` and, on a miss, walks the
+  registered families for one that covers the whole string.
+  `calc_menu_item_size` measures with that same font: it had sized
+  `item->rect` with the original, clipping the wider fallback render
+  ("オプション" truncating to "プショ"). See
+  `notes/ABLETON-WINE-MENU-FONT-FALLBACK.md`.
 - `0055`: set `WINED3D_SWAPCHAIN_PREFER_GL_PRESENT` for top-level D3D11
   swapchain windows. Without the flag, wined3d displayed every frame of
   Live's main window through GDI: it copied the finished frame from the

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -49,6 +49,7 @@ f4d4f0cecbc8a39bbaeb6faaf416d032ee934e7ed8420aa168b39b3c42f9dd58  0049-win32u-dr
 38eb5e1c43a521eea78308bfe1e2d1d662b287eca888660acc615819aa707d84  0051-win32u-include-the-non-client-area-in-setsyscolors.patch
 f278d870c0424748a9d7a7cd5a6e9feb0837900e6382f4ee9d7cfe214c0b9fd5  0052-win32u-hide-the-menu-bar-alt-key-mnemonic-underline.patch
 d32ac8ca55853e5488292d015e35a31d23744150e04af476742e781b58abc186  0053-winex11-export-the-app-minimum-tracking-size-as-PMin.patch
+95bb7c7bce42a4d010eb4c0c0232bf65b9165860d3782f4753efb2398d7caaa2  0054-win32u-fall-back-to-a-linked-font-for-missing-glyph.patch
 5c97ce27e69ea1caffef5197a8e0f19893829c1c868e06c89e660352ad2919a1  0055-dxgi-prefer-GL-present-for-top-level-swapchain-devic.patch
 11dbb4c36378fc274e8eaa281e9bfbe43835bd0fae2682924d19aee318b673bb  0056-dxgi-gate-parked-dcomp-reblits-on-window-visibility.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch

--- a/scripts/ableton-live
+++ b/scripts/ableton-live
@@ -588,21 +588,78 @@ sync_font_substitutes() {   # family -> route the shell-dialog faces to it
     done
 }
 
+# Ableton Sans/Ableton Sans Small are Latin-only, so register a SystemLink
+# chain for the substituted family: Tahoma, then the Noto Sans CJK cuts Live
+# bundles in Resources/Fonts, then Unifont as a full-Unicode last resort.
+# Patch 0054's get_fallback_font_for_text walks it; the registry data alone
+# does nothing, since win32u consults SystemLink only when selecting a whole
+# font by charset, never when rendering a glyph.
+#
+# Taken from Live's install, read directly with fc-scan, rather than asking
+# the host's fontconfig for "some" CJK font: Live ships these because its own
+# UI is localized into Japanese and Chinese, so they are present whenever Live
+# is, and the chain is then identical on every distro.
+sync_font_fallback() {   # family -> register its SystemLink chain from what sync_ui_font linked into winfonts
+    local fam="$1" want="tahoma.ttf,Tahoma" cur pat f base fc_fam pair
+    local winfonts="$WINEPREFIX/drive_c/windows/Fonts"
+    local -a pairs=()
+    if command -v fc-scan >/dev/null 2>&1; then
+        for pat in "$winfonts"/NotoSansCJKjp-Regular.otf "$winfonts"/NotoSansCJKsc-Regular.otf \
+                   "$winfonts"/NotoSansCJKkr-Regular.otf "$winfonts"/unifont_jp-*.ttf "$winfonts"/unifont_upper-*.ttf; do
+            for f in $pat; do
+                [ -e "$f" ] || continue
+                base="${f##*/}"
+                # %{fullname}, not %{family}: win32u matches a SystemLink entry
+                # on filename plus the name-ID-1 family, and %{family} reports
+                # ID 16 first. Live's NotoSansCJKjp-Regular.otf is
+                # "Noto Sans CJK JP Regular" in ID 1, so the ID 16 name matched
+                # nothing and the entry was dropped at load with a silent
+                # "Unable to find file", dumping CJK text onto Unifont.
+                fc_fam="$(fc-scan -f '%{fullname}\n' "$f" 2>/dev/null | head -1)"
+                [ -n "$fc_fam" ] && pairs+=("$base,$fc_fam")
+            done
+        done
+    fi
+    for pair in "${pairs[@]}"; do
+        want="${want}\\0${pair}"
+    done
+    cur="$(awk -v n="\"$fam\"=" '
+        /^\[Software\\\\Microsoft\\\\Windows NT\\\\CurrentVersion\\\\FontLink\\\\SystemLink\]/ { f=1; next }
+        /^\[/ { f=0 }
+        f && index($0, n) == 1 {
+            v = substr($0, length(n) + 1)
+            sub(/^str\(7\):"/, "", v); sub(/\\0"\r?$/, "", v)
+            print v; exit
+        }' "$WINEPREFIX/system.reg" 2>/dev/null || true)"
+    [ "$cur" = "$want" ] && return 0
+    echo "ableton-live: linking Tahoma + bundled CJK/Unicode fallback fonts for '$fam'" >&2
+    "$WINE_ROOT/bin/wine" reg add 'HKLM\Software\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink' \
+        /v "$fam" /t REG_MULTI_SZ /d "${want}\0" /f >/dev/null 2>&1 9>&-
+}
+
 sync_ui_font() {
     local mode="${ABLETON_UI_FONT:-auto}" winfonts="$WINEPREFIX/drive_c/windows/Fonts"
     local fonts_dir="" family="" f linked=0
     [ "$mode" = preserve ] && return 0
     [ -d "$winfonts" ] || return 0
     # Links from an install that was since removed or upgraded must not linger.
-    for f in "$winfonts"/AbletonSans*; do
+    for f in "$winfonts"/AbletonSans* "$winfonts"/NotoSansCJK* "$winfonts"/unifont_*; do
         [ -L "$f" ] && [ ! -e "$f" ] && rm -f "$f"
     done
     if [ "$mode" = off ]; then
-        for f in "$winfonts"/AbletonSans*; do
+        for f in "$winfonts"/AbletonSans* "$winfonts"/NotoSansCJK* "$winfonts"/unifont_*; do
             [ -L "$f" ] && rm -f "$f"
         done
         sync_font_substitutes Tahoma
         sync_metric_fonts Tahoma
+        # Tahoma gets its chain from win32u's hardcoded substitute list, so
+        # it needs no entry here. Clear any a previous auto/named run left for
+        # the Ableton families, which are no longer selected anywhere.
+        local fam
+        for fam in "Ableton Sans" "Ableton Sans Small"; do
+            "$WINE_ROOT/bin/wine" reg delete 'HKLM\Software\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink' \
+                /v "$fam" /f >/dev/null 2>&1 9>&- || true
+        done
         return 0
     fi
     [ -n "$live_exe_unix" ] && fonts_dir="${live_exe_unix%/Program/*}/Resources/Fonts"
@@ -624,8 +681,22 @@ sync_ui_font() {
     else
         family="$mode"
     fi
+    # Fallback faces for the chain sync_font_fallback registers below. Linked
+    # for every mode that reaches here, not just auto: a named family is as
+    # Latin-limited as Ableton Sans, so keeping these under auto left
+    # ABLETON_UI_FONT=<name> with a Tahoma-only chain and CJK back to tofu.
+    # Both weights, so bold menu items get a real bold face. The auto path has
+    # already returned by now if nothing was substituted, so this cannot leave
+    # unreferenced symlinks behind.
+    if [ -d "$fonts_dir" ]; then
+        for f in "$fonts_dir"/NotoSansCJK*.otf "$fonts_dir"/unifont_*.ttf; do
+            [ -e "$f" ] || continue
+            ln -sf "$f" "$winfonts/${f##*/}"
+        done
+    fi
     sync_font_substitutes "$family"
     sync_metric_fonts "$family"
+    sync_font_fallback "$family"
 }
 
 # Mirror the host light/dark scheme into the prefix before each launch: Live's "Follow system"

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -71,7 +71,6 @@ extras="$(cd "$root/patches" && ls 00*.patch pipeasio/*.patch 2>/dev/null | grep
 declare -A SERIES_GAPS=(
     [0027]="retired 2026-07-14 — gitignore housekeeping, no artifact effect"
     [0044]="reserved 2026-07-24 for the issue 57 parked-pane reblit gate; shipped as 0056 instead"
-    [0054]="reserved 2026-07-29 for PR 77's language-fallback font patch"
 )
 seq_expect=1
 for f in $(awk '{print $2}' "$SERIES" | grep -v '^pipeasio/' | sort); do
@@ -172,6 +171,7 @@ STAMP_ONLY='
 0052|logic-only (DT_HIDEPREFIX on the menu bar DrawTextW call; no new string literal)
 0056|ascii|lib/wine/x86_64-windows/dxgi.dll|Re-blit skipped (hidden ancestry)
 0053|logic-only (WM_GETMINMAXINFO minimum exported as PMinSize hints; no new string literal)
+0054|logic-only (per-string SystemLink font fallback in draw_menu_item, plus the calc_menu_item_size CJK-measurement fix; no new string literal)
 '
 wide_pattern() {  # ascii string -> PCRE matching its UTF-16LE bytes
     printf '%s' "$1" | od -An -v -tx1 | tr -d '\n' | tr -s ' ' ' ' \


### PR DESCRIPTION
## Summary

Fixes #35 point 5: non-Latin menu text — a non-Latin locale, a translated menu, a non-Latin project or track name — rendered as tofu or nothing at all, because the launcher substitutes Wine's stock chrome font with Ableton's own `Ableton Sans`/`Ableton Sans Small`, which is Latin-only.

## The fix

Wine populates the `SystemLink` fallback chain correctly but consults it only when selecting a whole font by charset, never when rendering a glyph, so a registered fallback family sits unused. `0054` adds the missing per-string consumer in `dlls/win32u/menu.c`: `draw_menu_item` tests coverage with `NtGdiGetGlyphIndicesW` and, on a miss, walks the registered families (`get_font_link_families`, new in `font.c`) for the first that covers the string.

`calc_menu_item_size` now measures with that same font. It had sized `item->rect` with the original, missing-glyph font, so the wider fallback render was clipped — `"オプション"` truncating to `"プショ"`.

Three smaller bugs found while tracing real Japanese text. `NtGdiExtGetObjectW` returns the resolved face's full name rather than the family the chain is registered under, so the style suffix is stripped and the lookup retried. Item text carries its `'\t'`-separated shortcut column and no font has a glyph for a tab, which was failing otherwise-covered entries. Lone UTF-16 surrogate halves are in no font's cmap, so a Set name holding an emoji failed every candidate on every paint.

The candidate array was `WCHAR names[4]`, so only the first four chain entries were ever tried. The chain the launcher builds is six, leaving both Unifont entries — the safety net the code documents — unreachable. Raised to 16.

## Fallback fonts

`sync_font_fallback` originally picked the CJK fallback with `fc-match` against whatever the host had installed, so the result varied per distro. It now reads known files out of Live's `Resources/Fonts` directly with `fc-scan`. Live ships Noto Sans CJK because its own UI is localized into Japanese and Chinese, so the files are there whenever Live is, and `sync_ui_font`'s auto path already returns early unless that directory exists. Both weights are linked, so bold menu items get a real bold face. Nothing is vendored and the release artifact does not grow.

Entries use `%{fullname}`, not `%{family}`. `load_system_links` matches a `SystemLink` entry on filename plus the **name-ID-1** family, and `%{family}` reports the ID 16 typographic name first — Live's `NotoSansCJKjp-Regular.otf` is `"Noto Sans CJK JP Regular"` in ID 1, with the bare `"Noto Sans CJK JP"` only in ID 16. The ID 16 name matched no family win32u knew, so the entry was dropped at load with a silent `Unable to find file` and Japanese fell through Tahoma to Unifont: rendering, but blocky.

## Testing

- [x] Full container build passes, 76/76 audit checks.
- [x] Japanese menu bar and dropdowns render correctly end to end, including the previously-truncated settings label. @amenohi2 tested an earlier revision against a native macOS build and supplied the screenshots that confirmed the layout — thanks.
- [x] Four-entry cap verified rather than assumed: with host CJK hidden via `FONTCONFIG_FILE`, no Noto in the prefix, and a chain crafted so the only covering font sat at position five, Japanese rendered — unreachable under the old cap.
- [x] Name-ID-1 fix proven causally in a prefix built with no host fonts at all, one variable changed: the ID 16 name gives `Unable to find file`, the ID 1 name loads Live's own file. The fresh prefix matters — `FONTCONFIG_FILE` alone cannot isolate one that has already persisted the host's font paths into its registry, which quietly invalidated two earlier comparisons.

`notes/ABLETON-WINE-MENU-FONT-FALLBACK.md` documents the mechanism and is tracked here for the first time.

The commits @shibco reviewed are no longer on any branch, though GitHub still resolves them by hash, so the `Fixed in <sha>` links in my replies above still work.
