### PR TITLE
release: accept a hand-written summary via --notes-file

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,6 +2,13 @@
 # Publish the current VERSION as a GitHub release.
 #
 #   GH_TOKEN=<fine-grained PAT, contents read/write> ./scripts/release.sh
+#   GH_TOKEN=... ./scripts/release.sh --notes-file notes.md
+#
+# --notes-file takes a hand-written markdown summary of the release and puts
+# it at the top of the release body, above the install instructions and build
+# provenance the workflow generates. The file is read at publish time and is
+# not committed anywhere; write it wherever is convenient. Without the flag
+# the body is exactly what the workflow drafted, as before.
 #
 # Verifies the locally built dist/ artifacts, pushes the v<VERSION> tag (the
 # release workflow then drafts the release with notes from BUILD-INFO),
@@ -14,6 +21,16 @@ set -euo pipefail
 here="$(cd "$(dirname "$0")" && pwd)"
 root="$(cd "$here/.." && pwd)"
 cd "$root"
+
+notes=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --notes-file)
+            [ $# -ge 2 ] || { echo "!! --notes-file needs a path" >&2; exit 1; }
+            notes="$2"; shift 2 ;;
+        *) echo "!! unknown argument: $1 (see the header of $0)" >&2; exit 1 ;;
+    esac
+done
 
 NAME="wine-d2d1-nspa-11.13"
 VERSION="$(cat VERSION)"
@@ -30,6 +47,11 @@ api="https://api.github.com/repos/$repo"
 gh_api() { curl -fsS -H "Authorization: Bearer $token" -H "Accept: application/vnd.github+json" "$@"; }
 
 echo "== [0/4] verify the $VERSION artifacts =="
+# fail on a bad --notes-file now, not after the tag is pushed and 112M uploaded
+if [ -n "$notes" ]; then
+    [ -f "$notes" ] || { echo "!! no such notes file: $notes" >&2; exit 1; }
+    grep -q '[^[:space:]]' "$notes" || { echo "!! notes file is empty: $notes" >&2; exit 1; }
+fi
 for f in "$run" "$run.sha256" "$tarball" "$tarball.sha256" "$info"; do
     [ -f "$f" ] || { echo "!! missing $f: run ./build.sh and ./scripts/make-installer.sh first" >&2; exit 1; }
 done
@@ -77,7 +99,21 @@ for f in "$run" "$run.sha256" "$tarball" "$tarball.sha256" "$info" \
 done
 
 echo "== [4/4] publish =="
-gh_api -X PATCH "$api/releases/$rid" -d '{"draft": false}' >/dev/null
+if [ -n "$notes" ]; then
+    # Strip any block an earlier run left, so re-running after a failed upload
+    # replaces the summary rather than stacking a second copy. The second sed
+    # drops the blank line that block leaves behind, which would otherwise add
+    # a line to the body on every run.
+    body="$(gh_api "$api/releases/$rid" | jq -r '.body // ""' \
+        | sed '/<!-- release-notes:start -->/,/<!-- release-notes:end -->/d' \
+        | sed '/./,$!d')"
+    jq -n --rawfile n "$notes" --arg b "$body" \
+        '{body: ("<!-- release-notes:start -->\n" + $n
+                 + "\n<!-- release-notes:end -->\n\n" + $b), draft: false}' \
+        | gh_api -X PATCH "$api/releases/$rid" -d @- >/dev/null
+else
+    gh_api -X PATCH "$api/releases/$rid" -d '{"draft": false}' >/dev/null
+fi
 echo
 echo "OK: https://github.com/$repo/releases/tag/$TAG"
 echo "Latest installer: https://github.com/$repo/releases/latest/download/install-ableton-latest.run"


### PR DESCRIPTION
The release body was entirely generated: the workflow drafts it from a fixed template plus BUILD-INFO, so anything specific to a release had to be typed into the GitHub web UI after publishing.

--notes-file takes a markdown file and puts it at the top of the body, above the generated install instructions and build provenance. It is read at publish time and committed nowhere, so drafting it needs no particular location or ceremony. Without the flag the body is unchanged.

A bad or empty path fails in step 0, before the tag is pushed and the assets are uploaded, rather than after. The summary is delimited with HTML comments and stripped before being re-added, so re-running after a failed upload replaces it instead of appending a second copy.

Verified against a throwaway draft release seeded with a real generated body: GitHub accepts the request, the summary lands above the generated tail, and three consecutive runs leave a byte-identical body.