### PR TITLE
Identify Intel GPUs properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Live's GPU renderer is available again on Intel graphics newer than 2019
+  (issue 84, Wine patch 0057). Wine reported every Intel GPU from Ice Lake
+  through Lunar Lake, and the Arc A-series cards, as "Intel(R) HD Graphics
+  4000", a 2012 device that Live refuses to use, so the Preferences dialog
+  greyed out "Enable GPU Renderer". Wine now reports the real device names.
+  Reported by stickyfran.
+
 ## 2026.07.29.1
 
 - Live now uses its GPU renderer. Prefix setup removes the legacy

--- a/notes/ABLETON-WINE-GPU-RENDERER.md
+++ b/notes/ABLETON-WINE-GPU-RENDERER.md
@@ -170,12 +170,44 @@ measurement. With 0059 there is nothing to trade: the bar is gone and
 the direct path survives. 0058 stays in as the safety net, silent, and
 as the assertion that the two contexts now agree.
 
+## Device identification (added 2026-07-30, updated 2026-08-01, issue 84)
+
+Live checks the graphics card before it enables the GPU renderer. It
+reads the device name and PCI ID that wined3d reports, and wined3d
+takes both from a device table. A card missing from that table is
+reported as "Intel(R) HD Graphics 4000", a 2012 device that Live
+rejects. On such a machine Preferences > Display & Input greys out
+"Enable GPU Renderer" with the reason text "Intel(R) HD Graphics
+4000: Unexplained slow UI at zoom-level 100% and/or crashes", and
+nothing else in this note applies.
+
+The table ended at 2018's Coffee Lake, plus one Battlemage entry from
+patch 0035. Wine patch 0057 adds the families from Ice Lake through
+Lunar Lake and the Arc A-series cards, so Live sees a current device
+name and its own check passes. Confirmed on issue 84's Meteor Lake
+laptop 2026-07-30: stickyfran built this branch and the GPU renderer
+enabled (issue 84 comments).
+
+Patch 0061 covers devices missing from the table by synthesising the
+description from the driver's own renderer string. That is not enough
+for Meteor Lake: the synthesised name, "Intel(R) Arc(tm) Graphics", is
+the device's real Windows name, and a build with 0061 alone stayed
+greyed out on the same laptop (PR 105 comments, 2026-07-31). A table
+entry takes precedence over 0061, and the "(MTL)" suffix in 0057's
+entry is what passes Live's check. A traced launch from that machine
+confirming the exact rejected name is still open.
+
+To check a machine: open Preferences > Display & Input. "Enable GPU
+Renderer" must be a switch, not greyed out with the HD 4000 reason
+text.
+
 ## Related
 
 - [Diagnosis narrative](ABLETON-WINE-GPU-RENDERER-WEBVIEW2-DIAGNOSIS.md)
 - [Learn View flicker mechanism](ABLETON-WINE-LEARNVIEW-FLICKER.md)
 - [Patch 0053](../patches/0053-winex11-export-the-app-minimum-tracking-size-as-PMin.patch)
 - [Patch 0055](../patches/0055-dxgi-prefer-GL-present-for-top-level-swapchain-devic.patch)
+- [Patch 0057](../patches/0057-wined3d-add-Intel-graphics-devices-from-Ice-Lake-to-.patch)
 - Resize trace from the diagnosis session:
   `~/Projects/Code/ableton/live-resize-trace-gpu-20260727.log`
   (machine-local)

