### PR TITLE
fix/dcomp reblit visibility gate

### DIFF
--- a/patches/0056-dxgi-gate-parked-dcomp-reblits-on-window-visibility.patch
+++ b/patches/0056-dxgi-gate-parked-dcomp-reblits-on-window-visibility.patch
@@ -1,0 +1,61 @@
+Subject: dxgi: gate parked dcomp reblits on window visibility (issue 57)
+
+Closing a WebView2 pane (e.g. Live's Learn View) does not tear the
+WebView2 stack down — Live parks it for reuse by reparenting the pane
+chain under a hidden helper toplevel. The composition target window
+this file subclasses stays alive too: still WS_VISIBLE, still the old
+pane size, swapchain and comp buffer untouched. Neither of
+dcomp_reblit_comp_buffer's liveness signals fires for a parked target
+— it never receives WM_NCDESTROY, and dcomp_comp_buffer_current()
+still reports the buffer current since nothing ever resizes it — so
+the steady reblit patch 0041 relies on to pin the composite above the
+sibling Chrome_RenderWidgetHostHWND software frame keeps stamping the
+last frame into the now-dead pane rect at the timer cadence, fighting
+whatever Live's own UI paints there instead. The result is a
+persistent flicker in the closed pane's rectangle that outlives the
+close and needs a Live restart to clear (issue 57).
+
+IsWindowVisible() walks the ancestor chain, so it is the right
+discriminator: a parked pane (hidden ancestors) reports FALSE while an
+open pane (whole chain WS_VISIBLE) keeps the always-reblit behaviour
+0041 needs. Minimized host windows keep WS_VISIBLE — iconizing a
+window does not clear it — so minimize/restore is unaffected. No
+re-arm is needed either: the timer keeps running, and reblits resume
+by themselves once Live reparents the pane chain back into a visible
+ancestor on reopen.
+
+diff --git a/dlls/dxgi/factory.c b/dlls/dxgi/factory.c
+index 1111111..2222222 100644
+--- a/dlls/dxgi/factory.c
++++ b/dlls/dxgi/factory.c
+@@ -493,6 +493,30 @@ static void dcomp_reblit_comp_buffer(HWND hwnd, const char *reason)
+ {
+     HDC comp_dc = (HDC)GetPropW(hwnd, L"__wine_dcomp_comp_dc");
+     LPARAM dims = (LPARAM)GetPropW(hwnd, L"__wine_dcomp_comp_size");
++
++    /* Parked targets must not be re-blitted (issue 57). A closed-but-parked
++     * WebView2 pane keeps its whole browser stack alive for reuse: Live
++     * reparents the pane chain under a hidden helper toplevel, but this
++     * target window stays WS_VISIBLE at the old pane size, and neither
++     * liveness signal above fires (no WM_NCDESTROY, buffer still "current"
++     * since nothing resizes it) — so without this gate the reblit below
++     * keeps stamping the last frame into the dead pane rect at the timer
++     * cadence forever, fighting the app's own repaints (XDamage-verified
++     * 5 Hz flicker that outlives the close). IsWindowVisible() walks the
++     * ancestor chain, so a parked pane (hidden ancestors) reports FALSE
++     * while an open pane (whole chain WS_VISIBLE) keeps the always-reblit
++     * 0041 needs. Minimized host windows keep WS_VISIBLE (iconizing does
++     * not clear it), so minimize/restore is unaffected; reblits resume by
++     * themselves, no re-arm needed, once Live reparents the pane back into
++     * a visible ancestor on reopen. */
++    if (!IsWindowVisible(hwnd))
++    {
++        static unsigned int hidden_count;
++        ++hidden_count;
++        if (hidden_count <= 3 || !(hidden_count % 500))
++            FIXME("Re-blit skipped (hidden ancestry): hwnd %p reason=%s.\n", hwnd, reason);
++        return;
++    }
+ 
+     if (comp_dc && dims)
+     {

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -49,5 +49,6 @@ f4d4f0cecbc8a39bbaeb6faaf416d032ee934e7ed8420aa168b39b3c42f9dd58  0049-win32u-dr
 38eb5e1c43a521eea78308bfe1e2d1d662b287eca888660acc615819aa707d84  0051-win32u-include-the-non-client-area-in-setsyscolors.patch
 f278d870c0424748a9d7a7cd5a6e9feb0837900e6382f4ee9d7cfe214c0b9fd5  0052-win32u-hide-the-menu-bar-alt-key-mnemonic-underline.patch
 d32ac8ca55853e5488292d015e35a31d23744150e04af476742e781b58abc186  0053-winex11-export-the-app-minimum-tracking-size-as-PMin.patch
+11dbb4c36378fc274e8eaa281e9bfbe43835bd0fae2682924d19aee318b673bb  0056-dxgi-gate-parked-dcomp-reblits-on-window-visibility.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -70,7 +70,9 @@ extras="$(cd "$root/patches" && ls 00*.patch pipeasio/*.patch 2>/dev/null | grep
 # titles and notes/); a gap is fine if documented here, a dropped patch is not.
 declare -A SERIES_GAPS=(
     [0027]="retired 2026-07-14 — gitignore housekeeping, no artifact effect"
-    [0044]="reserved 2026-07-24 for the issue 57 parked-pane reblit gate; entry harmless once 0044 lands"
+    [0044]="reserved 2026-07-24 for the issue 57 parked-pane reblit gate; shipped as 0056 instead"
+    [0054]="reserved 2026-07-29 for PR 77's language-fallback font patch"
+    [0055]="reserved 2026-07-29 for PR 94's GL-present patch"
 )
 seq_expect=1
 for f in $(awk '{print $2}' "$SERIES" | grep -v '^pipeasio/' | sort); do
@@ -168,6 +170,7 @@ STAMP_ONLY='
 0050|logic-only (per-process sys-color cache reset on WM_SYSCOLORCHANGE; no new string literal)
 0051|logic-only (RDW_FRAME added to the SetSysColors redraw flags; no new string literal)
 0052|logic-only (DT_HIDEPREFIX on the menu bar DrawTextW call; no new string literal)
+0056|ascii|lib/wine/x86_64-windows/dxgi.dll|Re-blit skipped (hidden ancestry)
 0053|logic-only (WM_GETMINMAXINFO minimum exported as PMinSize hints; no new string literal)
 '
 wide_pattern() {  # ascii string -> PCRE matching its UTF-16LE bytes


### PR DESCRIPTION
Fixes #57 — closing the Learn View leaves a permanent flicker in the region the pane occupied.

## The bug

Live parks the WebView2 stack for reuse instead of tearing it down: the pane chain is reparented under a hidden helper toplevel, while the composition target window stays `WS_VISIBLE` at the old pane size. jttdev's report has the `hwndspy` dump.

Nothing signals the close to Wine — no `WM_NCDESTROY`, and the comp buffer still passes 0030's currency check because nothing resized it. So the idle reblit keeps stamping the last frame into the dead pane rect at timer cadence, fighting Live's own repaints. That alternation is the flicker.

## The fix

Gate `dcomp_reblit_comp_buffer()` on `IsWindowVisible()` — one condition, one early return.

`IsWindowVisible()` walks the ancestor chain rather than testing a single style bit, which is what makes it work here: a parked pane has hidden ancestors and reports `FALSE`, an open pane has a fully visible chain and keeps 0041's always-reblit behaviour. Minimising doesn't clear `WS_VISIBLE`, so minimise/restore is unaffected, and reblits resume on reopen with no re-arm.

**Known limit** (raised by @giang17, who maintains this function upstream): the gate stops the *stamping*, not the *stamp*. The last frame stays in the host surface until the app repaints that region. Live repaints its full client area continuously so it's overwritten immediately — but an app that only repaints damaged regions would keep it as a fossil. He fixed that case content-side upstream, in commits not present in our 11.13 base.

## Numbering

Landed as 0056: `0054` is reserved for PR #77 and `0055` is PR #94. Both are documented in the audit's `SERIES_GAPS` table so the numbering check passes while they're in review, and the `0044` entry now points at 0056.

## Testing

With the GPU renderer enabled (no `-_ForceGdiBackend` in `Options.txt`): open the Learn View, close it, watch the region it occupied. Before, the last frame alternates with Live's UI indefinitely. After, it's just Live's UI.

To confirm the gate fires — the launcher sets `WINEDEBUG=-all`, so pass it explicitly or the log is empty:

```bash
WINEDEBUG=fixme+all,err+all ableton-live > log 2>&1
grep -c "Re-blit skipped (hidden ancestry)" log
```

Verified on Live 12.4.3 Suite, WebView2 150.0.4078.105, AMD Navi 31, COSMIC/Wayland via XWayland. All 52 patches apply cleanly to a fresh 11.13 base; build and audit pass.
