### PR TITLE
Patch 0065: fix Live fullscreen layout and exit

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -73,6 +73,8 @@ make verify
 - `ABLETON_DCOMP=off` disables DirectComposition for one launch.
 - `WINE_X11_FORCE_OFFSCREEN_CLASS=off` disables the default Max for Live
   selection-flicker fix for one launch.
+- `WINE_WIN32_FULLSCREEN_CLASS=off` disables the default Live fullscreen
+  layout and exit-state fix for one launch.
 - `ABLETON_RT=off` disables realtime scheduling for one launch.
 - `PIPEASIO_*` variables override PipeASIO settings for one launch.
 - `ENGINE` selects the container engine used by build scripts. The default is

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -29,6 +29,38 @@ This workaround is only needed for affected plugins. See the
 [Pianoteq investigation](notes/ABLETON-WINE-PIANOTEQ-DPI-GHOST-BUG.md) for the
 confirmed failure mode.
 
+## Live's "Enable GPU Renderer" setting is greyed out
+
+If you're experiencing performance issues or high CPU usage when idle, Live
+may not be using your GPU. By default, Live will always offload the UI to
+your GPU for maximum performance, but will only do so when it recognises
+the name of your GPU. On Linux, GPUs will 'tell' Live their name without
+any external interference, and because Live is anticipating that interference,
+it may not recognise the GPU's name and refuse to use the GPU.
+
+To confirm this problem, open **Settings > Display & Input**. 
+If **Enable GPU Renderer** is greyed out, and the note under it names a 
+graphics card that is not the one in your computer, then you're seeing this
+exact problem. 
+
+To solve it: **update this project**.
+
+Download [the latest installer](https://github.com/shibco/ableton-linux/releases/latest/download/install-ableton-latest.run)
+and run the update. It keeps your Live installation, your license, and
+your projects:
+
+```bash
+sh ~/Downloads/install-ableton-latest.run --update
+```
+
+Start Live, open **Settings > Display & Input**, and turn on **Enable GPU
+Renderer**. Live now names your real graphics card, and the setting stays
+on.
+
+If the setting is still greyed out on 2026.08.01.1 or newer,
+[open an issue](https://github.com/shibco/ableton-linux/issues) and
+include your graphics card model.
+
 ## Live 11: Max for Live fails after the first launch
 
 After running Live 11 once, close Live and run:
@@ -121,6 +153,29 @@ or CPU-governor settings. Log out and back in after it completes. Run
 Restart Live after moving it between monitors with different scale factors.
 Override automatic detection for one launch with `ABLETON_DPI_MODE`; available
 values are listed in [the build and configuration reference](BUILDING.md#environment-variables).
+
+## Full Screen shows shifted content or does not fully exit
+
+Update to a release newer than 2026.08.01.1. On 2026.08.01.1 and older,
+**View > Full Screen** and F11 show Live's content shifted, clicks land away
+from their targets, and leaving fullscreen keeps the fullscreen image on
+screen until the window is moved.
+
+Download [the latest installer](https://github.com/shibco/ableton-linux/releases/latest/download/install-ableton-latest.run)
+and run the update. It keeps your Live installation, your license, and
+your projects:
+
+```bash
+sh ~/Downloads/install-ableton-latest.run --update
+```
+
+Until you can update, drag Live's window once after leaving fullscreen to
+clear the stuck image.
+
+If fullscreen is still wrong after the update, launch once with
+`WINE_WIN32_FULLSCREEN_CLASS=off ableton-live`, then
+[open an issue](https://github.com/shibco/ableton-linux/issues) and include
+your desktop environment and whether that launch behaved differently.
 
 ## Report a problem
 

--- a/notes/ABLETON-WINE-FULLSCREEN.md
+++ b/notes/ABLETON-WINE-FULLSCREEN.md
@@ -1,0 +1,88 @@
+# Ableton Live fullscreen layout and exit state
+
+Issue 42 has two related fullscreen failures. `View -> Full Screen` can leave
+the native menu visible, while F11 can shift or clip Live's client area and
+offset pointer input. Exiting fullscreen can also leave the compositor showing
+a fullscreen-sized surface until the window is moved or resized.
+
+## Menu and client offset
+
+Live uses custom chrome but leaves its Win32 menu attached while entering
+fullscreen. Wine therefore continues to reserve and paint a menu band during
+non-client calculation. Live compensates with a slightly oversized and shifted
+window, so the Win32 client origin no longer agrees with the compositor's
+viewport. The rendered controls and their input coordinates are displaced by
+the unwanted menu allowance.
+
+Patch 0065 lets the launcher select one exact top-level Windows class through
+`WINE_WIN32_FULLSCREEN_CLASS`. When that class requests a rectangle covering a
+monitor with no more than a small edge overshoot, win32u marks the window as
+fullscreen before non-client calculation and clamps the request to the exact
+monitor rectangle. The still-attached menu contributes no layout or painting
+while that mark is active. Leaving fullscreen clears the mark and restores
+ordinary menu handling.
+
+The monitor-covering check is deliberately bounded: it does not turn arbitrary
+large window requests into fullscreen, and it does not affect child windows or
+classes that the launcher did not select.
+
+## Fullscreen exit
+
+Wine's X11 driver tracks both the compositor's current rectangle and a pending
+configure request. During fullscreen entry, a ConfigureNotify can satisfy the
+requested rectangle with a serial older than a later equivalent request. The
+window is already at the requested geometry, but `configure_serial` remains
+set.
+
+If Live exits fullscreen in that state, Wine delays the
+`_NET_WM_STATE_FULLSCREEN` removal while waiting for another configure. The
+window manager in turn keeps the fullscreen surface until the EWMH state is
+removed. An interactive move or resize produces a new configure and happens to
+break that wait, which is why dragging the window appeared to repair it.
+
+On the selected class's fullscreen-to-windowed transition, patch 0065 retires
+only a pending configure whose rectangle is already identical to the current
+compositor rectangle. It then updates `_NET_WM_STATE` before queuing the restored
+window geometry. No synthetic move, recursive `SetWindowPos`, or compositor
+specific command is involved.
+
+The diagnostic trace for the repaired path includes:
+
+```text
+retiring redundant fullscreen config ... before exit
+requesting _NET_WM_STATE 0
+```
+
+## Launcher and comparison override
+
+The Live launcher selects the exact main-window class by default:
+
+```text
+WINE_WIN32_FULLSCREEN_CLASS="Ableton Live Window Class"
+```
+
+For a one-launch unpatched comparison:
+
+```bash
+WINE_WIN32_FULLSCREEN_CLASS=off ableton-live
+```
+
+`off` is simply a non-matching class name, so both 0065 paths remain dormant.
+Without the variable, or for every other class, Wine keeps its existing
+behavior.
+
+This patch does not change general minimum-size handling. Patch 0053 remains
+responsible for exporting Live's `WM_GETMINMAXINFO` minimum as the X11
+`PMinSize` hint.
+
+## Validation
+
+- The complete Wine 11.13 patch stack built successfully and the build audit
+  passed 88 checks, including the win32u and winex11 0065 fingerprints.
+- `View -> Full Screen` and F11 entry/exit were exercised repeatedly on both
+  Niri with xwayland-satellite and Plasma/KWin with Xwayland.
+- Fullscreen covered the 1920x1080 output without a title bar, native menu, or
+  desktop panel; client content and pointer input remained aligned.
+- Each exit returned directly to normal floating geometry without a stale
+  fullscreen surface, and the window could be moved and resized immediately.
+- Ordinary windowed menu layout and post-fullscreen resizing remained intact.

--- a/notes/ABLETON-WINE-FULLSCREEN.md
+++ b/notes/ABLETON-WINE-FULLSCREEN.md
@@ -15,16 +15,22 @@ viewport. The rendered controls and their input coordinates are displaced by
 the unwanted menu allowance.
 
 Patch 0065 lets the launcher select one exact top-level Windows class through
-`WINE_WIN32_FULLSCREEN_CLASS`. When that class requests a rectangle covering a
-monitor with no more than a small edge overshoot, win32u marks the window as
-fullscreen before non-client calculation and clamps the request to the exact
-monitor rectangle. The still-attached menu contributes no layout or painting
-while that mark is active. Leaving fullscreen clears the mark and restores
-ordinary menu handling.
+`WINE_WIN32_FULLSCREEN_CLASS`. When that class becomes borderless and requests
+a rectangle covering a monitor with no more than a small edge overshoot,
+win32u marks the window as fullscreen before non-client calculation and clamps
+the request to the exact monitor rectangle. The still-attached menu contributes
+no layout or painting while that mark is active.
 
-The monitor-covering check is deliberately bounded: it does not turn arbitrary
-large window requests into fullscreen, and it does not affect child windows or
-classes that the launcher did not select.
+Live can enter fullscreen through a no-size window-position pass that skips
+`WM_NCCALCSIZE`. The patch therefore enforces the monitor-sized client after
+Wine's non-client calculation and discards stale windowed valid rectangles.
+This prevents the old menu/frame strip from being copied into the fullscreen
+surface and keeps rendered controls aligned with pointer input.
+
+The monitor-covering check is deliberately bounded and requires the selected
+window to be borderless. A captioned window can fill the monitor without being
+treated as fullscreen, so ordinary windowed layout and its menu remain intact.
+Child windows and classes that the launcher did not select are unaffected.
 
 ## Fullscreen exit
 
@@ -43,8 +49,10 @@ break that wait, which is why dragging the window appeared to repair it.
 On the selected class's fullscreen-to-windowed transition, patch 0065 retires
 only a pending configure whose rectangle is already identical to the current
 compositor rectangle. It then updates `_NET_WM_STATE` before queuing the restored
-window geometry. No synthetic move, recursive `SetWindowPos`, or compositor
-specific command is involved.
+window geometry. Removing the fullscreen marker also forces a non-client
+recalculation, restoring the ordinary menu and client rectangle even when Live
+exits through another no-size pass. No synthetic move, recursive `SetWindowPos`,
+or compositor-specific command is involved.
 
 The diagnostic trace for the repaired path includes:
 
@@ -61,19 +69,7 @@ The Live launcher selects the exact main-window class by default:
 WINE_WIN32_FULLSCREEN_CLASS="Ableton Live Window Class"
 ```
 
-For a one-launch unpatched comparison:
-
-```bash
-WINE_WIN32_FULLSCREEN_CLASS=off ableton-live
-```
-
-`off` is simply a non-matching class name, so both 0065 paths remain dormant.
-Without the variable, or for every other class, Wine keeps its existing
-behavior.
-
-This patch does not change general minimum-size handling. Patch 0053 remains
-responsible for exporting Live's `WM_GETMINMAXINFO` minimum as the X11
-`PMinSize` hint.
+`WINE_WIN32_FULLSCREEN_CLASS=off` is available for A/B comparison.
 
 ## Validation
 
@@ -85,4 +81,7 @@ responsible for exporting Live's `WM_GETMINMAXINFO` minimum as the X11
   desktop panel; client content and pointer input remained aligned.
 - Each exit returned directly to normal floating geometry without a stale
   fullscreen surface, and the window could be moved and resized immediately.
-- Ordinary windowed menu layout and post-fullscreen resizing remained intact.
+- A captioned window at exactly 1920x1080 remained windowed, kept its menu, and
+  did not advertise `_NET_WM_STATE_FULLSCREEN`.
+- FabFilter Pro-Q 4 opened, rendered, accepted input, and closed normally after
+  the fullscreen changes.

--- a/notes/ABLETON-WINE-FULLSCREEN.md
+++ b/notes/ABLETON-WINE-FULLSCREEN.md
@@ -76,7 +76,8 @@ WINE_WIN32_FULLSCREEN_CLASS="Ableton Live Window Class"
 - The complete Wine 11.13 patch stack built successfully and the build audit
   passed 88 checks, including the win32u and winex11 0065 fingerprints.
 - `View -> Full Screen` and F11 entry/exit were exercised repeatedly on both
-  Niri with xwayland-satellite and Plasma/KWin with Xwayland.
+  Niri with xwayland-satellite and Plasma/KWin with Xwayland. Follow-up runs
+  on GNOME, Sway, and MangoWM behaved the same (PR 114 comments, 2026-08-01).
 - Fullscreen covered the 1920x1080 output without a title bar, native menu, or
   desktop panel; client content and pointer input remained aligned.
 - Each exit returned directly to normal floating geometry without a stale
@@ -85,3 +86,14 @@ WINE_WIN32_FULLSCREEN_CLASS="Ableton Live Window Class"
   did not advertise `_NET_WM_STATE_FULLSCREEN`.
 - FabFilter Pro-Q 4 opened, rendered, accepted input, and closed normally after
   the fullscreen changes.
+
+## Open checks
+
+- Multi-monitor layouts remain untested. The normalization binds to the
+  monitor that `monitor_info_from_rect` returns for the requested rectangle,
+  and a window spanning two outputs matches no monitor within the 256-pixel
+  tolerance, so the patch leaves it alone. Entering fullscreen on each
+  output of a two-monitor setup still needs a verification run.
+- Fractional display scaling remains untested in fullscreen. The marking
+  runs in thread-DPI coordinates before `map_dpi_winpos`, matching the
+  surrounding code, and needs one run on a 125% or 150% desktop.

--- a/patches/0065-win32u-normalize-selected-fullscreen-window.patch
+++ b/patches/0065-win32u-normalize-selected-fullscreen-window.patch
@@ -52,7 +52,7 @@ index 15a460a..80d6fdf 100644
  extern int map_window_points( HWND hwnd_from, HWND hwnd_to, POINT *points, UINT count,
                                struct ratio dpi );
 diff --git a/dlls/win32u/window.c b/dlls/win32u/window.c
-index 2c86974..2a275ba 100644
+index 2c86974..6188247 100644
 --- a/dlls/win32u/window.c
 +++ b/dlls/win32u/window.c
 @@ -24,6 +24,7 @@
@@ -108,7 +108,26 @@ index 2c86974..2a275ba 100644
              get_menu( winpos->hwnd ) &&
              !EqualRect( &old_rects->client, &old_rects->window ) &&
              EqualRect( &params.rgrc[0], &new_rects->window ))
-@@ -4287,6 +4319,60 @@ BOOL WINAPI NtUserSetWindowPos( HWND hwnd, HWND after, INT x, INT y, INT cx, INT
+@@ -4151,6 +4183,18 @@ BOOL set_window_pos( WINDOWPOS *winpos, int parent_x, int parent_y )
+ 
+     calc_ncsize( winpos, &old_rects, &new_rects, valid_rects, parent_x, parent_y );
+ 
++    if (is_selected_fullscreen_window( winpos->hwnd,
++                                       get_window_long( winpos->hwnd, GWL_STYLE ) ))
++    {
++        /* Live can enter fullscreen through a no-size window-position pass,
++         * which skips WM_NCCALCSIZE and leaves the windowed menu/frame offset
++         * in the stored client rectangle. Enforce the selected fullscreen
++         * client after every calculation and preserve no stale windowed area. */
++        new_rects.client = new_rects.window;
++        SetRectEmpty( &valid_rects[0] );
++        SetRectEmpty( &valid_rects[1] );
++    }
++
+     surface = get_window_surface( winpos->hwnd, winpos->flags, FALSE, &new_rects, &surface_rect );
+     if (!apply_window_pos( winpos->hwnd, winpos->hwndInsertAfter, winpos->flags, surface,
+                            &new_rects, valid_rects ))
+@@ -4287,6 +4331,68 @@ BOOL WINAPI NtUserSetWindowPos( HWND hwnd, HWND after, INT x, INT y, INT cx, INT
      winpos.cy = cy;
      winpos.flags = flags;
  
@@ -119,6 +138,7 @@ index 2c86974..2a275ba 100644
 +    {
 +        RECT current;
 +        LONG req_x = winpos.x, req_y = winpos.y, req_width = winpos.cx, req_height = winpos.cy;
++        BOOL was_fullscreen = !!NtUserGetProp( winpos.hwnd, selected_fullscreen_prop );
 +        BOOL have_effective_rect = TRUE;
 +
 +        if ((flags & (SWP_NOMOVE | SWP_NOSIZE)) &&
@@ -153,7 +173,8 @@ index 2c86974..2a275ba 100644
 +                req_y + req_height >= mi.rcMonitor.bottom &&
 +                req_y + req_height <= mi.rcMonitor.bottom + 256;
 +
-+            if (covers_monitor)
++            if (covers_monitor &&
++                (get_window_long( winpos.hwnd, GWL_STYLE ) & WS_CAPTION) != WS_CAPTION)
 +            {
 +                NtUserSetProp( winpos.hwnd, selected_fullscreen_prop, UlongToHandle( 1 ) );
 +                winpos.x = mi.rcMonitor.left;
@@ -162,7 +183,13 @@ index 2c86974..2a275ba 100644
 +                winpos.cy = mon_height;
 +                winpos.flags &= ~(SWP_NOMOVE | SWP_NOSIZE);
 +            }
-+            else NtUserRemoveProp( winpos.hwnd, selected_fullscreen_prop );
++            else
++            {
++                NtUserRemoveProp( winpos.hwnd, selected_fullscreen_prop );
++                /* The fullscreen client override survives a no-size exit
++                 * unless the ordinary non-client area is recalculated. */
++                if (was_fullscreen) winpos.flags |= SWP_FRAMECHANGED;
++            }
 +        }
 +    }
 +
@@ -170,7 +197,7 @@ index 2c86974..2a275ba 100644
  
      if (is_current_thread_window( hwnd ))
 diff --git a/dlls/winex11.drv/window.c b/dlls/winex11.drv/window.c
-index 39aedc4..dfab140 100644
+index 39aedc4..9208df5 100644
 --- a/dlls/winex11.drv/window.c
 +++ b/dlls/winex11.drv/window.c
 @@ -118,6 +118,25 @@ static const WCHAR dcomp_active_propW[] =
@@ -199,7 +226,19 @@ index 39aedc4..dfab140 100644
  static const char *debugstr_mwm_hints( const MwmHints *hints )
  {
      return wine_dbg_sprintf( "%lx,%lx", hints->functions, hints->decorations );
-@@ -3989,6 +4008,25 @@ void X11DRV_WindowPosChanged( HWND hwnd, HWND insert_after, HWND owner_hint, UIN
+@@ -3963,6 +3982,11 @@ void X11DRV_WindowPosChanged( HWND hwnd, HWND insert_after, HWND owner_hint, UIN
+     struct window_rects old_rects;
+     BOOL is_managed, was_fullscreen, activate = !(swp_flags & SWP_NOACTIVATE), fullscreen = !!(swp_flags & WINE_SWP_FULLSCREEN);
+ 
++    /* A selected captioned window may legitimately fill a tiled work area.
++     * Geometry alone must not turn that ordinary window into EWMH fullscreen. */
++    if (fullscreen && selected_fullscreen_class( hwnd ) &&
++        (new_style & WS_CAPTION) == WS_CAPTION) fullscreen = FALSE;
++
+     if ((is_managed = is_window_managed( hwnd, swp_flags, fullscreen ))) make_owner_managed( hwnd );
+ 
+     if (!(data = get_win_data( hwnd ))) return;
+@@ -3989,6 +4013,25 @@ void X11DRV_WindowPosChanged( HWND hwnd, HWND insert_after, HWND owner_hint, UIN
      data->is_fullscreen = fullscreen;
      data->is_resizable = !!(swp_flags & WINE_SWP_RESIZABLE);
  

--- a/patches/0065-win32u-normalize-selected-fullscreen-window.patch
+++ b/patches/0065-win32u-normalize-selected-fullscreen-window.patch
@@ -1,0 +1,227 @@
+Subject: win32u, winex11: normalize a selected fullscreen window
+
+Some custom-chrome applications leave their native menu attached when they
+enter fullscreen. Wine then reserves and paints the menu, while the
+application compensates with an oversized, vertically shifted window. The
+Win32 client coordinates and compositor viewport consequently disagree.
+
+Allow a launcher to select one exact top-level Windows class. Mark its
+monitor-covering geometry before calculating the non-client area, exclude the
+attached menu from fullscreen layout and painting, and normalize only requests
+with a small edge overshoot to the exact monitor rectangle. Decorated
+non-fullscreen windows and every other class retain existing behavior.
+
+On fullscreen exit, retire a redundant compositor configure request when its
+geometry is already current. This lets Wine request fullscreen removal before
+queuing the restored window rectangle, avoiding a configure/state deadlock
+that otherwise clears only after an interactive move.
+
+diff --git a/dlls/win32u/defwnd.c b/dlls/win32u/defwnd.c
+index e377e5f..62c6155 100644
+--- a/dlls/win32u/defwnd.c
++++ b/dlls/win32u/defwnd.c
+@@ -68,7 +68,8 @@ static BOOL has_static_outer_frame( UINT ex_style )
+ 
+ static BOOL has_menu( HWND hwnd, UINT style )
+ {
+-    return (style & (WS_CHILD | WS_POPUP)) != WS_CHILD && get_menu( hwnd );
++    return (style & (WS_CHILD | WS_POPUP)) != WS_CHILD &&
++           !is_selected_fullscreen_window( hwnd, style ) && get_menu( hwnd );
+ }
+ 
+ void fill_rect( HDC dc, const RECT *rect, HBRUSH hbrush )
+@@ -1879,7 +1880,7 @@ static void handle_nc_calc_size( HWND hwnd, WPARAM wparam, RECT *win_rect )
+         win_rect->right  -= rect.right;
+         win_rect->bottom -= rect.bottom;
+ 
+-        if ((style & (WS_CHILD | WS_POPUP)) != WS_CHILD)
++        if (has_menu( hwnd, style ))
+         {
+             HMENU menu = get_menu( hwnd );
+ 
+diff --git a/dlls/win32u/win32u_private.h b/dlls/win32u/win32u_private.h
+index 15a460a..80d6fdf 100644
+--- a/dlls/win32u/win32u_private.h
++++ b/dlls/win32u/win32u_private.h
+@@ -310,6 +310,7 @@ extern BOOL get_window_rect_rel( HWND hwnd, enum coords_relative rel, RECT *rect
+ extern BOOL get_client_rect_rel( HWND hwnd, enum coords_relative rel, RECT *rect, struct ratio dpi );
+ extern BOOL get_window_rects( HWND hwnd, enum coords_relative relative,
+                               struct window_rects *rects, struct ratio dpi );
++extern BOOL is_selected_fullscreen_window( HWND hwnd, UINT style );
+ extern HWND *list_window_children( HWND hwnd );
+ extern int map_window_points( HWND hwnd_from, HWND hwnd_to, POINT *points, UINT count,
+                               struct ratio dpi );
+diff --git a/dlls/win32u/window.c b/dlls/win32u/window.c
+index 2c86974..2a275ba 100644
+--- a/dlls/win32u/window.c
++++ b/dlls/win32u/window.c
+@@ -24,6 +24,7 @@
+ #endif
+ 
+ #include <assert.h>
++#include <stdlib.h>
+ 
+ #include "ntstatus.h"
+ #include "ntgdi_private.h"
+@@ -41,6 +42,36 @@ static const struct ratio no_dpi;
+ 
+ static void *client_objects[MAX_USER_HANDLES];
+ 
++static const WCHAR selected_fullscreen_prop[] =
++    {'_','_','w','i','n','e','_','w','i','n','3','2','_','s','e','l','e','c','t','e','d','_',
++     'f','u','l','l','s','c','r','e','e','n',0};
++
++static BOOL is_selected_window_class( HWND hwnd )
++{
++    const char *selected_class = getenv( "WINE_WIN32_FULLSCREEN_CLASS" );
++    WCHAR class_buffer[128];
++    UNICODE_STRING class_name = {0, sizeof(class_buffer), class_buffer};
++    size_t selected_length;
++    unsigned int i;
++    INT class_length;
++
++    if (!selected_class || !selected_class[0]) return FALSE;
++    if (NtUserGetAncestor( hwnd, GA_PARENT ) != get_desktop_window()) return FALSE;
++    if ((selected_length = strlen( selected_class )) >= ARRAY_SIZE(class_buffer)) return FALSE;
++    if ((class_length = NtUserGetClassName( hwnd, FALSE, &class_name )) <= 0) return FALSE;
++    if ((unsigned int)class_length != selected_length) return FALSE;
++    for (i = 0; i < (unsigned int)class_length; ++i)
++        if ((unsigned char)selected_class[i] != class_buffer[i]) return FALSE;
++    return TRUE;
++}
++
++BOOL is_selected_fullscreen_window( HWND hwnd, UINT style )
++{
++    if (style & WS_CHILD) return FALSE;
++    if (!is_selected_window_class( hwnd )) return FALSE;
++    return (style & WS_CAPTION) != WS_CAPTION || NtUserGetProp( hwnd, selected_fullscreen_prop );
++}
++
+ #define SWP_AGG_NOGEOMETRYCHANGE \
+     (SWP_NOSIZE | SWP_NOCLIENTSIZE | SWP_NOZORDER)
+ #define SWP_AGG_NOPOSCHANGE \
+@@ -3853,6 +3884,7 @@ static UINT calc_ncsize( WINDOWPOS *winpos, const struct window_rects *old_rects
+          * temporarily reports a client rect covering the whole window. */
+         if (!(style & WS_CHILD) &&
+             !(winpos->flags & SWP_FRAMECHANGED) &&
++            !is_selected_fullscreen_window( winpos->hwnd, style ) &&
+             get_menu( winpos->hwnd ) &&
+             !EqualRect( &old_rects->client, &old_rects->window ) &&
+             EqualRect( &params.rgrc[0], &new_rects->window ))
+@@ -4287,6 +4319,60 @@ BOOL WINAPI NtUserSetWindowPos( HWND hwnd, HWND after, INT x, INT y, INT cx, INT
+     winpos.cy = cy;
+     winpos.flags = flags;
+ 
++    /* Mark the selected application's fullscreen geometry before non-client
++     * calculation, so an attached menu does not shift its client area. Keep
++     * small monitor-edge overshoots inside the exact monitor rectangle. */
++    if (is_selected_window_class( winpos.hwnd ))
++    {
++        RECT current;
++        LONG req_x = winpos.x, req_y = winpos.y, req_width = winpos.cx, req_height = winpos.cy;
++        BOOL have_effective_rect = TRUE;
++
++        if ((flags & (SWP_NOMOVE | SWP_NOSIZE)) &&
++            !get_window_rect( winpos.hwnd, &current, get_thread_dpi() ))
++            have_effective_rect = FALSE;
++        else if (flags & (SWP_NOMOVE | SWP_NOSIZE))
++        {
++            if (flags & SWP_NOMOVE)
++            {
++                req_x = current.left;
++                req_y = current.top;
++            }
++            if (flags & SWP_NOSIZE)
++            {
++                req_width = current.right - current.left;
++                req_height = current.bottom - current.top;
++            }
++        }
++
++        if (have_effective_rect && req_width > 0 && req_height > 0)
++        {
++            RECT requested = {req_x, req_y, req_x + req_width, req_y + req_height};
++            MONITORINFO mi = monitor_info_from_rect( requested, get_thread_dpi() );
++            LONG mon_width = mi.rcMonitor.right - mi.rcMonitor.left;
++            LONG mon_height = mi.rcMonitor.bottom - mi.rcMonitor.top;
++            BOOL covers_monitor =
++                mon_width > 0 && mon_height > 0 &&
++                req_x <= mi.rcMonitor.left && req_x >= mi.rcMonitor.left - 256 &&
++                req_y <= mi.rcMonitor.top && req_y >= mi.rcMonitor.top - 256 &&
++                req_x + req_width >= mi.rcMonitor.right &&
++                req_x + req_width <= mi.rcMonitor.right + 256 &&
++                req_y + req_height >= mi.rcMonitor.bottom &&
++                req_y + req_height <= mi.rcMonitor.bottom + 256;
++
++            if (covers_monitor)
++            {
++                NtUserSetProp( winpos.hwnd, selected_fullscreen_prop, UlongToHandle( 1 ) );
++                winpos.x = mi.rcMonitor.left;
++                winpos.y = mi.rcMonitor.top;
++                winpos.cx = mon_width;
++                winpos.cy = mon_height;
++                winpos.flags &= ~(SWP_NOMOVE | SWP_NOSIZE);
++            }
++            else NtUserRemoveProp( winpos.hwnd, selected_fullscreen_prop );
++        }
++    }
++
+     map_dpi_winpos( &winpos );
+ 
+     if (is_current_thread_window( hwnd ))
+diff --git a/dlls/winex11.drv/window.c b/dlls/winex11.drv/window.c
+index 39aedc4..dfab140 100644
+--- a/dlls/winex11.drv/window.c
++++ b/dlls/winex11.drv/window.c
+@@ -118,6 +118,25 @@ static const WCHAR dcomp_active_propW[] =
+     {'_','_','w','i','n','e','_','d','c','o','m','p','_','a','c','t','i','v','e',0};
+ static const WCHAR *dcomp_active_prop = dcomp_active_propW;
+ 
++static BOOL selected_fullscreen_class( HWND hwnd )
++{
++    const char *selected_class = getenv( "WINE_WIN32_FULLSCREEN_CLASS" );
++    WCHAR class_buffer[128];
++    UNICODE_STRING class_name = {0, sizeof(class_buffer), class_buffer};
++    size_t selected_length;
++    unsigned int i;
++    INT class_length;
++
++    if (!selected_class || !selected_class[0]) return FALSE;
++    if (NtUserGetAncestor( hwnd, GA_PARENT ) != NtUserGetDesktopWindow()) return FALSE;
++    if ((selected_length = strlen( selected_class )) >= ARRAY_SIZE(class_buffer)) return FALSE;
++    if ((class_length = NtUserGetClassName( hwnd, FALSE, &class_name )) <= 0) return FALSE;
++    if ((unsigned int)class_length != selected_length) return FALSE;
++    for (i = 0; i < (unsigned int)class_length; ++i)
++        if ((unsigned char)selected_class[i] != class_buffer[i]) return FALSE;
++    return TRUE;
++}
++
+ static const char *debugstr_mwm_hints( const MwmHints *hints )
+ {
+     return wine_dbg_sprintf( "%lx,%lx", hints->functions, hints->decorations );
+@@ -3989,6 +4008,25 @@ void X11DRV_WindowPosChanged( HWND hwnd, HWND insert_after, HWND owner_hint, UIN
+     data->is_fullscreen = fullscreen;
+     data->is_resizable = !!(swp_flags & WINE_SWP_RESIZABLE);
+ 
++    /* A fullscreen ConfigureNotify may satisfy the requested rectangle with
++     * a serial older than our redundant configure request. If the selected
++     * app exits fullscreen before another notify arrives, waiting for that
++     * request blocks _NET_WM_STATE removal, while the WM waits for removal
++     * before granting the normal rectangle. Retire only a pending configure
++     * whose geometry is already current, then request fullscreen removal
++     * before sync_window_position queues the normal rectangle. */
++    if (was_fullscreen && !fullscreen && selected_fullscreen_class( hwnd ) &&
++        data->configure_serial && !data->pending_state.above &&
++        EqualRect( &data->pending_state.rect, &data->current_state.rect ))
++    {
++        TRACE( "window %p/%lx retiring redundant fullscreen config %s request %lu before exit\n",
++               data->hwnd, data->whole_window, wine_dbgstr_rect(&data->pending_state.rect),
++               data->configure_serial );
++        data->configure_serial = 0;
++        clear_config_rounding( data, "redundant fullscreen config retired before exit" );
++        update_net_wm_states( data );
++    }
++
+     TRACE( "win %p/%lx new_rects %s style %08x flags %08x\n", hwnd, data->whole_window,
+            debugstr_window_rects(new_rects), new_style, swp_flags );
+ 

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -11,7 +11,7 @@ narrative — 5 merge conflicts, three build breaks the clean rebase didn't
 catch, a build.sh/pipefail tooling gotcha — is in
 `notes/ABLETON-WINE-11.11-TO-11.13-BASE-BUMP.md`.
 
-The current Wine series contains 62 files, numbered 0001 through 0064.
+The current Wine series contains 63 files, numbered 0001 through 0065.
 Patches 0027 and 0044 are intentionally absent.
 
 ## Applying the series
@@ -238,3 +238,9 @@ Apply them in sequence with the rest of the series.
   only intercepted in its `/select` form, so the library panel still
   spawned Wine Explorer. Fallbacks: the 0063 reveal ladder, then Wine
   Explorer. See `notes/ABLETON-WINE-SHOW-IN-EXPLORER.md`.
+- `0065`: normalize monitor-covering geometry for one launcher-selected
+  top-level Windows class, keep its attached menu out of fullscreen layout
+  and painting, and retire an already-satisfied X11 configure request before
+  removing `_NET_WM_STATE_FULLSCREEN` on exit. The Live launcher selects
+  `Ableton Live Window Class`; other classes and ordinary windowed geometry
+  retain Wine's existing behavior. See `notes/ABLETON-WINE-FULLSCREEN.md`.

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -60,5 +60,6 @@ eb85bc3dc958314b299ebe45dc690ed3e9958d7beea82647513964ca0531a1b6  0059-wined3d-q
 a07f7ecb2c3a568d8eeae9a42df558cea4d8e279e5bdeb0af67a6649086973f7  0062-winex11-keep-a-selected-top-level-class-offscreen.patch
 0a7fb762e4bef288556f2118c318f6e99fe5532bb61058ccdb6d7732bf42ba27  0063-comdlg32-reveal-explorer-select-folder-targets-throu.patch
 81e02eeac88e6eda5da8044cd5bf74a197b2742f77c46da54e61dbf300031bd3  0064-shell32-route-explorer-folder-open-commands-to-the-h.patch
+f81dc2d6fcd2e42a94e6f8824ec4a5ba981ea804adfb457ea9a7aaa3a6e23d06  0065-win32u-normalize-selected-fullscreen-window.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -60,6 +60,6 @@ eb85bc3dc958314b299ebe45dc690ed3e9958d7beea82647513964ca0531a1b6  0059-wined3d-q
 a07f7ecb2c3a568d8eeae9a42df558cea4d8e279e5bdeb0af67a6649086973f7  0062-winex11-keep-a-selected-top-level-class-offscreen.patch
 0a7fb762e4bef288556f2118c318f6e99fe5532bb61058ccdb6d7732bf42ba27  0063-comdlg32-reveal-explorer-select-folder-targets-throu.patch
 81e02eeac88e6eda5da8044cd5bf74a197b2742f77c46da54e61dbf300031bd3  0064-shell32-route-explorer-folder-open-commands-to-the-h.patch
-f81dc2d6fcd2e42a94e6f8824ec4a5ba981ea804adfb457ea9a7aaa3a6e23d06  0065-win32u-normalize-selected-fullscreen-window.patch
+7931be1771a070325eb0b87f970e51f7089c216f1bad128fb5ecf504e100e005  0065-win32u-normalize-selected-fullscreen-window.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/scripts/ableton-live
+++ b/scripts/ableton-live
@@ -6,7 +6,8 @@
 #            ABLETON_LIVE_VERSION=11|12 (restrict discovery to one major version),
 #            ABLETON_RT=off (skip the realtime probe; run Live under normal scheduling),
 #            ABLETON_LINKD=/path/to/ableton-linkd (Ableton Link session anchor override),
-#            WINE_X11_FORCE_OFFSCREEN_CLASS=off (disable the M4L selection-flicker fix).
+#            WINE_X11_FORCE_OFFSCREEN_CLASS=off (disable the M4L selection-flicker fix),
+#            WINE_WIN32_FULLSCREEN_CLASS=off (disable Live fullscreen normalization).
 set -u
 # Clear inherited Wine variables so this launch uses only the patched build.
 unset WINELOADER WINEDLLPATH WINEDLLOVERRIDES WINEARCH
@@ -21,6 +22,10 @@ export WINED3D_DCOMP_FORCE_FULL_REDRAW="${WINED3D_DCOMP_FORCE_FULL_REDRAW:-1}"
 # client surface. Keep Live on the offscreen path; "off" is a non-matching class
 # value and therefore provides a one-launch A/B override.
 export WINE_X11_FORCE_OFFSCREEN_CLASS="${WINE_X11_FORCE_OFFSCREEN_CLASS:-Ableton Live Window Class}"
+# Live leaves its native menu attached in fullscreen, and a redundant X11
+# configure can otherwise delay fullscreen removal on exit. Select only Live's
+# exact top-level class; "off" is a non-matching one-launch A/B override.
+export WINE_WIN32_FULLSCREEN_CLASS="${WINE_WIN32_FULLSCREEN_CLASS:-Ableton Live Window Class}"
 # Report host mount points as plain dirs (patch 0033); Live's browser treats
 # junctions without reparse data as unresolvable and skips them.
 export WINE_DISABLE_UNIX_MOUNT_REPARSE="${WINE_DISABLE_UNIX_MOUNT_REPARSE:-1}"

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -139,6 +139,8 @@ FINGERPRINTS='
 0063|ascii|lib/wine/x86_64-unix/comdlg32.so|org.freedesktop.FileManager1
 0064|ascii|lib/wine/x86_64-unix/comdlg32.so|ShowFolders
 0064|ascii|lib/wine/x86_64-windows/shell32.dll|__wine_portal_open_folder
+0065|ascii|lib/wine/x86_64-unix/win32u.so|WINE_WIN32_FULLSCREEN_CLASS
+0065|ascii|lib/wine/x86_64-unix/winex11.so|WINE_WIN32_FULLSCREEN_CLASS
 pipeasio/0001|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-clamp-sample-rate
 pipeasio/0002|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-midi-timebase
 '


### PR DESCRIPTION
## Summary

- Add Wine patch 0065 to normalize monitor-covering geometry for the launcher-selected Ableton Live window class.
- Exclude Live's still-attached native menu from fullscreen layout and painting, keeping rendered content and pointer coordinates aligned.
- Retire an already-satisfied X11 configure request during fullscreen exit so `_NET_WM_STATE_FULLSCREEN` is removed before restoring windowed geometry.
- `WINE_WIN32_FULLSCREEN_CLASS=off` is available for A/B comparison.

## Cause

Live retains its native Win32 menu while entering fullscreen. Wine consequently reserves a menu band even though Live expects the client area to cover the output, producing shifted or clipped content and offset pointer input.

On fullscreen exit, Wine can also retain a pending configure request whose rectangle has already been applied. It then waits for another configure before removing `_NET_WM_STATE_FULLSCREEN`, while the window manager waits for fullscreen removal before granting the restored rectangle. Moving or resizing the window breaks that wait accidentally.

Patch 0065 scopes both corrections to the exact top-level class selected by the launcher. VST windows continue to open, render, and resize normally.

## Validation

- The complete Wine 11.13 patch stack built successfully, and the build audit passed all 88 checks, including the new win32u and winex11 fingerprints.
- `View -> Full Screen` and F11 entry and exit were repeatedly verified on both Niri with xwayland-satellite and Plasma/KWin with Xwayland.
- Fullscreen hides the title bar, native menu, and desktop panel while keeping client content and pointer input aligned.
- Exiting fullscreen immediately restores normal floating geometry without stale fullscreen visuals; the window can be moved and resized without an extra drag or configure event.

Fixes #42