--- a/patches/0057-wined3d-add-Intel-graphics-devices-from-Ice-Lake-to-.patch
+++ b/patches/0057-wined3d-add-Intel-graphics-devices-from-Ice-Lake-to-.patch
@@ -1,0 +1,174 @@
+Subject: wined3d: add Intel graphics devices from Ice Lake to Lunar
+ Lake
+
+The GPU description table ends at Coffee Lake (UHD Graphics 630), plus
+the single Battlemage entry from patch 0035. Every Intel GPU released
+since 2019 is missing: the processor graphics families from Ice Lake
+through Lunar Lake, and the Arc A-series cards. wined3d reports all of
+them through the generic Intel fallback, "Intel(R) HD Graphics 4000".
+Ableton Live 12 blacklists that description by name ("Unexplained slow
+UI at zoom-level 100% and/or crashes"), marks its GPU renderer as not
+available, and drops to the slow GDI renderer.
+
+Mesa reports the real PCI ID through its query-renderer extension, so
+one description entry per device ID is enough; the renderer-string
+guessing tables are not involved. Add the mainstream device IDs of
+each family, taken from the pci.ids database. A device that is not
+listed keeps the old fallback until an entry is added for it.
+
+Like the other post-HD4000 Intel entries the cards reuse
+DRIVER_INTEL_HD4000; this tree has no newer Intel driver class. The
+video-memory values only matter when the driver does not report the
+real amount, which Mesa does.
+
+Origin: local fix for issue #84 (Meteor Lake Arc graphics on a Core
+Ultra 7 155H misidentified as HD Graphics 4000, Live's GPU renderer
+unavailable). Should also be upstreamed to Wine.
+---
+ dlls/wined3d/directx.c         | 68 ++++++++++++++++++++++++++++++++++
+ dlls/wined3d/wined3d_private.h | 53 ++++++++++++++++++++++++++
+ 2 files changed, 121 insertions(+)
+
+diff --git a/dlls/wined3d/directx.c b/dlls/wined3d/directx.c
+index 3cc5e3f..0decb19 100644
+--- a/dlls/wined3d/directx.c
++++ b/dlls/wined3d/directx.c
+@@ -666,6 +666,74 @@ static const struct wined3d_gpu_description gpu_description_table[] =
+     {HW_VENDOR_INTEL,      CARD_INTEL_HD630_2,             "Intel(R) HD Graphics 630",                                  DRIVER_INTEL_HD4000,  3072},
+     {HW_VENDOR_INTEL,      CARD_INTEL_UHD630_1,            "Intel(R) UHD Graphics 630",                                 DRIVER_INTEL_HD4000,  3072},
+     {HW_VENDOR_INTEL,      CARD_INTEL_UHD630_2,            "Intel(R) UHD Graphics 630",                                 DRIVER_INTEL_HD4000,  3072},
++    /* Ice Lake and newer. Without an entry here wined3d reports these
++     * devices through the generic Intel fallback ("Intel(R) HD Graphics
++     * 4000"), which Ableton Live 12 blacklists by name, disabling its
++     * GPU renderer (issue 84). */
++    /* Ice Lake */
++    {HW_VENDOR_INTEL,      CARD_INTEL_ICL_1,               "Intel(R) Iris(R) Plus Graphics (ICL)",                      DRIVER_INTEL_HD4000,  2048},
++    {HW_VENDOR_INTEL,      CARD_INTEL_ICL_2,               "Intel(R) Iris(R) Plus Graphics (ICL)",                      DRIVER_INTEL_HD4000,  2048},
++    /* Comet Lake */
++    {HW_VENDOR_INTEL,      CARD_INTEL_CMLU,                "Intel(R) UHD Graphics (CML-U)",                             DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_CMLH,                "Intel(R) UHD Graphics (CML-H)",                             DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_CMLS_1,              "Intel(R) UHD Graphics 630 (CML-S)",                         DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_CMLS_2,              "Intel(R) UHD Graphics 630 (CML-S)",                         DRIVER_INTEL_HD4000,  3072},
++    /* Tiger Lake */
++    {HW_VENDOR_INTEL,      CARD_INTEL_TGL_1,               "Intel(R) Iris(R) Xe Graphics (TGL)",                        DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_TGL_2,               "Intel(R) Iris(R) Xe Graphics (TGL)",                        DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_TGL_3,               "Intel(R) UHD Graphics (TGL-H)",                             DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_TGL_4,               "Intel(R) UHD Graphics (TGL-H)",                             DRIVER_INTEL_HD4000,  3072},
++    /* Rocket Lake */
++    {HW_VENDOR_INTEL,      CARD_INTEL_RKLS_1,              "Intel(R) UHD Graphics 750 (RKL-S)",                         DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_RKLS_2,              "Intel(R) UHD Graphics 730 (RKL-S)",                         DRIVER_INTEL_HD4000,  3072},
++    /* DG1 */
++    {HW_VENDOR_INTEL,      CARD_INTEL_DG1_1,               "Intel(R) Iris(R) Xe MAX Graphics (DG1)",                    DRIVER_INTEL_HD4000,  4096},
++    {HW_VENDOR_INTEL,      CARD_INTEL_DG1_2,               "Intel(R) Iris(R) Xe Graphics (DG1)",                        DRIVER_INTEL_HD4000,  4096},
++    /* Alder Lake */
++    {HW_VENDOR_INTEL,      CARD_INTEL_ADLS_1,              "Intel(R) UHD Graphics 770 (ADL-S)",                         DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_ADLS_2,              "Intel(R) UHD Graphics 730 (ADL-S)",                         DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_ADLHX,               "Intel(R) UHD Graphics 770 (ADL-HX)",                        DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_ADLS_3,              "Intel(R) UHD Graphics 770 (ADL-S)",                         DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_ADLS_4,              "Intel(R) UHD Graphics 730 (ADL-S)",                         DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_ADLS_5,              "Intel(R) UHD Graphics 710 (ADL-S)",                         DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_ADLP_1,              "Intel(R) Iris(R) Xe Graphics (ADL-P)",                      DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_ADLP_2,              "Intel(R) Iris(R) Xe Graphics (ADL-P)",                      DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_ADLP_3,              "Intel(R) Iris(R) Xe Graphics (ADL-P)",                      DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_ADLN_1,              "Intel(R) UHD Graphics (ADL-N)",                             DRIVER_INTEL_HD4000,  2048},
++    {HW_VENDOR_INTEL,      CARD_INTEL_ADLN_2,              "Intel(R) UHD Graphics (ADL-N)",                             DRIVER_INTEL_HD4000,  2048},
++    {HW_VENDOR_INTEL,      CARD_INTEL_ADLN_3,              "Intel(R) UHD Graphics (ADL-N)",                             DRIVER_INTEL_HD4000,  2048},
++    /* Raptor Lake */
++    {HW_VENDOR_INTEL,      CARD_INTEL_RPLP_1,              "Intel(R) UHD Graphics (RPL-P)",                             DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_RPLP_2,              "Intel(R) UHD Graphics (RPL-P)",                             DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_RPLS,                "Intel(R) UHD Graphics 770 (RPL-S)",                         DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_RPLP_3,              "Intel(R) Iris(R) Xe Graphics (RPL-P)",                      DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_RPLP_4,              "Intel(R) Iris(R) Xe Graphics (RPL-P)",                      DRIVER_INTEL_HD4000,  3072},
++    /* Arc A-series (Alchemist) */
++    {HW_VENDOR_INTEL,      CARD_INTEL_A770M,               "Intel(R) Arc(tm) A770M Graphics (DG2)",                     DRIVER_INTEL_HD4000,  16384},
++    {HW_VENDOR_INTEL,      CARD_INTEL_A730M,               "Intel(R) Arc(tm) A730M Graphics (DG2)",                     DRIVER_INTEL_HD4000,  12288},
++    {HW_VENDOR_INTEL,      CARD_INTEL_A550M,               "Intel(R) Arc(tm) A550M Graphics (DG2)",                     DRIVER_INTEL_HD4000,  8192},
++    {HW_VENDOR_INTEL,      CARD_INTEL_A370M,               "Intel(R) Arc(tm) A370M Graphics (DG2)",                     DRIVER_INTEL_HD4000,  4096},
++    {HW_VENDOR_INTEL,      CARD_INTEL_A350M,               "Intel(R) Arc(tm) A350M Graphics (DG2)",                     DRIVER_INTEL_HD4000,  4096},
++    {HW_VENDOR_INTEL,      CARD_INTEL_A770,                "Intel(R) Arc(tm) A770 Graphics (DG2)",                      DRIVER_INTEL_HD4000,  16384},
++    {HW_VENDOR_INTEL,      CARD_INTEL_A750,                "Intel(R) Arc(tm) A750 Graphics (DG2)",                      DRIVER_INTEL_HD4000,  8192},
++    {HW_VENDOR_INTEL,      CARD_INTEL_A580,                "Intel(R) Arc(tm) A580 Graphics (DG2)",                      DRIVER_INTEL_HD4000,  8192},
++    {HW_VENDOR_INTEL,      CARD_INTEL_A380,                "Intel(R) Arc(tm) A380 Graphics (DG2)",                      DRIVER_INTEL_HD4000,  6144},
++    {HW_VENDOR_INTEL,      CARD_INTEL_A310,                "Intel(R) Arc(tm) A310 Graphics (DG2)",                      DRIVER_INTEL_HD4000,  4096},
++    /* Meteor Lake */
++    {HW_VENDOR_INTEL,      CARD_INTEL_MTL_1,               "Intel(R) Graphics (MTL)",                                   DRIVER_INTEL_HD4000,  4096},
++    {HW_VENDOR_INTEL,      CARD_INTEL_MTL_2,               "Intel(R) Graphics (MTL)",                                   DRIVER_INTEL_HD4000,  4096},
++    {HW_VENDOR_INTEL,      CARD_INTEL_MTL_ARC,             "Intel(R) Arc(tm) Graphics (MTL)",                           DRIVER_INTEL_HD4000,  4096},
++    {HW_VENDOR_INTEL,      CARD_INTEL_MTL_3,               "Intel(R) Graphics (MTL)",                                   DRIVER_INTEL_HD4000,  4096},
++    {HW_VENDOR_INTEL,      CARD_INTEL_MTL_4,               "Intel(R) Graphics (MTL)",                                   DRIVER_INTEL_HD4000,  4096},
++    /* Arrow Lake */
++    {HW_VENDOR_INTEL,      CARD_INTEL_ARLU,                "Intel(R) Graphics (ARL-U)",                                 DRIVER_INTEL_HD4000,  4096},
++    {HW_VENDOR_INTEL,      CARD_INTEL_ARLP_ARC,            "Intel(R) Arc(tm) Graphics (ARL-P)",                         DRIVER_INTEL_HD4000,  4096},
++    {HW_VENDOR_INTEL,      CARD_INTEL_ARLS,                "Intel(R) Graphics (ARL-S)",                                 DRIVER_INTEL_HD4000,  4096},
++    {HW_VENDOR_INTEL,      CARD_INTEL_ARLP,                "Intel(R) Graphics (ARL-P)",                                 DRIVER_INTEL_HD4000,  4096},
++    /* Lunar Lake */
++    {HW_VENDOR_INTEL,      CARD_INTEL_LNL_1,               "Intel(R) Graphics (LNL)",                                   DRIVER_INTEL_HD4000,  4096},
++    {HW_VENDOR_INTEL,      CARD_INTEL_LNL_ARC,             "Intel(R) Arc(tm) Graphics 130V/140V (LNL)",                 DRIVER_INTEL_HD4000,  4096},
++    {HW_VENDOR_INTEL,      CARD_INTEL_LNL_2,               "Intel(R) Graphics (LNL)",                                   DRIVER_INTEL_HD4000,  4096},
+     /* Battlemage G21. Without this entry the card is reported through the
+      * generic Intel fallback ("Intel(R) HD Graphics 4000"), which Ableton
+      * Live 12 blacklists by name, disabling its GPU renderer. */
+diff --git a/dlls/wined3d/wined3d_private.h b/dlls/wined3d/wined3d_private.h
+index 6aa4ebb..21c4adc 100644
+--- a/dlls/wined3d/wined3d_private.h
++++ b/dlls/wined3d/wined3d_private.h
+@@ -2451,6 +2451,59 @@ enum wined3d_pci_device
+     CARD_INTEL_HD630_2              = 0x591b,
+     CARD_INTEL_UHD630_1             = 0x3e9b,
+     CARD_INTEL_UHD630_2             = 0x3e91,
++    CARD_INTEL_ICL_1                = 0x8a51,
++    CARD_INTEL_ICL_2                = 0x8a52,
++    CARD_INTEL_CMLU                 = 0x9b41,
++    CARD_INTEL_CMLH                 = 0x9bc4,
++    CARD_INTEL_CMLS_1               = 0x9bc5,
++    CARD_INTEL_CMLS_2               = 0x9bc8,
++    CARD_INTEL_TGL_1                = 0x9a40,
++    CARD_INTEL_TGL_2                = 0x9a49,
++    CARD_INTEL_TGL_3                = 0x9a60,
++    CARD_INTEL_TGL_4                = 0x9a68,
++    CARD_INTEL_RKLS_1               = 0x4c8a,
++    CARD_INTEL_RKLS_2               = 0x4c8b,
++    CARD_INTEL_DG1_1                = 0x4905,
++    CARD_INTEL_DG1_2                = 0x4908,
++    CARD_INTEL_ADLS_1               = 0x4680,
++    CARD_INTEL_ADLS_2               = 0x4682,
++    CARD_INTEL_ADLHX                = 0x4688,
++    CARD_INTEL_ADLS_3               = 0x4690,
++    CARD_INTEL_ADLS_4               = 0x4692,
++    CARD_INTEL_ADLS_5               = 0x4693,
++    CARD_INTEL_ADLP_1               = 0x46a6,
++    CARD_INTEL_ADLP_2               = 0x46a8,
++    CARD_INTEL_ADLP_3               = 0x46aa,
++    CARD_INTEL_ADLN_1               = 0x46d0,
++    CARD_INTEL_ADLN_2               = 0x46d1,
++    CARD_INTEL_ADLN_3               = 0x46d2,
++    CARD_INTEL_RPLP_1               = 0xa720,
++    CARD_INTEL_RPLP_2               = 0xa721,
++    CARD_INTEL_RPLS                 = 0xa780,
++    CARD_INTEL_RPLP_3               = 0xa7a0,
++    CARD_INTEL_RPLP_4               = 0xa7a1,
++    CARD_INTEL_A770M                = 0x5690,
++    CARD_INTEL_A730M                = 0x5691,
++    CARD_INTEL_A550M                = 0x5692,
++    CARD_INTEL_A370M                = 0x5693,
++    CARD_INTEL_A350M                = 0x5694,
++    CARD_INTEL_A770                 = 0x56a0,
++    CARD_INTEL_A750                 = 0x56a1,
++    CARD_INTEL_A580                 = 0x56a2,
++    CARD_INTEL_A380                 = 0x56a5,
++    CARD_INTEL_A310                 = 0x56a6,
++    CARD_INTEL_MTL_1                = 0x7d40,
++    CARD_INTEL_MTL_2                = 0x7d45,
++    CARD_INTEL_MTL_ARC              = 0x7d55,
++    CARD_INTEL_MTL_3                = 0x7d60,
++    CARD_INTEL_MTL_4                = 0x7dd5,
++    CARD_INTEL_ARLU                 = 0x7d41,
++    CARD_INTEL_ARLP_ARC             = 0x7d51,
++    CARD_INTEL_ARLS                 = 0x7d67,
++    CARD_INTEL_ARLP                 = 0x7dd1,
++    CARD_INTEL_LNL_1                = 0x6420,
++    CARD_INTEL_LNL_ARC              = 0x64a0,
++    CARD_INTEL_LNL_2                = 0x64b0,
+     CARD_INTEL_BMG_G21              = 0xe20b,
+ };
+ 

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -11,8 +11,8 @@ narrative — 5 merge conflicts, three build breaks the clean rebase didn't
 catch, a build.sh/pipefail tooling gotcha — is in
 `notes/ABLETON-WINE-11.11-TO-11.13-BASE-BUMP.md`.
 
