### PR TITLE
launcher: keep the GDI present path; 0055's GL path misplaces the frame

### DIFF
--- a/notes/ABLETON-WINE-GPU-RENDERER.md
+++ b/notes/ABLETON-WINE-GPU-RENDERER.md
@@ -96,6 +96,35 @@ These measurements come from one machine (AMD Navi 31, COSMIC/Wayland
 via XWayland). Confirmation on Intel or NVIDIA hardware and on a
 non-Wayland session is still open.
 
+### The direct path misplaces the frame on niri (2026-07-29)
+
+On niri (scrollable-tiling Wayland compositor, XWayland, AMD/radv) the
+direct path presents Live's frame at the wrong vertical origin. The
+image sits about 476 px low: a black band fills the top of the client
+area, the bottom of the mixer is clipped off-screen, and the whole UI
+looks displaced. Input hit-testing stays on the real layout, so
+clicking works where a control *should* be, not where it is drawn.
+That split — correct geometry, misplaced pixels — puts the fault in the
+present blit, not in Live's layout or the DPI policy.
+
+Measured on a 3840x2160 output at scale 1.25 (`LogPixels` 120). The X11
+window was 3840x2045 and its client child 3840x2017 at +0+28, both
+correct. `WINE_DISABLE_GL_PRESENT=1` renders correctly and logs `Using
+GDI present` once; the same build without it logs nothing and misplaces
+the frame.
+
+Unconfirmed, but the likely mechanism is that a tiling compositor
+resizes the window immediately after mapping, and the direct path
+bottom-aligns the pre-resize buffer in the new drawable (GL's origin is
+bottom-left, X11's is top-left). If that holds, every tiling
+compositor is affected and every floating one is not, which matches
+COSMIC being clean above. Untested on sway, Hyprland and i3.
+
+Until this is fixed, `scripts/ableton-live` and `scripts/max9` default
+`WINE_DISABLE_GL_PRESENT` to `1`, so the stack keeps the copy path and
+its bandwidth cost. Set `WINE_DISABLE_GL_PRESENT=0` to opt back into
+the direct path on a compositor where it renders correctly.
+
 ## Related
 
 - [Diagnosis narrative](ABLETON-WINE-GPU-RENDERER-WEBVIEW2-DIAGNOSIS.md)

--- a/scripts/ableton-live
+++ b/scripts/ableton-live
@@ -16,6 +16,14 @@ export PATH="$WINE_ROOT/bin:$PATH"
 export WINEDEBUG="${WINEDEBUG:--all}"
 export WINE_D3D_CONFIG="${WINE_D3D_CONFIG:-csmt=0x1}"
 export WINED3D_DCOMP_FORCE_FULL_REDRAW="${WINED3D_DCOMP_FORCE_FULL_REDRAW:-1}"
+# Patch 0055 prefers wined3d's GL present path for top-level swapchain windows.
+# On niri (scrollable-tiling Wayland compositor, XWayland) that presents Live's
+# frame at the wrong vertical origin: the image sits ~476px low, a black band
+# fills the top of the client area and the bottom is clipped, while input
+# hit-testing stays on the real layout. Default to the GDI present path until
+# that is fixed; WINE_DISABLE_GL_PRESENT=0 opts back into the GL path (0055
+# reads the value, so 0 is not "disabled"). See notes/ABLETON-WINE-GPU-RENDERER.md.
+export WINE_DISABLE_GL_PRESENT="${WINE_DISABLE_GL_PRESENT:-1}"
 # Report host mount points as plain dirs (patch 0033); Live's browser treats
 # junctions without reparse data as unresolvable and skips them.
 export WINE_DISABLE_UNIX_MOUNT_REPARSE="${WINE_DISABLE_UNIX_MOUNT_REPARSE:-1}"

--- a/scripts/max9
+++ b/scripts/max9
@@ -11,6 +11,9 @@ export WINEPREFIX="${ABLETON_WINEPREFIX:-$HOME/.wine-ableton}"
 export PATH="$WINE_ROOT/bin:$PATH"
 export WINEDEBUG="${WINEDEBUG:--all}"
 export WINE_D3D_CONFIG="${WINE_D3D_CONFIG:-csmt=0x1}"
+# Same GL-present default as scripts/ableton-live: patch 0055's GL path presents
+# top-level swapchain windows at the wrong vertical origin on niri/XWayland.
+export WINE_DISABLE_GL_PRESENT="${WINE_DISABLE_GL_PRESENT:-1}"
 export WINE_DISABLE_UNIX_MOUNT_REPARSE="${WINE_DISABLE_UNIX_MOUNT_REPARSE:-1}"
 export WINESERVER="$WINE_ROOT/bin/wineserver"
 export WINEDLLOVERRIDES="${WINEDLLOVERRIDES:+$WINEDLLOVERRIDES;}mscoree,mshtml="


### PR DESCRIPTION
A patch claude wanted to put in another PR
didn't see why not, so here's that to look at

just some docs and a patch that solves an issue I was having with Live rendering with a massive black bar on the upper third of the screen; fis is just an env var. If this is just a me issue and making `WINE_DISABLE_GL_PRESENT` 1 by default is not a good idea, go ahead and close this. Or if you don't like the docs/comments, lmk and I can clean those up

claude says:
```
Patch 0055 (PR #94, issue 91) prefers wined3d's GL present path for top-level swapchain windows. On niri -- scrollable tiling, Wayland, XWayland, AMD/radv -- that path presents Live's frame roughly 476px low: a black band fills the top of the client area, the bottom of the mixer is clipped off-screen, and the whole UI looks displaced. Input hit-testing stays on the real layout, so clicks land where a control should be rather than where it is drawn.

Correct geometry with misplaced pixels puts the fault in the present blit. Measured on a 3840x2160 output at scale 1.25 (LogPixels 120): the X11 window was 3840x2045 and its client child 3840x2017 at +0+28, and WM_NORMAL_HINTS carried 0053's PMinSize 1208x999 -- all correct. WINE_DISABLE_GL_PRESENT=1 renders correctly and logs "Using GDI present" once; the same build without it never logs it and misplaces the frame.

Default WINE_DISABLE_GL_PRESENT to 1 in both launchers, in the same ${VAR:-default} form as the other wined3d knobs there, so the stack keeps the copy path and its bandwidth cost until the direct path is fixed. WINE_DISABLE_GL_PRESENT=0 opts back in; 0055 reads the value, so 0 means the GL path, not "disabled". The patch series is untouched.

Likely mechanism, unconfirmed: a tiling compositor resizes the window right after mapping and the direct path bottom-aligns the pre-resize buffer in the new drawable (GL's origin is bottom-left, X11's is top-left). That would make every tiling compositor affected and every floating one clean, matching the COSMIC measurements in notes/ABLETON-WINE-GPU-RENDERER.md. Untested on sway, Hyprland and i3, so this is a blanket default rather than a per-compositor gate.
```