### PR TITLE
Patch 0060: implement IFileOperation::DeleteItem

### DIFF
--- a/patches/0060-shell32-implement-IFileOperation-DeleteItem.patch
+++ b/patches/0060-shell32-implement-IFileOperation-DeleteItem.patch
@@ -51,7 +51,7 @@ index 16074d5..8ce6702 100644
  static void set_file_operation_progress(struct file_operation *operation, unsigned int total, unsigned int sofar)
  {
      operation->progress_total = total;
-@@ -1982,6 +2005,42 @@ static HRESULT copy_engine_move(struct file_operation *operation, struct copy_en
+@@ -1982,6 +2005,44 @@ static HRESULT copy_engine_move(struct file_operation *operation, struct copy_en
      return COPYENGINE_S_NOT_HANDLED;
  }
  
@@ -62,6 +62,8 @@ index 16074d5..8ce6702 100644
 +    unsigned int len;
 +    int result;
 +    HRESULT hr;
++
++    TRACE("IFileOperation DeleteItem via SHFileOperation.\n");
 +
 +    if (FAILED((hr = SHGetNameFromIDList(op->item_pidl, SIGDN_FILESYSPATH, &path))))
 +        return hr;
@@ -94,7 +96,7 @@ index 16074d5..8ce6702 100644
  static HRESULT perform_file_operations(struct file_operation *operation)
  {
      struct copy_engine_operation *op;
-@@ -2011,6 +2070,28 @@ static HRESULT perform_file_operations(struct file_operation *operation)
+@@ -2011,6 +2072,28 @@ static HRESULT perform_file_operations(struct file_operation *operation)
                  break;
              }
  
@@ -123,7 +125,7 @@ index 16074d5..8ce6702 100644
              case COPY_ENGINE_MOVE:
              {
                  struct notify_move_item_param p;
-@@ -2247,9 +2328,12 @@ static HRESULT WINAPI file_operation_DeleteItem(IFileOperation *iface, IShellIte
+@@ -2247,9 +2330,12 @@ static HRESULT WINAPI file_operation_DeleteItem(IFileOperation *iface, IShellIte
  static HRESULT WINAPI file_operation_DeleteItem(IFileOperation *iface, IShellItem *item,
          IFileOperationProgressSink *sink)
  {

--- a/patches/0060-shell32-implement-IFileOperation-DeleteItem.patch
+++ b/patches/0060-shell32-implement-IFileOperation-DeleteItem.patch
@@ -1,0 +1,140 @@
+Subject: shell32: implement IFileOperation DeleteItem
+
+Live uses IFileOperation::DeleteItem for its shared deletion path,
+including browser deletion and pruning old project backups. Wine's
+method is a stub that returns E_NOTIMPL, although the older
+SHFileOperation delete and recycle-bin paths are implemented.
+
+Queue single-item deletes in the existing copy engine and execute them
+through SHFileOperation during PerformOperations. Preserve the modern
+FOFX_RECYCLEONDELETE flag by translating it to FOF_ALLOWUNDO, and send
+the matching progress-sink notifications.
+
+diff --git a/dlls/shell32/shlfileop.c b/dlls/shell32/shlfileop.c
+index 16074d5..8ce6702 100644
+--- a/dlls/shell32/shlfileop.c
++++ b/dlls/shell32/shlfileop.c
+@@ -1692,6 +1692,7 @@ enum copy_engine_opcode
+ enum copy_engine_opcode
+ {
+     COPY_ENGINE_MOVE,
++    COPY_ENGINE_DELETE,
+     COPY_ENGINE_REMOVE_DIRECTORY_SILENT,
+ };
+ 
+@@ -1869,6 +1870,28 @@ static HRESULT notify_post_move_item(IFileOperationProgressSink *sink, struct fi
+     return IFileOperationProgressSink_PostMoveItem(sink, op->tsf, p->item, op->folder, op->name, p->result, p->new_item);
+ }
+ 
++struct notify_delete_item_param
++{
++    IShellItem *item;
++    HRESULT result;
++};
++
++static HRESULT notify_pre_delete_item(IFileOperationProgressSink *sink, struct file_operation *operations,
++        struct copy_engine_operation *op, void *context)
++{
++    struct notify_delete_item_param *p = context;
++
++    return IFileOperationProgressSink_PreDeleteItem(sink, op->tsf, p->item);
++}
++
++static HRESULT notify_post_delete_item(IFileOperationProgressSink *sink, struct file_operation *operations,
++        struct copy_engine_operation *op, void *context)
++{
++    struct notify_delete_item_param *p = context;
++
++    return IFileOperationProgressSink_PostDeleteItem(sink, op->tsf, p->item, p->result, NULL);
++}
++
+ static void set_file_operation_progress(struct file_operation *operation, unsigned int total, unsigned int sofar)
+ {
+     operation->progress_total = total;
+@@ -1982,6 +2005,42 @@ static HRESULT copy_engine_move(struct file_operation *operation, struct copy_en
+     return COPYENGINE_S_NOT_HANDLED;
+ }
+ 
++static HRESULT copy_engine_delete(struct file_operation *operation, struct copy_engine_operation *op)
++{
++    SHFILEOPSTRUCTW file_op = {0};
++    WCHAR *path, *source;
++    unsigned int len;
++    int result;
++    HRESULT hr;
++
++    if (FAILED((hr = SHGetNameFromIDList(op->item_pidl, SIGDN_FILESYSPATH, &path))))
++        return hr;
++
++    len = lstrlenW(path);
++    if (!(source = malloc((len + 2) * sizeof(*source))))
++    {
++        CoTaskMemFree(path);
++        return E_OUTOFMEMORY;
++    }
++    memcpy(source, path, (len + 1) * sizeof(*source));
++    source[len + 1] = 0;
++    CoTaskMemFree(path);
++
++    file_op.wFunc = FO_DELETE;
++    file_op.pFrom = source;
++    file_op.fFlags = operation->flags;
++    if (operation->flags & FOFX_RECYCLEONDELETE)
++        file_op.fFlags |= FOF_ALLOWUNDO;
++    result = SHFileOperationW(&file_op);
++    free(source);
++
++    if (result)
++        return HRESULT_FROM_WIN32(result);
++    if (file_op.fAnyOperationsAborted)
++        return HRESULT_FROM_WIN32(ERROR_CANCELLED);
++    return S_OK;
++}
++
+ static HRESULT perform_file_operations(struct file_operation *operation)
+ {
+     struct copy_engine_operation *op;
+@@ -2011,6 +2070,28 @@ static HRESULT perform_file_operations(struct file_operation *operation)
+                 break;
+             }
+ 
++            case COPY_ENGINE_DELETE:
++            {
++                struct notify_delete_item_param p;
++
++                if (FAILED((hr = SHCreateItemFromIDList(op->item_pidl, &IID_IShellItem, (void **)&p.item))))
++                    break;
++                if (FAILED((hr = file_operation_notify(operation, op, FALSE, &p, notify_pre_delete_item))))
++                {
++                    IShellItem_Release(p.item);
++                    return hr;
++                }
++                p.result = copy_engine_delete(operation, op);
++                if (FAILED((hr = file_operation_notify(operation, op, TRUE, &p, notify_post_delete_item))))
++                {
++                    IShellItem_Release(p.item);
++                    return hr;
++                }
++                hr = p.result;
++                IShellItem_Release(p.item);
++                break;
++            }
++
+             case COPY_ENGINE_MOVE:
+             {
+                 struct notify_move_item_param p;
+@@ -2247,9 +2328,12 @@ static HRESULT WINAPI file_operation_DeleteItem(IFileOperation *iface, IShellIte
+ static HRESULT WINAPI file_operation_DeleteItem(IFileOperation *iface, IShellItem *item,
+         IFileOperationProgressSink *sink)
+ {
+-    FIXME("(%p, %p, %p): stub.\n", iface, item, sink);
++    TRACE("(%p, %p, %p).\n", iface, item, sink);
+ 
+-    return E_NOTIMPL;
++    if (!item)
++        return E_INVALIDARG;
++
++    return add_operation(impl_from_IFileOperation(iface), COPY_ENGINE_DELETE, item, NULL, NULL, sink, 0, NULL);
+ }
+ 
+ static HRESULT WINAPI file_operation_DeleteItems(IFileOperation *iface, IUnknown *items)

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -51,6 +51,6 @@ f278d870c0424748a9d7a7cd5a6e9feb0837900e6382f4ee9d7cfe214c0b9fd5  0052-win32u-hi
 d32ac8ca55853e5488292d015e35a31d23744150e04af476742e781b58abc186  0053-winex11-export-the-app-minimum-tracking-size-as-PMin.patch
 5c97ce27e69ea1caffef5197a8e0f19893829c1c868e06c89e660352ad2919a1  0055-dxgi-prefer-GL-present-for-top-level-swapchain-devic.patch
 11dbb4c36378fc274e8eaa281e9bfbe43835bd0fae2682924d19aee318b673bb  0056-dxgi-gate-parked-dcomp-reblits-on-window-visibility.patch
-833cc07de27e1e549f0a342158943f52e8ade09be6787696bc3d74a1fb53aadb  0060-shell32-implement-IFileOperation-DeleteItem.patch
+291b923e70cdc27453b2d16979823ad5aba3476b4fb1590b18620a730d029ca6  0060-shell32-implement-IFileOperation-DeleteItem.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -51,5 +51,6 @@ f278d870c0424748a9d7a7cd5a6e9feb0837900e6382f4ee9d7cfe214c0b9fd5  0052-win32u-hi
 d32ac8ca55853e5488292d015e35a31d23744150e04af476742e781b58abc186  0053-winex11-export-the-app-minimum-tracking-size-as-PMin.patch
 5c97ce27e69ea1caffef5197a8e0f19893829c1c868e06c89e660352ad2919a1  0055-dxgi-prefer-GL-present-for-top-level-swapchain-devic.patch
 11dbb4c36378fc274e8eaa281e9bfbe43835bd0fae2682924d19aee318b673bb  0056-dxgi-gate-parked-dcomp-reblits-on-window-visibility.patch
+833cc07de27e1e549f0a342158943f52e8ade09be6787696bc3d74a1fb53aadb  0060-shell32-implement-IFileOperation-DeleteItem.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -72,6 +72,9 @@ declare -A SERIES_GAPS=(
     [0027]="retired 2026-07-14 — gitignore housekeeping, no artifact effect"
     [0044]="reserved 2026-07-24 for the issue 57 parked-pane reblit gate; shipped as 0056 instead"
     [0054]="reserved 2026-07-29 for PR 77's language-fallback font patch"
+    [0057]="reserved 2026-07-30 for PR 105's wined3d GPU naming patch"
+    [0058]="reserved 2026-07-30 for PR 102's GDI client-rect disagreement patch"
+    [0059]="reserved 2026-07-30 for PR 107's DPI-context client-rect query patch"
 )
 seq_expect=1
 for f in $(awk '{print $2}' "$SERIES" | grep -v '^pipeasio/' | sort); do
@@ -172,6 +175,7 @@ STAMP_ONLY='
 0052|logic-only (DT_HIDEPREFIX on the menu bar DrawTextW call; no new string literal)
 0056|ascii|lib/wine/x86_64-windows/dxgi.dll|Re-blit skipped (hidden ancestry)
 0053|logic-only (WM_GETMINMAXINFO minimum exported as PMinSize hints; no new string literal)
+0060|logic-only (IFileOperation DeleteItem queue and execution; verified by API repro)
 '
 wide_pattern() {  # ascii string -> PCRE matching its UTF-16LE bytes
     printf '%s' "$1" | od -An -v -tx1 | tr -d '\n' | tr -s ' ' ' ' \

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -132,6 +132,7 @@ FINGERPRINTS='
 0043|ascii|lib/wine/x86_64-windows/shell32.dll|__wine_portal_show_item
 0045|ascii|lib/wine/x86_64-windows/ole32.dll|revoke for another process windows is disabled
 0055|wide|lib/wine/x86_64-windows/dxgi.dll|WINE_DISABLE_GL_PRESENT
+0060|ascii|lib/wine/x86_64-windows/shell32.dll|IFileOperation DeleteItem via SHFileOperation
 pipeasio/0001|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-clamp-sample-rate
 pipeasio/0002|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-midi-timebase
 '
@@ -175,7 +176,6 @@ STAMP_ONLY='
 0052|logic-only (DT_HIDEPREFIX on the menu bar DrawTextW call; no new string literal)
 0056|ascii|lib/wine/x86_64-windows/dxgi.dll|Re-blit skipped (hidden ancestry)
 0053|logic-only (WM_GETMINMAXINFO minimum exported as PMinSize hints; no new string literal)
-0060|logic-only (IFileOperation DeleteItem queue and execution; verified by API repro)
 '
 wide_pattern() {  # ascii string -> PCRE matching its UTF-16LE bytes
     printf '%s' "$1" | od -An -v -tx1 | tr -d '\n' | tr -s ' ' ' ' \

--- a/tools/ifileoperation-delete.c
+++ b/tools/ifileoperation-delete.c
@@ -1,0 +1,113 @@
+/* ifileoperation-delete.c -- reproduce IFileOperation::DeleteItem.
+ *
+ * Usage: ifileoperation-delete.exe PATH [modern]
+ *
+ * The optional "modern" argument uses FOFX_RECYCLEONDELETE, as Live does.
+ * Without it, the probe uses the older FOF_ALLOWUNDO recycle flag. The probe
+ * succeeds only if DeleteItem and PerformOperations succeed, the operation is
+ * not aborted, and PATH no longer exists at its original location.
+ *
+ * Build against a Wine source tree:
+ *   winegcc -b x86_64-windows -mconsole -o ifileoperation-delete.exe \
+ *       ifileoperation-delete.c -lole32 -lshell32 -luuid
+ */
+
+#define COBJMACROS
+#include <windows.h>
+#include <shobjidl.h>
+#include <shlobj.h>
+#include <stdio.h>
+#include <string.h>
+
+static void print_hr(const char *name, HRESULT hr)
+{
+    printf("%s=0x%08lx\n", name, (unsigned long)hr);
+}
+
+int main(int argc, char **argv)
+{
+    IFileOperation *operation = NULL;
+    IShellItem *item = NULL;
+    WCHAR path[MAX_PATH + 1];
+    DWORD flags = FOF_ALLOWUNDO | FOF_NO_UI;
+    DWORD error;
+    BOOL aborted = FALSE;
+    HRESULT hr;
+    int ret = 1;
+
+    if (argc < 2 || argc > 3)
+    {
+        fprintf(stderr, "usage: ifileoperation-delete.exe PATH [modern]\n");
+        return 2;
+    }
+    if (argc == 3)
+    {
+        if (strcmp(argv[2], "modern"))
+        {
+            fprintf(stderr, "unknown mode: %s\n", argv[2]);
+            return 2;
+        }
+        flags = FOFX_RECYCLEONDELETE | FOF_NO_UI;
+    }
+
+    if (!MultiByteToWideChar(CP_UTF8, 0, argv[1], -1, path, MAX_PATH + 1))
+    {
+        fprintf(stderr, "path conversion failed: %lu\n", (unsigned long)GetLastError());
+        return 2;
+    }
+    if (GetFileAttributesW(path) == INVALID_FILE_ATTRIBUTES)
+    {
+        fprintf(stderr, "path does not exist: %lu\n", (unsigned long)GetLastError());
+        return 2;
+    }
+
+    hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+    print_hr("CoInitializeEx", hr);
+    if (FAILED(hr)) return 1;
+
+    hr = CoCreateInstance(&CLSID_FileOperation, NULL, CLSCTX_INPROC_SERVER,
+            &IID_IFileOperation, (void **)&operation);
+    print_hr("CoCreateInstance", hr);
+    if (FAILED(hr)) goto done;
+
+    hr = SHCreateItemFromParsingName(path, NULL, &IID_IShellItem, (void **)&item);
+    print_hr("SHCreateItemFromParsingName", hr);
+    if (FAILED(hr)) goto done;
+
+    hr = IFileOperation_SetOperationFlags(operation, flags);
+    print_hr("SetOperationFlags", hr);
+    if (FAILED(hr)) goto done;
+
+    hr = IFileOperation_DeleteItem(operation, item, NULL);
+    print_hr("DeleteItem", hr);
+    if (FAILED(hr)) goto done;
+
+    hr = IFileOperation_PerformOperations(operation);
+    print_hr("PerformOperations", hr);
+    if (FAILED(hr)) goto done;
+
+    hr = IFileOperation_GetAnyOperationsAborted(operation, &aborted);
+    print_hr("GetAnyOperationsAborted", hr);
+    printf("aborted=%u\n", aborted);
+    if (FAILED(hr) || aborted) goto done;
+
+    if (GetFileAttributesW(path) != INVALID_FILE_ATTRIBUTES)
+    {
+        fprintf(stderr, "path still exists after successful operation\n");
+        goto done;
+    }
+    error = GetLastError();
+    if (error != ERROR_FILE_NOT_FOUND && error != ERROR_PATH_NOT_FOUND)
+    {
+        fprintf(stderr, "path check failed: %lu\n", (unsigned long)error);
+        goto done;
+    }
+
+    ret = 0;
+
+done:
+    if (item) IShellItem_Release(item);
+    if (operation) IFileOperation_Release(operation);
+    CoUninitialize();
+    return ret;
+}


### PR DESCRIPTION
## Summary

- Add Wine patch `0060` implementing `IFileOperation::DeleteItem`.
- Fix Live's shared deletion path used by both browser deletion and backup pruning.
- Preserve recycle-bin behavior through the existing copy engine.

## Cause

Wine's `IFileOperation::DeleteItem` implementation is a stub that returns `E_NOTIMPL`. Ableton Live uses this function for both deleting files from its browser and pruning old project backups, causing both operations to fail:

```text
error: failed to move to trash "<project>/Backup/<old-backup>.als": io error
info: Exception: "<old-backup>.als" cannot be deleted.
```

## Validation

- The API reproduction changes from `E_NOTIMPL` to success.
- Live properly prunes down to the most recent 10 backups on default settings.