-The current Wine series contains 59 files, numbered 0001 through 0062.
-Patches 0027, 0044, and 0057 are intentionally absent.
+The current Wine series contains 60 files, numbered 0001 through 0062.
+Patches 0027 and 0044 are intentionally absent.
 
 ## Applying the series
 
@@ -92,8 +92,8 @@ Apply them in sequence with the rest of the series.
   portal. Wine Explorer remains the fallback when the portal or policy refuses
   the request. Mailbox commit: `996524ab`. See
   `notes/ABLETON-WINE-SHOW-IN-EXPLORER.md`.
-- `0044`: reserved for the issue 57 parked-pane reblit work. No patch file is
-  shipped.
+- `0044`: reserved for the issue 57 parked-pane reblit work, which shipped
+  as patch 0056 instead. No patch file is shipped under this number.
 - `0045`: reject `RevokeDragDrop` for a window owned by another process. This
   prevents a foreign-process drop-target pointer from crashing Live when a
   WebView2 plugin editor closes. Ported from `giang17/wine` commit
@@ -182,8 +182,17 @@ Apply them in sequence with the rest of the series.
 - `0056`: gate parked DirectComposition reblits on window visibility.
   A parked WebView2 composition target kept stamping its stale
   composite over live siblings (issue 57).
-- `0057`: reserved for the Intel GPU identification work on the
-  `fix/intel-gpu` branch. No patch file is shipped here yet.
+- `0057`: identify Intel GPUs from Ice Lake through Lunar Lake, plus the
+  Arc A-series cards. Without an entry wined3d reports each of them as
+  "Intel(R) HD Graphics 4000", which Live 12 rejects for D3D11, exactly
+  as 0035 describes for Battlemage. Device IDs come from the pci.ids
+  database; devices still missing fall through to 0061's synthesised
+  description instead. A table entry takes precedence over 0061, and for
+  Meteor Lake it has to: 0061 synthesises the device's real Windows
+  name, "Intel(R) Arc(tm) Graphics", and a 0061-only build stayed
+  greyed out on the issue 84 machine (PR 105 comments, 2026-07-31). The
+  "(MTL)" suffix in the table name is what passes Live's check. See
+  issue 84 and `notes/ABLETON-WINE-GPU-RENDERER.md`.
 - `0058`: fall back to the GDI present path for any frame whose
   present-time client rect disagrees with the captured destination
   rect. The direct GL path (0055) y-flips against a client rect
