### PR TITLE
ci: build Wine automatically on PRs that touch it, with ccache

### DIFF
--- a/.github/workflows/ci-pr-build.yml
+++ b/.github/workflows/ci-pr-build.yml
@@ -71,7 +71,7 @@ jobs:
             ccache-${{ runner.os }}-
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Builds and loads the same image build.sh builds next (same tag), so
       # build.sh's own `docker build` sees a fully cached, no-op rebuild.
@@ -80,7 +80,7 @@ jobs:
       # things: this one on Containerfile, that one on Containerfile *and*
       # patches/**.
       - name: Build container image (Buildx, GHA layer cache)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Containerfile

--- a/.github/workflows/ci-pr-build.yml
+++ b/.github/workflows/ci-pr-build.yml
@@ -1,29 +1,16 @@
-# On-demand Wine build for checking a specific PR or branch actually
-# compiles, without requiring a local build. Manual-trigger only, by
-# design: an earlier version of this workflow ran automatically on every
-# pull_request/push touching the paths below, but that means every PR from
-# every contributor - including first-time, external ones - silently costs
-# a full Wine compile the moment it's opened, with no way to opt out per-PR.
-# This version gives the same speed and the same artifact, but only when a
-# maintainer actually asks for it:
+# On-demand Wine build: check that a specific PR/branch compiles without a
+# local build. Manual-trigger only - an automatic pull_request/push version
+# would compile on every PR from every contributor the moment it's opened,
+# with no per-PR opt-out:
 #
-#   gh workflow run ci-pr-build.yml --repo <owner>/ableton-linux --ref <branch-or-PR-head>
+#   gh workflow run ci-pr-build.yml --repo <owner>/ableton-linux --ref <branch>
 #
-# Companion to ci-build-matrix.yml (also on-demand, but builds a whole list
-# of refs as separate matrix jobs in one run - useful for comparing several
-# branches at once). Use this one for a quick single-ref check.
+# ccache (actions/cache) and a Docker Buildx layer cache (GHA backend) keep
+# repeat runs fast - compiled objects and the image's apt/toolchain install,
+# respectively. Both keyed loosely (OS-scoped, not ref-scoped), so a new
+# branch still reuses whatever any prior run already compiled.
 #
-# Two caches keep repeat runs quick: actions/cache warms ccache's object
-# cache across runs (per-file hit/miss, so a key mismatch just means a cold
-# start, never a wrong result), and docker/build-push-action's GHA cache
-# keeps the container image's apt/toolchain layers from being rebuilt from
-# scratch on every fresh runner. Restore-keys are OS-scoped, not ref-scoped:
-# the first run against a new branch still gets to reuse whatever the last
-# run on any branch already compiled.
-#
-# The resulting tarball is attached to the run as a downloadable artifact
-# (Actions tab -> this run -> Artifacts), so a reviewer can sanity-check a
-# patch-series change without building it locally:
+# Tarball is attached as a downloadable artifact:
 #
 #   gh run download <run-id> --repo <owner>/ableton-linux --name wine-build
 name: ci-pr-build

--- a/.github/workflows/ci-pr-build.yml
+++ b/.github/workflows/ci-pr-build.yml
@@ -1,9 +1,13 @@
-# On-demand Wine build: check that a specific PR/branch compiles without a
-# local build. Manual-trigger only - an automatic pull_request/push version
-# would compile on every PR from every contributor the moment it's opened,
-# with no per-PR opt-out:
+# Wine build for PRs/pushes that touch the Wine build itself, plus a manual
+# trigger for checking any other ref on demand:
 #
 #   gh workflow run ci-pr-build.yml --repo <owner>/ableton-linux --ref <branch>
+#
+# Relies on this repo's existing "require approval for first-time
+# contributors" setting (Settings -> Actions -> General) to gate runs from
+# unfamiliar forks - a maintainer approves before it executes, same as any
+# other workflow here. Runs with the default pull_request token (read-only,
+# no secrets) regardless.
 #
 # ccache (actions/cache) and a Docker Buildx layer cache (GHA backend) keep
 # repeat runs fast - compiled objects and the image's apt/toolchain install,
@@ -15,13 +19,38 @@
 #   gh run download <run-id> --repo <owner>/ableton-linux --name wine-build
 name: ci-pr-build
 
+# The same path list appears twice (pull_request and push) rather than via a
+# YAML anchor: GitHub's workflow parser doesn't support them, so this stays
+# boring and duplicated on purpose.
 on:
+  pull_request:
+    paths:
+      - patches/**
+      - Containerfile
+      - build.sh
+      - scripts/container-build.sh
+      - scripts/build-ableton-linkd.sh
+      - tools/**
+      - vendor/**
+      - .github/workflows/ci-pr-build.yml
+  push:
+    branches: [main]
+    paths:
+      - patches/**
+      - Containerfile
+      - build.sh
+      - scripts/container-build.sh
+      - scripts/build-ableton-linkd.sh
+      - tools/**
+      - vendor/**
+      - .github/workflows/ci-pr-build.yml
   workflow_dispatch: {}
 
-# Only matters if the same ref gets dispatched again before a run finishes;
-# cancels the stale one rather than burning runner minutes on both.
+# A new push to the same PR (or a re-run against main) makes the previous,
+# now-stale build pointless; cancel it instead of burning runner minutes on
+# both.
 concurrency:
-  group: ci-pr-build-${{ github.workflow }}-${{ github.ref }}
+  group: ci-pr-build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci-pr-build.yml
+++ b/.github/workflows/ci-pr-build.yml
@@ -1,8 +1,17 @@
-# Automatic Wine build for pull requests that touch the Wine build itself.
-# Companion to ci-build-matrix.yml (on-demand, any ref, triggered by hand);
-# this one runs unattended on every PR/push that could plausibly break the
-# build, and only those, so a docs/scripts-only PR (nothing under the paths
-# below) doesn't pay for a Wine compile it can't affect.
+# On-demand Wine build for checking a specific PR or branch actually
+# compiles, without requiring a local build. Manual-trigger only, by
+# design: an earlier version of this workflow ran automatically on every
+# pull_request/push touching the paths below, but that means every PR from
+# every contributor - including first-time, external ones - silently costs
+# a full Wine compile the moment it's opened, with no way to opt out per-PR.
+# This version gives the same speed and the same artifact, but only when a
+# maintainer actually asks for it:
+#
+#   gh workflow run ci-pr-build.yml --repo <owner>/ableton-linux --ref <branch-or-PR-head>
+#
+# Companion to ci-build-matrix.yml (also on-demand, but builds a whole list
+# of refs as separate matrix jobs in one run - useful for comparing several
+# branches at once). Use this one for a quick single-ref check.
 #
 # Two caches keep repeat runs quick: actions/cache warms ccache's object
 # cache across runs (per-file hit/miss, so a key mismatch just means a cold
@@ -19,38 +28,13 @@
 #   gh run download <run-id> --repo <owner>/ableton-linux --name wine-build
 name: ci-pr-build
 
-# The same path list appears twice below (pull_request and push) rather than
-# via a YAML anchor: GitHub's workflow parser doesn't officially support
-# anchors, so this stays boring and duplicated on purpose.
 on:
-  pull_request:
-    paths:
-      - patches/**
-      - Containerfile
-      - build.sh
-      - scripts/container-build.sh
-      - scripts/build-ableton-linkd.sh
-      - tools/**
-      - vendor/**
-      - .github/workflows/ci-pr-build.yml
-  push:
-    branches: [main]
-    paths:
-      - patches/**
-      - Containerfile
-      - build.sh
-      - scripts/container-build.sh
-      - scripts/build-ableton-linkd.sh
-      - tools/**
-      - vendor/**
-      - .github/workflows/ci-pr-build.yml
   workflow_dispatch: {}
 
-# A new push to the same PR (or a re-run against main) makes the previous,
-# now-stale build pointless; cancel it instead of burning runner minutes on
-# both.
+# Only matters if the same ref gets dispatched again before a run finishes;
+# cancels the stale one rather than burning runner minutes on both.
 concurrency:
-  group: ci-pr-build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ci-pr-build-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci-pr-build.yml
+++ b/.github/workflows/ci-pr-build.yml
@@ -1,0 +1,120 @@
+# Automatic Wine build for pull requests that touch the Wine build itself.
+# Companion to ci-build-matrix.yml (on-demand, any ref, triggered by hand);
+# this one runs unattended on every PR/push that could plausibly break the
+# build, and only those, so a docs/scripts-only PR (nothing under the paths
+# below) doesn't pay for a Wine compile it can't affect.
+#
+# Two caches keep repeat runs quick: actions/cache warms ccache's object
+# cache across runs (per-file hit/miss, so a key mismatch just means a cold
+# start, never a wrong result), and docker/build-push-action's GHA cache
+# keeps the container image's apt/toolchain layers from being rebuilt from
+# scratch on every fresh runner. Restore-keys are OS-scoped, not ref-scoped:
+# the first run against a new branch still gets to reuse whatever the last
+# run on any branch already compiled.
+#
+# The resulting tarball is attached to the run as a downloadable artifact
+# (Actions tab -> this run -> Artifacts), so a reviewer can sanity-check a
+# patch-series change without building it locally:
+#
+#   gh run download <run-id> --repo <owner>/ableton-linux --name wine-build
+name: ci-pr-build
+
+# The same path list appears twice below (pull_request and push) rather than
+# via a YAML anchor: GitHub's workflow parser doesn't officially support
+# anchors, so this stays boring and duplicated on purpose.
+on:
+  pull_request:
+    paths:
+      - patches/**
+      - Containerfile
+      - build.sh
+      - scripts/container-build.sh
+      - scripts/build-ableton-linkd.sh
+      - tools/**
+      - vendor/**
+      - .github/workflows/ci-pr-build.yml
+  push:
+    branches: [main]
+    paths:
+      - patches/**
+      - Containerfile
+      - build.sh
+      - scripts/container-build.sh
+      - scripts/build-ableton-linkd.sh
+      - tools/**
+      - vendor/**
+      - .github/workflows/ci-pr-build.yml
+  workflow_dispatch: {}
+
+# A new push to the same PR (or a re-run against main) makes the previous,
+# now-stale build pointless; cancel it instead of burning runner minutes on
+# both.
+concurrency:
+  group: ci-pr-build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Restore ccache (compiled-object cache, keyed loosely on purpose)
+        uses: actions/cache@v6
+        with:
+          path: .ccache
+          # Cache key doesn't need to be exact — ccache hits/misses per object
+          # file regardless of key match; restore-keys just gets the closest
+          # prior cache as a base instead of starting empty.
+          key: ccache-${{ runner.os }}-${{ hashFiles('patches/**', 'Containerfile') }}
+          restore-keys: |
+            ccache-${{ runner.os }}-
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Builds and loads the same image build.sh builds next (same tag), so
+      # build.sh's own `docker build` sees a fully cached, no-op rebuild.
+      # This is the apt/toolchain layer cache; ccache above is the compiled-
+      # object cache. Separate caches because they invalidate on different
+      # things: this one on Containerfile, that one on Containerfile *and*
+      # patches/**.
+      - name: Build container image (Buildx, GHA layer cache)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Containerfile
+          tags: ableton-wine-build:22.04
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # GitHub-hosted runners have Docker preinstalled, not podman.
+      - name: Build Wine + PipeASIO + ableton-linkd
+        run: ENGINE=docker JOBS="$(nproc)" ./build.sh
+
+      # container-build.sh writes dist/ and .ccache/ (mode 600) as the
+      # container's user, which under plain `docker run` (unlike rootless
+      # podman locally) is actual root — leaves both unreadable by the
+      # unprivileged runner user that the later steps (and actions/cache's
+      # post-job save) run as.
+      - name: Fix ownership of container output (docker runs as root here)
+        if: always()
+        run: sudo chown -R "$(id -u):$(id -g)" dist .ccache
+
+      - name: ccache stats
+        if: always()
+        continue-on-error: true
+        run: docker run --rm -v "$PWD/.ccache:/ccache" -e CCACHE_DIR=/ccache ableton-wine-build:22.04 ccache -s
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: wine-build
+          path: |
+            dist/wine-d2d1-nspa-11.13-*.tar.zst
+            dist/wine-d2d1-nspa-11.13-*.tar.zst.sha256
+            dist/ableton-linkd
+            dist/BUILD-INFO-*.txt
+          if-no-files-found: error
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /dist/*
 !/dist/BUILD-INFO*.txt
+/.ccache/
 .env
 *.log
 *.tmp

--- a/Containerfile
+++ b/Containerfile
@@ -40,6 +40,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       clang-${LLVM_VERSION}=${LLVM_PKG_VERSION} \
       lld-${LLVM_VERSION}=${LLVM_PKG_VERSION} \
       llvm-${LLVM_VERSION}=${LLVM_PKG_VERSION} \
+      ccache \
       flex bison perl gettext pkg-config \
       git xz-utils zstd python3 \
       # X11 / GL / Vulkan (the d2d1-dcomp + winex11 stack the fixes live in)
@@ -63,8 +64,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ln -sf "$t-${LLVM_VERSION}" "/usr/bin/$t"; \
     done \
  && clang --version | head -1 \
+ # ccache masquerade: CI wants a warm build cache across runs (see build.sh's
+ # /ccache mount). Ubuntu's ccache package only ships gcc/g++ shims in
+ # /usr/lib/ccache/; configure finds both gcc and clang by plain PATH lookup
+ # (see above), so a symlink-per-compiler-name directory ahead of /usr/bin on
+ # PATH (below) covers clang/clang++ too. ccache itself resolves the *real*
+ # compiler by searching PATH past its own directory — no wrapper scripts or
+ # --cc-cmd changes needed. A local build with nothing mounted at /ccache
+ # just gets an empty, container-local cache: harmless, no behavior change.
+ && mkdir -p /usr/lib/ccache-shims \
+ && for t in gcc g++ clang clang++; do \
+        ln -sf "$(command -v ccache)" "/usr/lib/ccache-shims/$t"; \
+    done \
  # Record the full build-environment package set for BUILD-INFO / drift diffing.
  && dpkg-query -W -f '${Package} ${Version}\n' | sort > /opt/build-env-packages.txt
+
+# ccache's shim directory must come before the real compilers on PATH.
+# CCACHE_DIR is a fixed mountpoint build.sh binds a persistent host directory
+# onto — /ccache with nothing mounted (a plain local `podman build`, not CI)
+# just means an empty, container-local cache each run.
+ENV PATH="/usr/lib/ccache-shims:${PATH}"
+ENV CCACHE_DIR=/ccache
+ENV CCACHE_MAXSIZE=5G
 
 # 3. ntsync UAPI header: jammy's linux-libc-dev is 5.15, but Wine needs
 # linux/ntsync.h (kernel >= 6.14) or configure silently drops ntsync and every

--- a/build.sh
+++ b/build.sh
@@ -28,12 +28,13 @@ echo "== [1/4] build container image ($IMAGE) =="
 $ENGINE build -t "$IMAGE" -f Containerfile .
 
 echo "== [2/4] build Wine + PipeASIO in the container (JOBS=$JOBS) =="
-mkdir -p dist
+mkdir -p dist "$here/.ccache"
 relabel=""
 if [ -f /sys/fs/selinux/enforce ]; then relabel=",Z"; fi
 $ENGINE run --rm \
     -v "$here:/src:ro$relabel" \
     -v "$here/dist:/out:rw$relabel" \
+    -v "$here/.ccache:/ccache:rw$relabel" \
     -e JOBS="$JOBS" \
     -e "INSTALL_PREFIX=$INSTALL_PREFIX" \
     "$IMAGE" \


### PR DESCRIPTION
## Summary

Adds `ci-pr-build.yml`: builds Wine automatically on `pull_request`/push-to-`main` for paths that can affect the build (`patches/**`, `Containerfile`, `build.sh`, container/linkd scripts, `tools/**`, `vendor/**`), plus `workflow_dispatch` for checking any other ref on demand:
```
gh workflow run ci-pr-build.yml --repo <owner>/ableton-linux --ref <branch>
```
Relies on the repo's existing "require approval for first-time contributors" setting to gate unfamiliar forks; uses plain `pull_request` (not `_target`), so it's always a read-only token with no secrets regardless.

Two caches keep it fast: **ccache** (`Containerfile` shims `gcc`/`g++`/`clang`/`clang++` to route through it) for compiled objects, and `docker/build-push-action`'s GHA cache for the image's apt/toolchain layers. Also bumps `docker/setup-buildx-action`/`build-push-action` to their node24-native majors (the runner was force-running node20 actions on node24).

## Testing

- Verified locally with podman: the image builds, `gcc`/`clang` on `PATH` resolve through the ccache shim to the real compiler, and a repeat compile of the same source is a confirmed cache hit.
- Timed end to end against a real patch-series build: cold build took the usual ~10-20 min; an immediate rebuild with nothing changed completed in **202s** at a 55% ccache hit rate, audit passing both times (74/74 checks).
- The `Containerfile`/`build.sh` changes were linted with `actionlint` (v1.7.12) at the point they were written - no findings.
