### PR TITLE
Prefer GL present for top-level swapchain windows (issue 91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
   (Wine patch 0053). winex11 now exports the `WM_GETMINMAXINFO` minimum
   as the X11 `PMinSize` hint, and the window manager stops the drag at
   the minimum.
+- Fixed high CPU use and display traffic with the GPU renderer (issue 91,
+  Wine patch 0055). Wine copied every finished frame of Live's main window
+  from the graphics card back into main memory and sent it to the display
+  server as a full image, about 650 MB per second during continuous UI
+  activity such as mouse movement. Wine now shows finished frames directly
+  from the graphics card. Set `WINE_DISABLE_GL_PRESENT=1` to restore the
+  previous behaviour. Diagnosis and measurements by Lucas Gillingham.
 
 - The installer now configures Ableton Link during installation. Setup no
   longer adds a multicast route or NetworkManager hook: the Link SDK selects

--- a/notes/ABLETON-WINE-GPU-RENDERER.md
+++ b/notes/ABLETON-WINE-GPU-RENDERER.md
@@ -59,11 +59,48 @@ Checks that still need a pass after longer real-world use: file dialogs
 under sustained work, plugin editor open/close (JUCE, SWAM), and both
 panes across scale factors other than 200%.
 
+## Present path (added 2026-07-29, issue 91)
+
+A present is the step where Live hands a finished frame to Wine for
+display. With the GPU renderer on, Wine handled every present of Live's
+main window on its GDI path: it copied the finished frame from the
+graphics card into main memory and sent it to the display server as a
+full-window image, about 14 MB per frame at 2560x1350. An idle window
+presents nothing, so the idle figures above stay correct. Continuous UI
+activity, including mouse movement over the window, produced about
+650 MB per second of display-server traffic and used more than one CPU
+core. Lucas Gillingham (ClickSentinel) reported and measured this in
+issue 91.
+
+Wine patch 0055 marks the main window's frame buffers at creation with
+`WINED3D_SWAPCHAIN_PREFER_GL_PRESENT`. Wine then shows each finished
+frame directly from the graphics card with `glXSwapBuffers` and skips
+the copy. The patch applies this to top-level windows only. Windows
+with the `WS_CHILD` style (composition targets, embedded plugin
+editors) keep the GDI path because they have no X11 window of their
+own. Windows with the `WS_POPUP` style (Settings, the authorisation
+dialog, context menus) also keep the GDI path because they show black
+content on the direct path until the first click or keypress. Set
+`WINE_DISABLE_GL_PRESENT=1` in the environment to restore the GDI path
+for every window; a rebuild is unnecessary.
+
+To confirm which path a build uses, start Live with
+`WINEDEBUG=fixme+all,err+all` and count the message `Using GDI present`
+in the log. One occurrence means the copy path. Zero means the direct
+path. The launcher sets `WINEDEBUG=-all` by default, so pass
+`WINEDEBUG` explicitly. Turn tracing off when measuring bandwidth,
+because the log's own writes count toward `/proc/<pid>/io`.
+
+These measurements come from one machine (AMD Navi 31, COSMIC/Wayland
+via XWayland). Confirmation on Intel or NVIDIA hardware and on a
+non-Wayland session is still open.
+
 ## Related
 
 - [Diagnosis narrative](ABLETON-WINE-GPU-RENDERER-WEBVIEW2-DIAGNOSIS.md)
 - [Learn View flicker mechanism](ABLETON-WINE-LEARNVIEW-FLICKER.md)
 - [Patch 0053](../patches/0053-winex11-export-the-app-minimum-tracking-size-as-PMin.patch)
+- [Patch 0055](../patches/0055-dxgi-prefer-GL-present-for-top-level-swapchain-devic.patch)
 - Resize trace from the diagnosis session:
   `~/Projects/Code/ableton/live-resize-trace-gpu-20260727.log`
   (machine-local)

--- a/notes/ABLETON-WINE-GPU-RENDERER.md
+++ b/notes/ABLETON-WINE-GPU-RENDERER.md
@@ -82,7 +82,8 @@ own. Windows with the `WS_POPUP` style (Settings, the authorisation
 dialog, context menus) also keep the GDI path because they show black
 content on the direct path until the first click or keypress. Set
 `WINE_DISABLE_GL_PRESENT=1` in the environment to restore the GDI path
-for every window; a rebuild is unnecessary.
+for every window; a rebuild is unnecessary. The value `0` is ignored
+and keeps the direct path.
 
 To confirm which path a build uses, start Live with
 `WINEDEBUG=fixme+all,err+all` and count the message `Using GDI present`

--- a/patches/0055-dxgi-prefer-GL-present-for-top-level-swapchain-devic.patch
+++ b/patches/0055-dxgi-prefer-GL-present-for-top-level-swapchain-devic.patch
@@ -1,0 +1,72 @@
+Subject: dxgi: prefer GL present for top-level swapchain device
+ windows
+
+wined3d presents a D3D11 swapchain through swapchain_blit_gdi() unless
+WINED3D_SWAPCHAIN_PREFER_GL_PRESENT is set, and the only code that set
+it was the DirectComposition target-switch path in factory.c. Live's
+main window is a plain top-level swapchain window, so every Present
+read the full backbuffer off the GPU into system memory and pushed it
+to the display server as a full-window image: about 14 MB per frame at
+2560x1350, ~650 MB/s of display-server traffic and more than one core
+while the mouse moves across the window (issue 91). On the GL path the
+present stays on the GPU and ends in glXSwapBuffers: ~0.4 MB/s and
+about 20% of a core in the same test, and the fire-once "Using GDI
+present." FIXME stops firing.
+
+d3d11_swapchain_init now sets the preference when the device window is
+top-level. WS_CHILD device windows (dcomp composition targets,
+embedded plugin editors) have no X11 whole_window, and WS_POPUP ones
+(Live's Settings and authorisation dialogs, context menus; some are
+framed, WS_POPUP | WS_CAPTION, style 96c80000) paint black on the GL
+path until first interaction, so both keep the GDI path. The test uses
+style bits rather than the parent because
+CreateSwapChainForComposition()'s own WS_CHILD window is parented to
+the desktop, and a parent test would call it top-level. The dcomp
+target-switch code in factory.c still overrides the flags per target
+window, and FORCE_GDI_PRESENT beats the preference at present time.
+
+WINE_DISABLE_GL_PRESENT restores the GDI path without a rebuild.
+
+Diagnosis and measurements: Lucas Gillingham (ClickSentinel), issue 91.
+---
+ dlls/dxgi/swapchain.c | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+diff --git a/dlls/dxgi/swapchain.c b/dlls/dxgi/swapchain.c
+index b4ed824..ec49330 100644
+--- a/dlls/dxgi/swapchain.c
++++ b/dlls/dxgi/swapchain.c
+@@ -1187,6 +1187,33 @@ HRESULT d3d11_swapchain_init(struct d3d11_swapchain *swapchain, struct dxgi_devi
+         goto cleanup;
+     }
+ 
++    /* Top-level device windows have an X11 whole_window, so GL can bind a
++     * client drawable and glXSwapBuffers straight from the GPU; without the
++     * preference every Present takes swapchain_blit_gdi()'s path: read the
++     * whole backbuffer back into system memory and push it to the display
++     * server as a full-window image (issue 91).  WS_CHILD device windows
++     * (dcomp composition targets, embedded plugin editors) have no
++     * whole_window, and WS_POPUP ones (Live's Settings and authorisation
++     * dialogs, context menus — some are framed, WS_POPUP | WS_CAPTION)
++     * paint black on the GL path until first interaction, so both keep the
++     * GDI path.  The dcomp target-switch code in factory.c still overrides
++     * this per target window, and FORCE_GDI_PRESENT beats the preference
++     * at present time.  WINE_DISABLE_GL_PRESENT restores the old behaviour
++     * without a rebuild. */
++    if (desc->device_window)
++    {
++        LONG style = GetWindowLongW(desc->device_window, GWL_STYLE);
++        WCHAR disable[2];
++
++        if (!(style & (WS_CHILD | WS_POPUP))
++                && !GetEnvironmentVariableW(L"WINE_DISABLE_GL_PRESENT", disable, ARRAY_SIZE(disable)))
++        {
++            wined3d_swapchain_set_prefer_gl_present(swapchain->wined3d_swapchain, TRUE);
++            FIXME("Top-level device window %p (style %#lx), preferring GL present.\n",
++                    desc->device_window, style);
++        }
++    }
++
+     state = wined3d_swapchain_get_state(swapchain->wined3d_swapchain);
+     wined3d_swapchain_state_get_size(state, &desc->backbuffer_width, &desc->backbuffer_height);
+ 

--- a/patches/0055-dxgi-prefer-GL-present-for-top-level-swapchain-devic.patch
+++ b/patches/0055-dxgi-prefer-GL-present-for-top-level-swapchain-devic.patch
@@ -25,18 +25,20 @@ the desktop, and a parent test would call it top-level. The dcomp
 target-switch code in factory.c still overrides the flags per target
 window, and FORCE_GDI_PRESENT beats the preference at present time.
 
-WINE_DISABLE_GL_PRESENT restores the GDI path without a rebuild.
+WINE_DISABLE_GL_PRESENT=1 restores the GDI path without a rebuild. The
+value is read, not just the presence, so =0 keeps the GL path (PR 94
+review).
 
 Diagnosis and measurements: Lucas Gillingham (ClickSentinel), issue 91.
 ---
- dlls/dxgi/swapchain.c | 27 +++++++++++++++++++++++++++
- 1 file changed, 27 insertions(+)
+ dlls/dxgi/swapchain.c | 32 ++++++++++++++++++++++++++++++++
+ 1 file changed, 32 insertions(+)
 
 diff --git a/dlls/dxgi/swapchain.c b/dlls/dxgi/swapchain.c
-index b4ed824..ec49330 100644
+index b4ed824..3fd784e 100644
 --- a/dlls/dxgi/swapchain.c
 +++ b/dlls/dxgi/swapchain.c
-@@ -1187,6 +1187,33 @@ HRESULT d3d11_swapchain_init(struct d3d11_swapchain *swapchain, struct dxgi_devi
+@@ -1187,6 +1187,38 @@ HRESULT d3d11_swapchain_init(struct d3d11_swapchain *swapchain, struct dxgi_devi
          goto cleanup;
      }
  
@@ -51,15 +53,20 @@ index b4ed824..ec49330 100644
 +     * paint black on the GL path until first interaction, so both keep the
 +     * GDI path.  The dcomp target-switch code in factory.c still overrides
 +     * this per target window, and FORCE_GDI_PRESENT beats the preference
-+     * at present time.  WINE_DISABLE_GL_PRESENT restores the old behaviour
-+     * without a rebuild. */
++     * at present time.  WINE_DISABLE_GL_PRESENT=1 restores the old
++     * behaviour without a rebuild; a value of 0 is ignored. */
 +    if (desc->device_window)
 +    {
 +        LONG style = GetWindowLongW(desc->device_window, GWL_STYLE);
-+        WCHAR disable[2];
++        WCHAR val[8] = {0};
++        BOOL disabled;
 +
-+        if (!(style & (WS_CHILD | WS_POPUP))
-+                && !GetEnvironmentVariableW(L"WINE_DISABLE_GL_PRESENT", disable, ARRAY_SIZE(disable)))
++        /* A value too long for the buffer leaves val zeroed and counts as
++         * set, so any long value still disables. */
++        disabled = GetEnvironmentVariableW(L"WINE_DISABLE_GL_PRESENT", val, ARRAY_SIZE(val))
++                && val[0] != '0';
++
++        if (!disabled && !(style & (WS_CHILD | WS_POPUP)))
 +        {
 +            wined3d_swapchain_set_prefer_gl_present(swapchain->wined3d_swapchain, TRUE);
 +            FIXME("Top-level device window %p (style %#lx), preferring GL present.\n",

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -11,8 +11,8 @@ narrative — 5 merge conflicts, three build breaks the clean rebase didn't
 catch, a build.sh/pipefail tooling gotcha — is in
 `notes/ABLETON-WINE-11.11-TO-11.13-BASE-BUMP.md`.
 
-The current Wine series contains 51 files, numbered 0001 through 0053.
-Patches 0027 and 0044 are intentionally absent.
+The current Wine series contains 52 files, numbered 0001 through 0055.
+Patches 0027, 0044, and 0054 are intentionally absent.
 
 ## Applying the series
 
@@ -153,4 +153,20 @@ Apply them in sequence with the rest of the series.
   Live counter mid-drag and the window fought the drag (growth at the
   opposite edge, occasional spurious maximize). Found 2026-07-27 while
   enabling Live's GPU renderer. See
+  `notes/ABLETON-WINE-GPU-RENDERER.md`.
+- `0054`: reserved for the language-fallback font work on PR 77. No
+  patch file is shipped.
+- `0055`: set `WINED3D_SWAPCHAIN_PREFER_GL_PRESENT` for top-level D3D11
+  swapchain windows. Without the flag, wined3d displayed every frame of
+  Live's main window through GDI: it copied the finished frame from the
+  graphics card into main memory and sent it to the display server as a
+  full-window image, about 650 MB per second and more than one CPU core
+  while the mouse moves across the window (issue 91). With the flag,
+  wined3d shows each frame directly from the graphics card with
+  `glXSwapBuffers`. Windows with the `WS_CHILD` or `WS_POPUP` style
+  keep the GDI path: child windows have no X11 window of their own, and
+  popup windows show black content on the direct path until the first
+  interaction. Setting `WINE_DISABLE_GL_PRESENT` in the environment
+  restores the GDI path for every window. Diagnosis and measurements:
+  Lucas Gillingham (ClickSentinel). See
   `notes/ABLETON-WINE-GPU-RENDERER.md`.

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -166,7 +166,8 @@ Apply them in sequence with the rest of the series.
   `glXSwapBuffers`. Windows with the `WS_CHILD` or `WS_POPUP` style
   keep the GDI path: child windows have no X11 window of their own, and
   popup windows show black content on the direct path until the first
-  interaction. Setting `WINE_DISABLE_GL_PRESENT` in the environment
-  restores the GDI path for every window. Diagnosis and measurements:
+  interaction. Setting `WINE_DISABLE_GL_PRESENT=1` restores the GDI
+  path for every window; the value `0` is ignored. Diagnosis and
+  measurements:
   Lucas Gillingham (ClickSentinel). See
   `notes/ABLETON-WINE-GPU-RENDERER.md`.

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -49,5 +49,6 @@ f4d4f0cecbc8a39bbaeb6faaf416d032ee934e7ed8420aa168b39b3c42f9dd58  0049-win32u-dr
 38eb5e1c43a521eea78308bfe1e2d1d662b287eca888660acc615819aa707d84  0051-win32u-include-the-non-client-area-in-setsyscolors.patch
 f278d870c0424748a9d7a7cd5a6e9feb0837900e6382f4ee9d7cfe214c0b9fd5  0052-win32u-hide-the-menu-bar-alt-key-mnemonic-underline.patch
 d32ac8ca55853e5488292d015e35a31d23744150e04af476742e781b58abc186  0053-winex11-export-the-app-minimum-tracking-size-as-PMin.patch
+71cd8a8bcb9bfab7873502cf7417602a7e8eb6b0ad34d5c9f7183344256ba5c3  0055-dxgi-prefer-GL-present-for-top-level-swapchain-devic.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -49,6 +49,6 @@ f4d4f0cecbc8a39bbaeb6faaf416d032ee934e7ed8420aa168b39b3c42f9dd58  0049-win32u-dr
 38eb5e1c43a521eea78308bfe1e2d1d662b287eca888660acc615819aa707d84  0051-win32u-include-the-non-client-area-in-setsyscolors.patch
 f278d870c0424748a9d7a7cd5a6e9feb0837900e6382f4ee9d7cfe214c0b9fd5  0052-win32u-hide-the-menu-bar-alt-key-mnemonic-underline.patch
 d32ac8ca55853e5488292d015e35a31d23744150e04af476742e781b58abc186  0053-winex11-export-the-app-minimum-tracking-size-as-PMin.patch
-71cd8a8bcb9bfab7873502cf7417602a7e8eb6b0ad34d5c9f7183344256ba5c3  0055-dxgi-prefer-GL-present-for-top-level-swapchain-devic.patch
+5c97ce27e69ea1caffef5197a8e0f19893829c1c868e06c89e660352ad2919a1  0055-dxgi-prefer-GL-present-for-top-level-swapchain-devic.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -71,6 +71,7 @@ extras="$(cd "$root/patches" && ls 00*.patch pipeasio/*.patch 2>/dev/null | grep
 declare -A SERIES_GAPS=(
     [0027]="retired 2026-07-14 — gitignore housekeeping, no artifact effect"
     [0044]="reserved 2026-07-24 for the issue 57 parked-pane reblit gate; entry harmless once 0044 lands"
+    [0054]="reserved 2026-07-29 for PR 77's language-fallback font patch; entry harmless once 0054 lands"
 )
 seq_expect=1
 for f in $(awk '{print $2}' "$SERIES" | grep -v '^pipeasio/' | sort); do
@@ -127,6 +128,7 @@ FINGERPRINTS='
 0043|ascii|lib/wine/x86_64-unix/comdlg32.so|org.freedesktop.portal.OpenURI
 0043|ascii|lib/wine/x86_64-windows/shell32.dll|__wine_portal_show_item
 0045|ascii|lib/wine/x86_64-windows/ole32.dll|revoke for another process windows is disabled
+0055|wide|lib/wine/x86_64-windows/dxgi.dll|WINE_DISABLE_GL_PRESENT
 pipeasio/0001|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-clamp-sample-rate
 pipeasio/0002|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-midi-timebase
 '


### PR DESCRIPTION
WIP PR for patch `0055` based on investigations by @ClickSentinel.

So from what I understand, `wined3d` displays every frame of Live's main window through GDI. 

So this bug copies the finished frame from the graphics card into main memory and sent it to the display server as a full-window image, which is like 600mb per second during continuous UI activity. 

This patch sets `WINED3D_SWAPCHAIN_PREFER_GL_PRESENT` when a top-level window's frame buffers are created, so `wined3d` shows each frame directly from the graphics card with `glXSwapBuffers`. 

`WS_CHILD` and `WS_POPUP` windows keep the GDI path. `WINE_DISABLE_GL_PRESENT=1` restores the GDI path for every window.

Please test!