@@ -214,6 +223,6 @@ Apply them in sequence with the rest of the series.
   winex11's offscreen-composited path. The Live launcher selects
   `Ableton Live Window Class`, preventing M4L child visibility from
   unmapping and reparenting the full Live client when track selection
-  changes. Was proposed as 0057 on PR 88; renumbered, 0057 stays
-  reserved for `fix/intel-gpu`. See
+  changes. Was proposed as 0057 on PR 88; renumbered, and 0057 went to
+  the Intel GPU identification work it was reserved for. See
   `notes/ABLETON-WINE-M4L-SELECTION-FLICKER.md`.

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -52,6 +52,7 @@ d32ac8ca55853e5488292d015e35a31d23744150e04af476742e781b58abc186  0053-winex11-e
 95bb7c7bce42a4d010eb4c0c0232bf65b9165860d3782f4753efb2398d7caaa2  0054-win32u-fall-back-to-a-linked-font-for-missing-glyph.patch
 5c97ce27e69ea1caffef5197a8e0f19893829c1c868e06c89e660352ad2919a1  0055-dxgi-prefer-GL-present-for-top-level-swapchain-devic.patch
 11dbb4c36378fc274e8eaa281e9bfbe43835bd0fae2682924d19aee318b673bb  0056-dxgi-gate-parked-dcomp-reblits-on-window-visibility.patch
