### PR TITLE
Patch 0057: Fix M4L track-selection flicker in winex11

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -71,6 +71,8 @@ make verify
   colors.
 - `ABLETON_UI_FONT=auto|preserve|off|<family>` controls the Wine UI font.
 - `ABLETON_DCOMP=off` disables DirectComposition for one launch.
+- `WINE_X11_FORCE_OFFSCREEN_CLASS=off` disables the default Max for Live
+  selection-flicker fix for one launch.
 - `ABLETON_RT=off` disables realtime scheduling for one launch.
 - `PIPEASIO_*` variables override PipeASIO settings for one launch.
 - `ENGINE` selects the container engine used by build scripts. The default is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
   pane's area at timer cadence. DirectComposition re-blits now stop while the
   target window's ancestor chain is hidden. Reported by jttdev, reviewed by
   Giang Nguyen.
+- Fixed the whole Live window flashing when selecting away from or back to a
+  Max for Live track (Wine patch 0057). The launcher now keeps Live's client
+  surface on winex11's offscreen-composited path instead of letting M4L child
+  visibility unmap and reparent the full client.
 - Menu colors now follow the desktop theme correctly (issue 35, Wine patches
   0049 to 0052). The menu bar takes the darker chrome color and dropdowns take
   the lighter content color, grayed items lose the engraved bevel,

--- a/notes/ABLETON-WINE-M4L-SELECTION-FLICKER.md
+++ b/notes/ABLETON-WINE-M4L-SELECTION-FLICKER.md
@@ -1,0 +1,66 @@
+# Max for Live selection flicker
+
+## Symptom
+
+With a Max for Live device such as Convolution Reverb Pro selected, choosing a
+different track and then choosing the M4L track again can flash Live's whole
+window black. The device continues to run and its rendered contents remain
+healthy.
+
+## Window transition
+
+The visible M4L device contributes a child window to Live's client area.
+Selecting away hides the child; selecting back shows it. That changes the
+client clipping region evaluated by `needs_client_window_clipping()` in
+`dlls/winex11.drv/init.c`.
+
+For a simple region, `needs_offscreen_rendering()` returns false and the client
+window is attached to Live's whole X window. For a clipped region it returns
+true, `client_surface_update_offscreen()` redirects the client through
+XComposite, and `detach_client_window()` reparents it to winex11's dummy
+parent. Reversing the selection reverses the operation.
+
+The observed full-client sequence was:
+
+```text
+Unmap    win=0x3000100 parent=0x3000056 geo=0,23 1920x1057
+Reparent win=0x3000100 parent=0x3200003 geo=0,23 1920x1057
+Map      win=0x3000100 parent=0x3200003 geo=0,23 1920x1057
+
+Unmap    win=0x3000100 parent=0x3200003 geo=0,0 1920x1057
+Reparent win=0x3000100 parent=0x3000056 geo=0,0 1920x1057
+Map      win=0x3000100 parent=0x3000056 geo=0,0 1920x1057
+```
+
+Those transitions began 8-13 ms after the corresponding selection clicks. A
+first-M4L-device capture included a compositor frame with mean luminance
+`0.0120`; stable Live frames measured about `0.2205`.
+
+## Patch 0057
+
+Patch 0057 adds `WINE_X11_FORCE_OFFSCREEN_CLASS`. When it exactly matches a
+top-level Windows class, winex11 keeps that window's client surface on the
+offscreen-composited path. The Live launcher defaults it to:
+
+```bash
+WINE_X11_FORCE_OFFSCREEN_CLASS="Ableton Live Window Class"
+```
+
+This changes neither child visibility nor device rendering. It removes the
+full-client attach/detach operation caused by those visibility changes.
+
+Across six track-away/track-back cycles with the patch enabled:
+
+- full-client `Unmap`/`Reparent`/`Map` transitions: 0
+- compositor frames captured: 347
+- minimum mean luminance: `0.224746`
+- frames below `0.10`: 0
+
+For a one-launch control using the original behavior:
+
+```bash
+WINE_X11_FORCE_OFFSCREEN_CLASS=off ableton-live
+```
+
+`off` is simply a class name that does not match Live, so the Wine behavior is
+not forced.

