### PR TITLE
max9: point the default runtime at 11.13

### DIFF
--- a/scripts/max9
+++ b/scripts/max9
@@ -6,7 +6,7 @@
 #            ABLETON_LINKD=/path/to/ableton-linkd (Ableton Link session anchor).
 set -u
 unset WINELOADER WINEDLLPATH WINEDLLOVERRIDES WINEARCH
-WINE_ROOT="${ABLETON_WINE_ROOT:-$HOME/.local/opt/wine-d2d1-nspa-11.11}"
+WINE_ROOT="${ABLETON_WINE_ROOT:-$HOME/.local/opt/wine-d2d1-nspa-11.13}"
 export WINEPREFIX="${ABLETON_WINEPREFIX:-$HOME/.wine-ableton}"
 export PATH="$WINE_ROOT/bin:$PATH"
 export WINEDEBUG="${WINEDEBUG:--all}"


### PR DESCRIPTION
AI updated path
moved that change to another PR
here's that

claude:
```
The 11.13 base bump (PR #53) renamed the runtime directory to wine-d2d1-nspa-11.13 across build.sh, install.sh, make-installer.sh, release.sh, container-build.sh, build-audit.sh, setup-run-header.sh, setup-prefix.sh, uninstall.sh, bench-run.sh, check-ntsync.sh, check-live-audio.sh, ableton-live and the bin/ launchers. scripts/max9 kept the 11.11 default, so running max9 without ABLETON_WINE_ROOT set points at a directory that no longer exists.
```