+cb9c7fbf965bdab40dfe304c32ae7d40918bdd7b60cd2ab4858e2540a574bbe6  0057-wined3d-add-Intel-graphics-devices-from-Ice-Lake-to-.patch
 d41fba04c9682abf22abfcc147dbc3e1ed0b931f688d2736c60eca83670895f8  0058-wined3d-use-GDI-present-when-the-present-time-client.patch
 eb85bc3dc958314b299ebe45dc690ed3e9958d7beea82647513964ca0531a1b6  0059-wined3d-query-the-flip-s-client-rect-in-the-window-s.patch
 291b923e70cdc27453b2d16979823ad5aba3476b4fb1590b18620a730d029ca6  0060-shell32-implement-IFileOperation-DeleteItem.patch

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -130,6 +130,7 @@ FINGERPRINTS='
 0045|ascii|lib/wine/x86_64-windows/ole32.dll|revoke for another process windows is disabled
 0055|wide|lib/wine/x86_64-windows/dxgi.dll|WINE_DISABLE_GL_PRESENT
 0056|ascii|lib/wine/x86_64-windows/dxgi.dll|Re-blit skipped (hidden ancestry)
+0057|ascii|lib/wine/x86_64-windows/wined3d.dll|Arc(tm) Graphics (MTL)
 0058|ascii|lib/wine/x86_64-windows/wined3d.dll|Present-time client rect disagrees
 0059|ascii|lib/wine/x86_64-windows/wined3d.dll|Flip client rect queried in the window DPI context
 0060|ascii|lib/wine/x86_64-windows/shell32.dll|IFileOperation DeleteItem via SHFileOperation


### PR DESCRIPTION
This PR makes Live's GPU renderer available again on Intel graphics newer than 2019 (issue 84, Wine patch 0057). Wine reported every Intel GPU from Ice Lake through Lunar Lake, and the Arc A-series cards, as "Intel(R) HD Graphics 4000", a 2012 device that Live refuses to use, so the Preferences dialog greyed out "Enable GPU Renderer". Wine now reports the real device names. 

Thank you to @stickyfran for being persistent with this!