--- a/patches/0057-winex11-keep-a-selected-top-level-class-offscreen.patch
+++ b/patches/0057-winex11-keep-a-selected-top-level-class-offscreen.patch
@@ -1,0 +1,64 @@
+Subject: winex11: keep a selected top-level class offscreen
+
+Live's Max for Live device view contains a child window. Selecting away from
+an M4L track hides that child; selecting the track again shows it. The child
+changes the top-level client clipping region between simple and non-simple,
+so needs_offscreen_rendering alternates for Live's whole client surface.
+
+client_surface_update_offscreen implements each change by unmapping the
+1920x1057 client window, reparenting it between Live's whole window and
+winex11's dummy parent, and mapping it again. Xwayland can expose the empty
+client during that round trip. A compositor capture measured the resulting
+black frame at 0.0120 mean luminance versus about 0.2205 normally.
+
+Allow a launcher to name one exact top-level Windows class that should remain
+on the offscreen-composited path. The comparison is deliberately limited to
+top-level windows and exact ASCII class names. Setting
+WINE_X11_FORCE_OFFSCREEN_CLASS to "Ableton Live Window Class" prevents the
+attach/detach transition without changing M4L child lifetime or rendering.
+
+In an unforced control, track-away/track-back clicks were followed within
+8-13 ms by full-client Unmap/Reparent/Map sequences. With the class forced
+offscreen, six identical cycles produced no full-client transitions; none of
+347 compositor frames fell below 0.2247 mean luminance.
+
+diff --git a/dlls/winex11.drv/init.c b/dlls/winex11.drv/init.c
+index b3ebc0b..4097ef3 100644
+--- a/dlls/winex11.drv/init.c
++++ b/dlls/winex11.drv/init.c
+@@ -220,6 +220,27 @@ static BOOL needs_client_window_clipping( HWND hwnd )
+     return ret > 0;
+ }
+ 
++static BOOL force_offscreen_for_class( HWND hwnd )
++{
++    const char *forced_class = getenv( "WINE_X11_FORCE_OFFSCREEN_CLASS" );
++    WCHAR class_buffer[128];
++    UNICODE_STRING class_name = {0, sizeof(class_buffer), class_buffer};
++    unsigned int i;
++    size_t forced_length;
++    INT length;
++
++    if (!forced_class || !forced_class[0]) return FALSE;
++    forced_length = strlen( forced_class );
++    if (forced_length >= ARRAY_SIZE(class_buffer)) return FALSE;
++    if (NtUserGetAncestor( hwnd, GA_PARENT ) != NtUserGetDesktopWindow()) return FALSE;
++    if ((length = NtUserGetClassName( hwnd, FALSE, &class_name )) <= 0) return FALSE;
++    if ((unsigned int)length != forced_length) return FALSE;
++
++    for (i = 0; i < (unsigned int)length; ++i)
++        if ((unsigned char)forced_class[i] != class_buffer[i]) return FALSE;
++    return TRUE;
++}
++
+ BOOL needs_offscreen_rendering( HWND hwnd )
+ {
+     static const WCHAR dcomp_target_propW[] =
+@@ -227,6 +248,7 @@ BOOL needs_offscreen_rendering( HWND hwnd )
+     static const WCHAR d3d_hwnd_target_propW[] =
+         {'_','_','w','i','n','e','_','d','3','d','_','h','w','n','d','_','t','a','r','g','e','t',0};
+ 
++    if (force_offscreen_for_class( hwnd )) return TRUE;
+     if (NtUserGetDpiForWindow( hwnd ) != NtUserGetWinMonitorDpi( hwnd, MDT_RAW_DPI )) return TRUE; /* needs DPI scaling */
+     if (NtUserGetAncestor( hwnd, GA_PARENT ) != NtUserGetDesktopWindow())
+     {

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -11,7 +11,7 @@ narrative — 5 merge conflicts, three build breaks the clean rebase didn't
 catch, a build.sh/pipefail tooling gotcha — is in
 `notes/ABLETON-WINE-11.11-TO-11.13-BASE-BUMP.md`.
 
-The current Wine series contains 52 files, numbered 0001 through 0055.
+The current Wine series contains 54 files, numbered 0001 through 0057.
 Patches 0027, 0044, and 0054 are intentionally absent.
 
 ## Applying the series
@@ -171,3 +171,8 @@ Apply them in sequence with the rest of the series.
   measurements:
   Lucas Gillingham (ClickSentinel). See
   `notes/ABLETON-WINE-GPU-RENDERER.md`.
+- `0057`: let the launcher keep one exact top-level Windows class on
+  winex11's offscreen-composited path. The Live launcher selects
+  `Ableton Live Window Class`, preventing M4L child visibility from
+  unmapping and reparenting the full Live client when track selection
+  changes. See `notes/ABLETON-WINE-M4L-SELECTION-FLICKER.md`.

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -51,5 +51,6 @@ f278d870c0424748a9d7a7cd5a6e9feb0837900e6382f4ee9d7cfe214c0b9fd5  0052-win32u-hi
 d32ac8ca55853e5488292d015e35a31d23744150e04af476742e781b58abc186  0053-winex11-export-the-app-minimum-tracking-size-as-PMin.patch
 5c97ce27e69ea1caffef5197a8e0f19893829c1c868e06c89e660352ad2919a1  0055-dxgi-prefer-GL-present-for-top-level-swapchain-devic.patch
 11dbb4c36378fc274e8eaa281e9bfbe43835bd0fae2682924d19aee318b673bb  0056-dxgi-gate-parked-dcomp-reblits-on-window-visibility.patch
+a07f7ecb2c3a568d8eeae9a42df558cea4d8e279e5bdeb0af67a6649086973f7  0057-winex11-keep-a-selected-top-level-class-offscreen.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/scripts/ableton-live
+++ b/scripts/ableton-live
@@ -5,7 +5,8 @@
 #            ABLETON_LIVE_EXE=/path/into/prefix/.../Ableton Live NN Edition.exe (pick one install),
 #            ABLETON_LIVE_VERSION=11|12 (restrict discovery to one major version),
 #            ABLETON_RT=off (skip the realtime probe; run Live under normal scheduling),
-#            ABLETON_LINKD=/path/to/ableton-linkd (Ableton Link session anchor override).
+#            ABLETON_LINKD=/path/to/ableton-linkd (Ableton Link session anchor override),
+#            WINE_X11_FORCE_OFFSCREEN_CLASS=off (disable the M4L selection-flicker fix).
 set -u
 # Clear inherited Wine variables so this launch uses only the patched build.
 unset WINELOADER WINEDLLPATH WINEDLLOVERRIDES WINEARCH
@@ -16,6 +17,10 @@ export PATH="$WINE_ROOT/bin:$PATH"
 export WINEDEBUG="${WINEDEBUG:--all}"
 export WINE_D3D_CONFIG="${WINE_D3D_CONFIG:-csmt=0x1}"
 export WINED3D_DCOMP_FORCE_FULL_REDRAW="${WINED3D_DCOMP_FORCE_FULL_REDRAW:-1}"
+# M4L child visibility otherwise makes winex11 detach and reattach Live's whole
+# client surface. Keep Live on the offscreen path; "off" is a non-matching class
+# value and therefore provides a one-launch A/B override.
+export WINE_X11_FORCE_OFFSCREEN_CLASS="${WINE_X11_FORCE_OFFSCREEN_CLASS:-Ableton Live Window Class}"
 # Report host mount points as plain dirs (patch 0033); Live's browser treats
 # junctions without reparse data as unresolvable and skips them.
 export WINE_DISABLE_UNIX_MOUNT_REPARSE="${WINE_DISABLE_UNIX_MOUNT_REPARSE:-1}"

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -129,6 +129,7 @@ FINGERPRINTS='
 0043|ascii|lib/wine/x86_64-windows/shell32.dll|__wine_portal_show_item
 0045|ascii|lib/wine/x86_64-windows/ole32.dll|revoke for another process windows is disabled
 0055|wide|lib/wine/x86_64-windows/dxgi.dll|WINE_DISABLE_GL_PRESENT
+0057|ascii|lib/wine/x86_64-unix/winex11.so|WINE_X11_FORCE_OFFSCREEN_CLASS
 pipeasio/0001|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-clamp-sample-rate
 pipeasio/0002|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-midi-timebase
 '


### PR DESCRIPTION
## Summary

- Add Wine patch 0057 to keep Ableton Live’s client surface on the offscreen-composited path.
- Enable the fix by default in the Live launcher.
- Provide `WINE_X11_FORCE_OFFSCREEN_CLASS=off` for comparison testing.
- Add build verification and technical documentation.

## Cause

Showing or hiding a Max for Live child window changes Live’s client clipping region. Wine responds by unmapping and reparenting the entire Live window, which can produce a black frame under Xwayland.

## Validation

- Unpatched selection changes produced full-window `Unmap → Reparent → Map` sequences within 8–13 ms.
- `winex11.so` builds successfully and repository verification passes.
