### PR TITLE
Fix mp3 import: winegstreamer

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -56,6 +56,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       # driver. PipeASIO builds against the vendored PipeWire SDK below, not a
       # jammy package (jammy's 0.3.48 predates the thread-utils API it needs).
       libasound2-dev libpulse-dev \
+      # media import: without these, configure silently drops winegstreamer
+      # and mp3/mp4/wma import just fails (issue #44). Actual codec plugins
+      # still come from the user's host GStreamer install at runtime.
+      libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
       # TLS (Live online auth / pack downloads), USB display bridge, XDG portal
       libgnutls28-dev libusb-1.0-0-dev libudev-dev libdbus-1-dev \
  && rm -rf /var/lib/apt/lists/* \

--- a/scripts/container-build.sh
+++ b/scripts/container-build.sh
@@ -93,6 +93,14 @@ if [ ! -s "$winealsa_unix" ]; then
     exit 1
 fi
 
+# configure also silently drops winegstreamer (mp3/mp4/wma import) without
+# the gstreamer-1.0 dev packages — shipped unnoticed until issue #44.
+winegstreamer_unix="$PREFIX_ROOT/lib/wine/x86_64-unix/winegstreamer.so"
+if [ ! -s "$winegstreamer_unix" ]; then
+    echo "!! winegstreamer.so missing: libgstreamer1.0-dev/libgstreamer-plugins-base1.0-dev not present at configure time; no mp3/mp4/wma import" >&2
+    exit 1
+fi
+
 # configure also silently drops ntsync without linux/ntsync.h; every NT sync
 # wait then becomes a wineserver round trip (~1.3 cores with Live running).
 # Shipped unnoticed twice in 2026-07. Check BOTH halves: the 07-12 build lost

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -72,6 +72,7 @@ for required in \
     lib/wine/x86_64-unix/libusb-1.0.so \
     lib/wine/x86_64-unix/comdlg32.so \
     lib/wine/x86_64-unix/winealsa.so \
+    lib/wine/x86_64-unix/winegstreamer.so \
     lib/wine/x86_64-windows/pipeasio64.dll \
     lib/wine/x86_64-windows/pipeasio.dll \
     lib/wine/x86_64-unix/pipeasio64.dll.so \


### PR DESCRIPTION
## Summary

`Containerfile` never installed `libgstreamer1.0-dev`/`libgstreamer-plugins-base1.0-dev`. Wine's `configure` treats GStreamer support as opt-out (`--without-gstreamer`), not opt-in, so without those packages it silently dropped the `winegstreamer` module — no build failure, just a notice buried in the configure log.

Without `winegstreamer.dll`/`.so`, `mfplat`'s Media Foundation source resolver has no backend to hand media files to, so mp3 import failed on every build. The exact error depends on prefix history: `MF_E_UNSUPPORTED_BYTESTREAM_TYPE` on a clean prefix, or `E_OUTOFMEMORY` out of `wg_parser_create` on a prefix carrying a stale leftover `winegstreamer.dll` from an older build with no matching backend. Same root cause either way.

This adds the two dev packages to `Containerfile`, plus build-audit gates in `scripts/container-build.sh` and `scripts/install.sh` that fail loudly if `winegstreamer.so` doesn't actually get produced — the same protection the build already has for `winealsa` and `ntsync` silently dropping.

Fixes #44.

## Test plan

- [x] Build audit passes (76 checks); packaged tarball now contains `lib/wine/x86_64-unix/winegstreamer.so` and `winegstreamer.dll` (both previously absent).
- [x] Installed over a real `~/.wine-ableton` and confirmed mp3 import works.