### PR TITLE
Make Link opt-out sticky and version the setup marker

### DIFF
--- a/scripts/setup-link.sh
+++ b/scripts/setup-link.sh
@@ -5,6 +5,10 @@
 # ~/.local/share/ableton-wine/ableton-linkd); this script never builds software.
 set -euo pipefail
 here="$(cd "$(dirname "$0")" && pwd)"
+# Bump whenever this script's system-level effects change (hook body, firewall
+# rule, unit handling): forces one re-run on hosts with a stale marker so an
+# existing install picks up the fix instead of silently keeping old behavior.
+LINK_SETUP_VERSION=2
 
 if pgrep -f "Ableton Live.*\.exe" >/dev/null 2>&1; then
     echo "!! Live is running: close it before changing Link networking" >&2
@@ -120,4 +124,4 @@ else
     echo "OK: Link networking via $iface; ableton-linkd anchor skipped"
 fi
 mkdir -p "$HOME/.local/share/ableton-wine"
-printf '%s\n' "$iface" > "$HOME/.local/share/ableton-wine/link-configured"
+printf '%s\n%s\n' "$iface" "$LINK_SETUP_VERSION" > "$HOME/.local/share/ableton-wine/link-configured"

--- a/scripts/setup-run-header.sh
+++ b/scripts/setup-run-header.sh
@@ -6,6 +6,7 @@
 #   --update         update compatibility files; keep Live, authorization, and projects
 #   --no-launch      never run the Ableton installer (zip/exe) automatically
 #   --no-link        skip Ableton Link network configuration
+#   --link           configure Ableton Link even if previously skipped or declined
 #   --extract DIR    unpack this installer's files into DIR and exit
 #   --uninstall      remove the installed Wine, launcher, and menu entries
 #   --prefix         with --uninstall: also delete the Wine prefix and Live
@@ -37,15 +38,17 @@ fail() { printf '!! %s\n' "$*" >&2; exit 1; }
 mode=install
 do_launch=1
 do_link_setup=1
+do_link_force=0
 extract_dir=""
 drop_prefix=0
 while [ $# -gt 0 ]; do
     case "$1" in
-        --help|-h)      head -17 "$self" | sed -n '2,17{s/^# \{0,1\}//;p}'; exit 0 ;;
+        --help|-h)      head -18 "$self" | sed -n '2,18{s/^# \{0,1\}//;p}'; exit 0 ;;
         --runtime-only) mode=runtime ;;
         --update)       mode=update ;;
         --no-launch)    do_launch=0 ;;
         --no-link)      do_link_setup=0 ;;
+        --link)         do_link_setup=1; do_link_force=1 ;;
         --uninstall)    mode=uninstall ;;
         --prefix)       drop_prefix=1 ;;
         --extract)      mode=extract; extract_dir="${2:?--extract needs a directory}"; shift ;;
@@ -175,14 +178,27 @@ rm -f "$workdir/payload.tar"
 
 configure_link() {
     local marker="$HOME/.local/share/ableton-wine/link-configured"
+    local required_version=2   # keep in sync with setup-link.sh's LINK_SETUP_VERSION
 
     if [ "$do_link_setup" -eq 0 ]; then
         say "-- Ableton Link network setup skipped (--no-link)"
+        mkdir -p "$(dirname "$marker")" 2>/dev/null || true
+        printf 'declined\n%s\n' "$required_version" > "$marker" 2>/dev/null || true
         return 0
     fi
-    if [ -f "$marker" ]; then
-        say "-- Ableton Link networking is already configured"
-        return 0
+
+    if [ -f "$marker" ] && [ "$do_link_force" -ne 1 ]; then
+        local state ver
+        state="$(sed -n 1p "$marker")"
+        ver="$(sed -n 2p "$marker")"
+        if [ "$state" = declined ]; then
+            say "-- Ableton Link networking was previously declined (--no-link); pass --link to configure it now"
+            return 0
+        fi
+        if [ "$ver" = "$required_version" ]; then
+            say "-- Ableton Link networking is already configured"
+            return 0
+        fi
     fi
 
     say "-- configuring Ableton Link networking"


### PR DESCRIPTION
PR for a combination of fixes into #80 

`configure_link()` treats the marker file (`~/.local/share/ableton-wine/link-configured`) as a simple "have we done this before?" flag. That causes two things:

1. Anyone who already ran the old `setup-link.sh` has that marker sitting there, so `--update` will never touch it again — which means they never actually get the new VPN-aware NetworkManager hook. They're stuck on the old, VPN-unsafe one unless they know to delete the marker or re-run the script themselves. Kind of ironic since they're the people most likely to hit the bug this branch fixes.
2. `--no-link` doesn't stick. If someone opts out on their first install and later runs `--update` without remembering to pass `--no-link` again, they get hit with a surprise `sudo` prompt on what should've been a quiet update.

fixes:

- `setup-link.sh` now carries a `LINK_SETUP_VERSION`, written into the marker next to the interface name. `configure_link()` only skips when the recorded version matches what's expected, so bumping it forces one clean re-run on affected machines and then goes back to being quiet.
- `--no-link` now writes a `declined` state into that same marker, so it's respected on later `--update` runs without having to repeat it every time. Added `--link` as the explicit opt-back-in (shows up in `--help`, wired through the arg parser and into `configure_link()`).

Ran `bash -n` + shellcheck on both files, and walked through all six marker states by hand (fresh install, rerun at the same version, rerun at a stale version, `--no-link`, a later `--update` without re-passing it, and `--link` overriding a decline) — behaves as expected in each case.

Only `scripts/setup-link.sh` and `scripts/setup-run-header.sh` are touched, nothing else.