### PR TITLE
Patch 0058: GDI present for frames whose client rect disagrees (issue 100)

### DIFF
--- a/notes/ABLETON-WINE-GPU-RENDERER.md
+++ b/notes/ABLETON-WINE-GPU-RENDERER.md
@@ -127,7 +127,48 @@ rate-limited TRACE record both rects and the backbuffer size, so an
 affected machine can show which side lies, toward a root fix in
 `translate_drawable_coords` itself.
 
-Runtime verification on an affected compositor is pending.
+Runtime verification is below: the gate is correct, and the
+disagreement it detects has a root cause worth fixing.
+
+### The disagreement is a DPI-context gap; patch 0059 closes it (2026-07-30)
+
+The trigger is fractional display scaling, not a compositor, a driver
+or a window manager. It reproduces on AMD Navi 31 under COSMIC/Wayland
+— a setup with no symptom at 100% — by putting the prefix at 125%
+(`ABLETON_DPI_MODE=dpi120`, LogPixels 120). That covers both reports:
+niri at 125%, and issue 100's KDE/NVIDIA machine, where the trigger is
+Live's Enable HiDPI Mode.
+
+Patch 0023 brackets the present-time client-rect queries with the
+window's own DPI awareness context, in `wined3d_swapchain_present`,
+`wined3d_swapchain_resize_buffers`, `wined3d_swapchain_state_init` and
+`d3d12_swapchain_resize_buffers`. It does not cover
+`wined3d_texture_translate_drawable_coords`, the one that runs on the
+CS thread. The flip subtracts a height resolved in that thread's
+inherited context from a destination rect resolved in the window's,
+and under scaling those are two different numbers for the same window.
+
+Patch 0059 brackets that query the same way, and 0058's gate with it.
+The second half is not optional: the gate runs before the blit and
+sends mismatched frames to `swapchain_blit_gdi()`, which never reaches
+the flip, so an unbracketed gate diverts every scaled frame and the
+corrected flip never runs. The first build of 0059 showed no bar and a
+healthy frame rate while its own FIXME had fired zero times.
+
+Measured at 125% on one machine, mouse moving over the window, Live's
+CPU sampled with `top -b`, 15 readings at 2s (one core = 100%):
+
+| Series | Black bar | Live CPU | Present path |
+|---|---|---|---|
+| 0055, no 0058 | yes | 29.8% | direct |
+| + 0058 | no | 98.9% | copy |
+| + 0058 + 0059 | no | 25.2% | direct |
+
+0058 on its own trades the bar for the copy path's cost on every
+scaled setup, and that cost is not noticeable by feel — only by
+measurement. With 0059 there is nothing to trade: the bar is gone and
+the direct path survives. 0058 stays in as the safety net, silent, and
+as the assertion that the two contexts now agree.
 
 ## Related
 

--- a/notes/ABLETON-WINE-GPU-RENDERER.md
+++ b/notes/ABLETON-WINE-GPU-RENDERER.md
@@ -96,6 +96,39 @@ These measurements come from one machine (AMD Navi 31, COSMIC/Wayland
 via XWayland). Confirmation on Intel or NVIDIA hardware and on a
 non-Wayland session is still open.
 
+### The direct path can land the frame low; patch 0058 gates it (2026-07-30)
+
+Two reports show the direct path drawing Live's frame too low, a black
+band on top and the bottom rows clipped, while input hit-testing stays
+on the real layout: niri/XWayland at 125% (reported on PR 98, about
+476 px low) and KDE Plasma with NVIDIA when Live's Enable HiDPI Mode
+setting is on (issue 100). KDE floats its windows, so a tiling-only
+explanation does not cover both.
+
+The candidate mechanism both share sits in the present path. The
+destination rect is captured on Live's thread in the window's DPI
+context (patch 0023). The blit's y-flip re-queries the client rect
+later, on wined3d's CS thread, in that thread's DPI context
+(`wined3d_texture_translate_drawable_coords`). Nothing forces the two
+queries to agree: the threads can hold different DPI awareness, and
+the window can be resized between capture and execution. On a
+disagreement, GL's bottom-left origin lands the frame low by the
+difference.
+
+Patch 0058 gates the direct path on agreement, per frame: it re-queries
+the client rect on the CS thread and compares it with the captured
+destination rect. Matching frames keep the direct path. Disagreeing
+frames take the GDI path, which anchors top-left and renders correctly
+under the same mismatch. On an affected setup every frame disagrees,
+so the swapchain behaves as if `WINE_DISABLE_GL_PRESENT=1` without
+anyone setting it, and healthy setups keep the direct path. The
+fire-once FIXME `Present-time client rect disagrees` plus a
+rate-limited TRACE record both rects and the backbuffer size, so an
+affected machine can show which side lies, toward a root fix in
+`translate_drawable_coords` itself.
+
+Runtime verification on an affected compositor is pending.
+
 ## Related
 
 - [Diagnosis narrative](ABLETON-WINE-GPU-RENDERER-WEBVIEW2-DIAGNOSIS.md)

--- a/patches/0058-wined3d-use-GDI-present-when-the-present-time-client.patch
+++ b/patches/0058-wined3d-use-GDI-present-when-the-present-time-client.patch
@@ -1,0 +1,121 @@
+Subject: wined3d: use GDI present when the present-time client rect
+ disagrees (issue 100)
+
+The GL present path (0055) blits the backbuffer to the drawable and
+y-flips through wined3d_texture_translate_drawable_coords(), which
+queries the window's client rect on the CS thread at execution time.
+The destination rect it flips was captured earlier, on the presenting
+thread, in the window's DPI context (0023). Nothing guarantees the two
+agree: the CS thread's DPI context can resolve the same window to a
+different client height, and the window can be resized between capture
+and execution. When they disagree the flip height no longer matches
+the destination rect, and with GL's bottom-left origin the frame lands
+low: a black band fills the top of the client area and the bottom rows
+are clipped. Input hit-testing is unaffected, so clicks land on the
+real layout, not the drawn one.
+
+Reported twice with matching signatures: Live's frame about 476px low
+on niri/XWayland at 125% (PR 98), and Live's UI sliding down under KDE
+Plasma/NVIDIA when Live's 'Enable HiDPI Mode' setting is on (issue
+100); that toggle changes Live's DPI awareness and resizes the window
+after mapping.
+
+Gate the fast path on agreement: re-query the client rect on the CS
+thread right before the blit and compare it against the captured
+destination rect. When they match, GL present proceeds as before; when
+they do not, that frame takes swapchain_blit_gdi(), which anchors
+top-left and presents the same frame correctly under the mismatch
+(WINE_DISABLE_GL_PRESENT=1 renders correctly on the niri setup). On an
+affected configuration every frame disagrees, so the swapchain stays
+on the GDI path, behaving as if WINE_DISABLE_GL_PRESENT=1; healthy
+configurations keep the GL path and its bandwidth win. The mismatch
+branch routes to GDI explicitly rather than falling through: a
+DISCARD-effect swapchain would otherwise reach the plain GL branch and
+misplace the frame the same way.
+
+A fire-once FIXME marks the first mismatched frame; a rate-limited
+TRACE logs both rects and the backbuffer size, so an affected setup
+records which side disagrees (DPI context vs in-flight resize) toward
+a root fix in translate_drawable_coords itself.
+
+Reports: v33 (Version33), PR 98; NoskyD, issue 100.
+---
+ dlls/wined3d/swapchain.c | 56 +++++++++++++++++++++++++++++++++-------
+ 1 file changed, 47 insertions(+), 9 deletions(-)
+
+diff --git a/dlls/wined3d/swapchain.c b/dlls/wined3d/swapchain.c
+index d93ae04..0187087 100644
+--- a/dlls/wined3d/swapchain.c
++++ b/dlls/wined3d/swapchain.c
+@@ -1280,6 +1280,34 @@ static bool swapchain_present_is_partial_copy(struct wined3d_swapchain *swapchai
+     return false;
+ }
+ 
++/* The GL present blit y-flips through wined3d_texture_translate_drawable_coords(),
++ * which queries the window's client rect on this (CS) thread at execution time.
++ * dst_rect was captured on the presenting thread in the window's DPI context
++ * (wined3d_swapchain_present).  When the two disagree - a DPI-awareness
++ * mismatch between the two threads, or a window resize since the capture -
++ * the flip height no longer matches the destination rect: GL's bottom-left
++ * origin then lands the frame low, black band on top, bottom rows clipped
++ * (issue 100; the niri report on PR 98).  The GDI present path anchors
++ * top-left and shows the same frame correctly under the mismatch. */
++static bool swapchain_gl_present_size_agrees(const struct wined3d_swapchain *swapchain, const RECT *dst_rect)
++{
++    static unsigned int mismatch_count;
++    RECT client_rect;
++
++    GetClientRect(swapchain->win_handle, &client_rect);
++    if (client_rect.right - client_rect.left == dst_rect->right - dst_rect->left
++            && client_rect.bottom - client_rect.top == dst_rect->bottom - dst_rect->top)
++        return true;
++
++    if (!mismatch_count++)
++        FIXME("Present-time client rect disagrees with the captured dst rect, using GDI present for these frames.\n");
++    if (mismatch_count <= 5 || !(mismatch_count % 300))
++        TRACE("Size disagreement #%u: dst %s, cs-thread client %s, backbuffer %ux%u.\n",
++                mismatch_count, wine_dbgstr_rect(dst_rect), wine_dbgstr_rect(&client_rect),
++                swapchain->state.desc.backbuffer_width, swapchain->state.desc.backbuffer_height);
++    return false;
++}
++
+ static void swapchain_gl_present(struct wined3d_swapchain *swapchain,
+         const RECT *src_rect, const RECT *dst_rect, unsigned int swap_interval, uint32_t flags)
+ {
+@@ -1312,17 +1340,27 @@ static void swapchain_gl_present(struct wined3d_swapchain *swapchain,
+             && !(swapchain->state.desc.flags & WINED3D_SWAPCHAIN_FORCE_GDI_PRESENT)
+             && context_gl->dc != wined3d_device_gl(swapchain->device)->backup_dc)
+     {
+-        static unsigned int gl_present_count;
+-        gl_info = context_gl->gl_info;
++        if (swapchain_gl_present_size_agrees(swapchain, dst_rect))
++        {
++            static unsigned int gl_present_count;
++            gl_info = context_gl->gl_info;
+ 
+-        if (!(gl_present_count++ % 60))
+-            TRACE("GL popup present #%u: dc %p, win %p.\n",
+-                    gl_present_count, context_gl->dc, swapchain->win_handle);
++            if (!(gl_present_count++ % 60))
++                TRACE("GL popup present #%u: dc %p, win %p.\n",
++                        gl_present_count, context_gl->dc, swapchain->win_handle);
+ 
+-        swapchain_gl_set_swap_interval(swapchain, context_gl, swap_interval);
+-        wined3d_texture_load_location(back_buffer, 0, context, back_buffer->resource.draw_binding);
+-        swapchain_blit(swapchain, context, src_rect, dst_rect);
+-        gl_info->gl_ops.wgl.p_wglSwapBuffers(context_gl->dc);
++            swapchain_gl_set_swap_interval(swapchain, context_gl, swap_interval);
++            wined3d_texture_load_location(back_buffer, 0, context, back_buffer->resource.draw_binding);
++            swapchain_blit(swapchain, context, src_rect, dst_rect);
++            gl_info->gl_ops.wgl.p_wglSwapBuffers(context_gl->dc);
++        }
++        else
++        {
++            /* Not the fall-through chain below: a DISCARD-effect swapchain
++             * would otherwise reach the plain GL branch and misplace the
++             * frame the same way. */
++            swapchain_blit_gdi(swapchain, context, src_rect, dst_rect);
++        }
+     }
+     else if (context_gl->dc == wined3d_device_gl(swapchain->device)->backup_dc
+             || (swapchain->state.desc.flags & WINED3D_SWAPCHAIN_FORCE_GDI_PRESENT)

--- a/patches/0059-wined3d-query-the-flip-s-client-rect-in-the-window-s.patch
+++ b/patches/0059-wined3d-query-the-flip-s-client-rect-in-the-window-s.patch
@@ -1,0 +1,108 @@
+Subject: wined3d: query the flip's client rect in the window's DPI
+ context (issue 100)
+
+Patch 0023 brackets the present-time client-rect queries with the
+window's own DPI awareness context, because the surface a present lands
+in is sized in the window's pixels, never the calling thread's. It
+covered wined3d_swapchain_present, wined3d_swapchain_resize_buffers,
+wined3d_swapchain_state_init and d3d12_swapchain_resize_buffers. It did
+not cover wined3d_texture_translate_drawable_coords, which is the one
+that runs on the CS thread.
+
+That leaves the GL present path asking the same question twice and
+getting two answers. wined3d_swapchain_present captures dst_rect on the
+presenting thread in the window's DPI context. The blit's y-flip then
+re-queries the client rect in translate_drawable_coords, on wined3d's
+CS thread, whose DPI context is whatever it happened to inherit. Under
+fractional scaling those differ: the window is 1440 physical rows and
+1152 virtualised ones at 125%. The flip subtracts from the wrong
+height, and with GL's bottom-left origin the frame lands low by the
+difference - black band on top, bottom rows clipped, while hit-testing
+stays on the real layout (issue 100; the niri report on PR 98).
+
+Bracket this query the same way 0023 brackets the other four. Both
+sides then resolve the window in its own DPI context and agree by
+construction, so the flip height matches the destination rect and the
+GL path renders correctly under scaling instead of being gated onto
+GDI by 0058.
+
+Reproduced and measured on AMD Navi 31, COSMIC/Wayland via XWayland,
+2560x1440, by setting the prefix to 125% (LogPixels 120): the bar
+appears on 0055 without 0058; 0058 removes it but pins the swapchain to
+the GDI path, taking Live from 29.8% to 98.9% of a core with the mouse
+moving over the window. At 100% neither the bar nor the cost appears.
+
+0058's gate is bracketed the same way, and must be: it runs before the
+blit and routes mismatched frames to swapchain_blit_gdi(), which never
+reaches translate_drawable_coords at all.  Left unbracketed it compares
+a CS-thread height against a window-context dst_rect, disagrees on every
+scaled frame, and skips the corrected flip entirely - masking this fix
+rather than guarding it.  Bracketed, it stays in as the safety net and
+doubles as the assertion for this patch: with the contexts agreeing it
+stops firing.
+
+The fire-once FIXME marks the corrected query for the build audit and
+for confirming on an affected setup that this code path ran.
+
+Reports: NoskyD, issue 100; v33 (Version33), PR 98.
+Diagnosis and measurements: Lucas Gillingham (ClickSentinel).
+---
+ dlls/wined3d/swapchain.c | 10 ++++++++++
+ dlls/wined3d/texture.c   | 17 +++++++++++++++++
+ 2 files changed, 27 insertions(+)
+
+diff --git a/dlls/wined3d/texture.c b/dlls/wined3d/texture.c
+index 1a2b3c4..5d6e7f8 100644
+--- a/dlls/wined3d/texture.c
++++ b/dlls/wined3d/texture.c
+@@ -86,8 +86,25 @@
+         drawable_height = desc->backbuffer_height;
+     else
+     {
++        static unsigned int once;
+         RECT client_rect;
++        DPI_AWARENESS_CONTEXT prev;
++
++        /* This runs on the CS thread, whose DPI context is whatever it
++         * inherited, while dst_rect was captured on the presenting thread in
++         * the window's own context (0023).  Under fractional scaling the two
++         * resolve the same window to different heights, the y-flip below
++         * subtracts from the wrong one, and GL's bottom-left origin lands the
++         * frame low: black band on top, bottom rows clipped (issue 100).
++         * Query in the window's context, as 0023 does everywhere else, so the
++         * flip height and the destination rect agree by construction. */
++        prev = SetThreadDpiAwarenessContext(GetWindowDpiAwarenessContext(window));
+         GetClientRect(window, &client_rect);
++        SetThreadDpiAwarenessContext(prev);
++
++        if (!once++)
++            FIXME("Flip client rect queried in the window DPI context.\n");
++
+         drawable_height = client_rect.bottom - client_rect.top;
+     }
+ 
+
+diff --git a/dlls/wined3d/swapchain.c b/dlls/wined3d/swapchain.c
+index 0187087..2a9b3c1 100644
+--- a/dlls/wined3d/swapchain.c
++++ b/dlls/wined3d/swapchain.c
+@@ -1219,9 +1219,19 @@
+ static bool swapchain_gl_present_size_agrees(const struct wined3d_swapchain *swapchain, const RECT *dst_rect)
+ {
+     static unsigned int mismatch_count;
++    DPI_AWARENESS_CONTEXT prev;
+     RECT client_rect;
+ 
++    /* Ask the way translate_drawable_coords now asks (0059) and the way
++     * dst_rect was captured (0023): in the window's own DPI context.  An
++     * unbracketed query here disagrees under fractional scaling on every
++     * frame, pinning the swapchain to GDI and skipping the blit - and with
++     * it the corrected flip - so the gate would mask the fix instead of
++     * guarding it. */
++    prev = SetThreadDpiAwarenessContext(GetWindowDpiAwarenessContext(swapchain->win_handle));
+     GetClientRect(swapchain->win_handle, &client_rect);
++    SetThreadDpiAwarenessContext(prev);
++
+     if (client_rect.right - client_rect.left == dst_rect->right - dst_rect->left
+             && client_rect.bottom - client_rect.top == dst_rect->bottom - dst_rect->top)
+         return true;

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -11,8 +11,8 @@ narrative — 5 merge conflicts, three build breaks the clean rebase didn't
 catch, a build.sh/pipefail tooling gotcha — is in
 `notes/ABLETON-WINE-11.11-TO-11.13-BASE-BUMP.md`.
 
-The current Wine series contains 52 files, numbered 0001 through 0055.
-Patches 0027, 0044, and 0054 are intentionally absent.
+The current Wine series contains 54 files, numbered 0001 through 0058.
+Patches 0027, 0044, 0054, and 0057 are intentionally absent.
 
 ## Applying the series
 
@@ -170,4 +170,18 @@ Apply them in sequence with the rest of the series.
   path for every window; the value `0` is ignored. Diagnosis and
   measurements:
   Lucas Gillingham (ClickSentinel). See
+  `notes/ABLETON-WINE-GPU-RENDERER.md`.
+- `0056`: gate parked DirectComposition reblits on window visibility.
+  A parked WebView2 composition target kept stamping its stale
+  composite over live siblings (issue 57).
+- `0057`: reserved for the Intel GPU identification work on the
+  `fix/intel-gpu` branch. No patch file is shipped here yet.
+- `0058`: fall back to the GDI present path for any frame whose
+  present-time client rect disagrees with the captured destination
+  rect. The direct GL path (0055) y-flips against a client rect
+  re-queried on wined3d's CS thread, while the destination rect was
+  captured in the window's DPI context on the presenting thread; a
+  disagreement (DPI-awareness mismatch between the threads, or a
+  resize in flight) lands the frame low with a black band on top
+  (issue 100 and the niri report on PR 98). See
   `notes/ABLETON-WINE-GPU-RENDERER.md`.

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -11,7 +11,7 @@ narrative — 5 merge conflicts, three build breaks the clean rebase didn't
 catch, a build.sh/pipefail tooling gotcha — is in
 `notes/ABLETON-WINE-11.11-TO-11.13-BASE-BUMP.md`.
 
-The current Wine series contains 54 files, numbered 0001 through 0058.
+The current Wine series contains 55 files, numbered 0001 through 0059.
 Patches 0027, 0044, 0054, and 0057 are intentionally absent.
 
 ## Applying the series
@@ -185,3 +185,8 @@ Apply them in sequence with the rest of the series.
   resize in flight) lands the frame low with a black band on top
   (issue 100 and the niri report on PR 98). See
   `notes/ABLETON-WINE-GPU-RENDERER.md`.
+- `0059`: query the y-flip's client rect in the window's DPI context.
+  0023 bracketed the present-time queries but missed
+  `wined3d_texture_translate_drawable_coords`, the one on the CS
+  thread; under fractional scaling the two disagreed and 0058's gate
+  fired on every frame. See `notes/ABLETON-WINE-GPU-RENDERER.md`.

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -51,5 +51,6 @@ f278d870c0424748a9d7a7cd5a6e9feb0837900e6382f4ee9d7cfe214c0b9fd5  0052-win32u-hi
 d32ac8ca55853e5488292d015e35a31d23744150e04af476742e781b58abc186  0053-winex11-export-the-app-minimum-tracking-size-as-PMin.patch
 5c97ce27e69ea1caffef5197a8e0f19893829c1c868e06c89e660352ad2919a1  0055-dxgi-prefer-GL-present-for-top-level-swapchain-devic.patch
 11dbb4c36378fc274e8eaa281e9bfbe43835bd0fae2682924d19aee318b673bb  0056-dxgi-gate-parked-dcomp-reblits-on-window-visibility.patch
+d41fba04c9682abf22abfcc147dbc3e1ed0b931f688d2736c60eca83670895f8  0058-wined3d-use-GDI-present-when-the-present-time-client.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -52,5 +52,6 @@ d32ac8ca55853e5488292d015e35a31d23744150e04af476742e781b58abc186  0053-winex11-e
 5c97ce27e69ea1caffef5197a8e0f19893829c1c868e06c89e660352ad2919a1  0055-dxgi-prefer-GL-present-for-top-level-swapchain-devic.patch
 11dbb4c36378fc274e8eaa281e9bfbe43835bd0fae2682924d19aee318b673bb  0056-dxgi-gate-parked-dcomp-reblits-on-window-visibility.patch
 d41fba04c9682abf22abfcc147dbc3e1ed0b931f688d2736c60eca83670895f8  0058-wined3d-use-GDI-present-when-the-present-time-client.patch
+eb85bc3dc958314b299ebe45dc690ed3e9958d7beea82647513964ca0531a1b6  0059-wined3d-query-the-flip-s-client-rect-in-the-window-s.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -131,6 +131,7 @@ FINGERPRINTS='
 0045|ascii|lib/wine/x86_64-windows/ole32.dll|revoke for another process windows is disabled
 0055|wide|lib/wine/x86_64-windows/dxgi.dll|WINE_DISABLE_GL_PRESENT
 0058|ascii|lib/wine/x86_64-windows/wined3d.dll|Present-time client rect disagrees
+0059|ascii|lib/wine/x86_64-windows/wined3d.dll|Flip client rect queried in the window DPI context
 pipeasio/0001|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-clamp-sample-rate
 pipeasio/0002|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-midi-timebase
 '

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -72,6 +72,7 @@ declare -A SERIES_GAPS=(
     [0027]="retired 2026-07-14 — gitignore housekeeping, no artifact effect"
     [0044]="reserved 2026-07-24 for the issue 57 parked-pane reblit gate; shipped as 0056 instead"
     [0054]="reserved 2026-07-29 for PR 77's language-fallback font patch"
+    [0057]="reserved 2026-07-30 for the Intel GPU identification fix on fix/intel-gpu"
 )
 seq_expect=1
 for f in $(awk '{print $2}' "$SERIES" | grep -v '^pipeasio/' | sort); do
@@ -129,6 +130,7 @@ FINGERPRINTS='
 0043|ascii|lib/wine/x86_64-windows/shell32.dll|__wine_portal_show_item
 0045|ascii|lib/wine/x86_64-windows/ole32.dll|revoke for another process windows is disabled
 0055|wide|lib/wine/x86_64-windows/dxgi.dll|WINE_DISABLE_GL_PRESENT
+0058|ascii|lib/wine/x86_64-windows/wined3d.dll|Present-time client rect disagrees
 pipeasio/0001|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-clamp-sample-rate
 pipeasio/0002|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-midi-timebase
 '


### PR DESCRIPTION
The GL present path (0055) can land Live's frame too low: black band on top, bottom clipped (#100; same signature as the niri report on #98).

Cause candidate: the destination rect is captured on Live's thread in the window's DPI context (0023), but the blit's y-flip re-queries the client rect later on wined3d's CS thread in that thread's DPI context. If the two disagree (thread DPI mismatch, or a resize in flight), GL's bottom-left origin lands the frame low by the difference.

Patch 0058 compares the two rects on every frame. Match: GL present as before. Mismatch: that frame takes the GDI path, which is correct under the same conditions. Affected setups end up on the GDI path full-time, as if WINE_DISABLE_GL_PRESENT=1; healthy setups keep the GL path. A fire-once FIXME and a rate-limited TRACE log both rects for diagnosis.

Build and 8/8 audit pass. Runtime verification on an affected setup (niri, or the #100 machine) is pending. If the bar survives there without the gate firing, the disagreement is driver-side and the follow-up is a DPI-consistent query in translate_drawable_coords.

If this verifies, this supersedes the proposed flag switch in #98.