### PR TITLE
Add Push 3 support.

### DIFF
--- a/notes/ABLETON-WINE-PUSH2-DISPLAY.md
+++ b/notes/ABLETON-WINE-PUSH2-DISPLAY.md
@@ -58,7 +58,9 @@ HKCU\Software\Wine\AppDefaults\Push2DisplayProcess.exe\DllOverrides
     libusb-1.0 = builtin
 ```
 
-Live keeps its application-local libusb DLL. No Ableton file is replaced.
+`setup-prefix.sh` also selects the builtin for the Live 12 executables
+([ABLETON-WINE-PUSH3-USB.md](ABLETON-WINE-PUSH3-USB.md)). No Ableton file
+is replaced.
 
 The bridge:
 

--- a/notes/ABLETON-WINE-PUSH2-DISPLAY.md
+++ b/notes/ABLETON-WINE-PUSH2-DISPLAY.md
@@ -144,6 +144,9 @@ Do not leave the override enabled when using a Wine runtime without patch
   loop.
 - Disconnect and `NO_DEVICE` recovery inside the bridge remain untested.
 - `Push3.exe` uses a different libusb surface and is outside this patch.
+  [Patch 0065](../patches/0065-libusb-1.0-extend-the-host-bridge-for-Push-3.patch)
+  extends the bridge for it; see
+  [ABLETON-WINE-PUSH3-USB.md](ABLETON-WINE-PUSH3-USB.md).
 - A Live process that started without MIDI ports does not discover them later.
 - Raw traces can contain the controller serial number. Do not publish them.
 

--- a/notes/ABLETON-WINE-PUSH3-USB.md
+++ b/notes/ABLETON-WINE-PUSH3-USB.md
@@ -6,9 +6,11 @@ libusb bridge so `Push3.exe` can reach Push 3's vendor USB interfaces through
 host libusb. The extension follows the same design as the Push 2 bridge,
 described in [ABLETON-WINE-PUSH2-DISPLAY.md](ABLETON-WINE-PUSH2-DISPLAY.md).
 
-Status: the code is written and the host USB path is verified on Push 3
-hardware. A runtime test of `Push3.exe` with Live has not happened yet.
-Do not describe Push 3 as supported until that test passes.
+Status: the host USB path is verified on Push 3 hardware. In the first
+contributor test, Live did not detect the Push 3 and did not start
+`Push3.exe`; the Detection section gives the cause and the correction.
+Runtime tests of detection and of `Push3.exe` with Live have not happened
+yet. Do not describe Push 3 as supported until they pass.
 
 ## Device
 
@@ -22,10 +24,10 @@ interface 5: MIDI, three ports (Live, User, External)
 interface 6: "xPort", vendor specific, bulk OUT 0x04 and IN 0x84, 512 bytes
 ```
 
-Linux exposes the audio and MIDI interfaces through `snd-usb-audio`, so Live
-identifies the controller the same way it identifies a Push 2. The display
-interface matches the Push 2 layout. Interface 6 has no Push 2 equivalent and
-its protocol is unknown.
+Linux exposes the audio and MIDI interfaces through `snd-usb-audio`, and
+Wine shows the three MIDI ports to Live. The display interface matches
+the Push 2 layout. Interface 6 has no Push 2 equivalent and its protocol
+is unknown.
 
 ## Cause
 
@@ -35,6 +37,37 @@ does not export: `libusb_bulk_transfer`, `libusb_strerror`,
 `libusb_hotplug_register_callback`, and `libusb_hotplug_deregister_callback`.
 The 0032 bridge also rejects claims on any interface other than 0, which
 blocks the xPort interface.
+
+## Detection
+
+Live starts `Push3.exe` only after it finds Push 3 hardware on USB.
+Push 3 has no control surface entry in Live's MIDI preferences. The
+Live 12 executable imports libusb and scans USB in its own process
+(import lists from `winedump -j import`):
+
+```text
+Live 12.4.3:   libusb_init, libusb_exit, libusb_get_device_list,
+               libusb_get_device_descriptor, libusb_free_device_list,
+               libusb_open, libusb_close, libusb_claim_interface,
+               libusb_release_interface, libusb_bulk_transfer,
+               libusb_strerror
+Live 12.4.5b7: the same list without libusb_bulk_transfer
+```
+
+Without an override, Live loads its application-local libusb DLL, which
+needs Windows USB drivers that do not exist in a Wine prefix. The scan
+finds no devices and Live never starts `Push3.exe`. A contributor trace
+from 2026-08-05 shows this state: all three MIDI ports visible in Live's
+MIDI preferences, no `Push3.exe` process.
+
+`setup-prefix.sh` therefore selects the builtin for the Live 12
+executables. Every Live 12 libusb import is a bridge export: nine from
+patch 0032, `libusb_bulk_transfer` and `libusb_strerror` from patch 0065.
+
+Do not set the Live override on a runtime without patch 0065: the loader
+cannot resolve `libusb_bulk_transfer` and `libusb_strerror` against the
+0032 bridge, and Live does not start. No released runtime contains patch
+0065.
 
 ## Bridge changes
 
@@ -50,15 +83,18 @@ Patch 0065 changes the builtin `libusb-1.0.dll`:
 - accepts claim and release for interface numbers 0 through 255 in both the
   PE and Unix layers, instead of interface 0 only
 
-The per-application override scopes the builtin to the helper, exactly as for
-Push 2. `setup-prefix.sh` sets:
+Per-application overrides select the builtin for the helper and for Live.
+`setup-prefix.sh` sets:
 
 ```text
 HKCU\Software\Wine\AppDefaults\Push3.exe\DllOverrides
     libusb-1.0 = builtin
+HKCU\Software\Wine\AppDefaults\<Live 12 executable>\DllOverrides
+    libusb-1.0 = builtin
 ```
 
-Live keeps its application-local libusb DLL. No Ableton file is replaced.
+The Live keys cover the Suite, Standard, Intro, Lite, Trial, and Beta
+executables.
 
 ## Verification
 
@@ -80,20 +116,11 @@ device, not a fault. Expect `Push3.exe` to consume this stream continuously;
 if the bridge's event handling stalls anywhere, this endpoint will show it
 first.
 
-Still open:
-
-- a runtime test of `Push3.exe` loading the builtin and streaming the display
-  in Live
-- the Live control-surface setup recipe for Push 3, to be recorded after the
-  runtime test
-- device node access: the probe ran under sudo. The repository ships no udev
-  rule, and stock systemd rules grant users the sound nodes, not the raw USB
-  node that libusb opens. How the production helper gets access on user
-  machines is unresolved for Push 2 and Push 3 alike.
+This hasn't been tested yet.
 
 ## Rollback
 
-Close Live and `Push3.exe`, then remove the helper override with this
+Close Live and `Push3.exe`, then remove the overrides with this
 project's Wine:
 
 ```bash
@@ -101,9 +128,14 @@ WINEPREFIX="$HOME/.wine-ableton" \
   "$HOME/.local/opt/wine-d2d1-nspa-11.13/bin/wine" reg delete \
   'HKCU\Software\Wine\AppDefaults\Push3.exe\DllOverrides' \
   /v libusb-1.0 /f
+WINEPREFIX="$HOME/.wine-ableton" \
+  "$HOME/.local/opt/wine-d2d1-nspa-11.13/bin/wine" reg delete \
+  'HKCU\Software\Wine\AppDefaults\Ableton Live 12 Suite.exe\DllOverrides' \
+  /v libusb-1.0 /f
 ```
 
-Do not leave the override enabled when using a Wine runtime without patch
+Repeat the second command for each installed Live 12 edition. Do not
+leave the overrides enabled when using a Wine runtime without patch
 0065.
 
 ## Limits
@@ -118,4 +150,5 @@ Do not leave the override enabled when using a Wine runtime without patch
   bridged.
 - The xPort protocol is undocumented. The bridge moves its bytes and nothing
   more.
+- Live 11 executables are not covered: their libusb imports are unverified.
 - Move is a different device and is not covered.

--- a/notes/ABLETON-WINE-PUSH3-USB.md
+++ b/notes/ABLETON-WINE-PUSH3-USB.md
@@ -1,0 +1,121 @@
+# Push 3 USB bridge
+
+[Patch 0065](../patches/0065-libusb-1.0-extend-the-host-bridge-for-Push-3.patch)
+extends the [patch 0032](../patches/0032-libusb-1.0-add-host-USB-bridge-for-Push-2.patch)
+libusb bridge so `Push3.exe` can reach Push 3's vendor USB interfaces through
+host libusb. The extension follows the same design as the Push 2 bridge,
+described in [ABLETON-WINE-PUSH2-DISPLAY.md](ABLETON-WINE-PUSH2-DISPLAY.md).
+
+Status: the code is written and the host USB path is verified on Push 3
+hardware. A runtime test of `Push3.exe` with Live has not happened yet.
+Do not describe Push 3 as supported until that test passes.
+
+## Device
+
+Push 3 is one composite USB device:
+
+```text
+2982:1969
+interface 0: display, bulk OUT 0x01 and IN 0x81, 512 bytes
+interfaces 1 to 4: USB audio (16 channels, internal and ADAT clock)
+interface 5: MIDI, three ports (Live, User, External)
+interface 6: "xPort", vendor specific, bulk OUT 0x04 and IN 0x84, 512 bytes
+```
+
+Linux exposes the audio and MIDI interfaces through `snd-usb-audio`, so Live
+identifies the controller the same way it identifies a Push 2. The display
+interface matches the Push 2 layout. Interface 6 has no Push 2 equivalent and
+its protocol is unknown.
+
+## Cause
+
+`Push3.exe` links against the same vendor libusb 1.0.23 DLL that ships with
+the Push 2 display helper, but imports four functions the patch 0032 bridge
+does not export: `libusb_bulk_transfer`, `libusb_strerror`,
+`libusb_hotplug_register_callback`, and `libusb_hotplug_deregister_callback`.
+The 0032 bridge also rejects claims on any interface other than 0, which
+blocks the xPort interface.
+
+## Bridge changes
+
+Patch 0065 changes the builtin `libusb-1.0.dll`:
+
+- exports `libusb_bulk_transfer` and forwards it to the host as one blocking
+  call on the calling thread
+- exports `libusb_strerror` with the standard libusb message strings
+- exports the two hotplug functions as stubs; registration returns
+  `LIBUSB_ERROR_NOT_SUPPORTED`. The vendor's Windows libusb build reports no
+  hotplug support either, so the helper already handles this result and polls
+  the device list instead
+- accepts claim and release for interface numbers 0 through 255 in both the
+  PE and Unix layers, instead of interface 0 only
+
+The per-application override scopes the builtin to the helper, exactly as for
+Push 2. `setup-prefix.sh` sets:
+
+```text
+HKCU\Software\Wine\AppDefaults\Push3.exe\DllOverrides
+    libusb-1.0 = builtin
+```
+
+Live keeps its application-local libusb DLL. No Ableton file is replaced.
+
+## Verification
+
+[`tools/push3usb.c`](../tools/push3usb.c) is the host-side probe, adapted from
+`push2usb.c`. It validates the descriptor layout of interfaces 0 and 6, claims
+and releases both, and runs a submit-and-cancel test on a bulk IN endpoint.
+The xPort transfer test runs only with `--cancel-in-xport`.
+
+A contributor ran the probe on Push 3 hardware on 2026-08-02:
+
+- enumeration, repeated claims, and releases succeeded on interfaces 0 and 6
+- the display cancel test returned `count=1 status=cancelled actual_length=0`
+- all three MIDI ports remained in the ALSA sequencer graph afterwards
+
+The xPort cancel test returned `status=cancelled` with `actual_length=512`:
+the device delivered a full packet before the cancel completed. The xPort IN
+endpoint always has data queued for the host. This is a property of the
+device, not a fault. Expect `Push3.exe` to consume this stream continuously;
+if the bridge's event handling stalls anywhere, this endpoint will show it
+first.
+
+Still open:
+
+- a runtime test of `Push3.exe` loading the builtin and streaming the display
+  in Live
+- the Live control-surface setup recipe for Push 3, to be recorded after the
+  runtime test
+- device node access: the probe ran under sudo. The repository ships no udev
+  rule, and stock systemd rules grant users the sound nodes, not the raw USB
+  node that libusb opens. How the production helper gets access on user
+  machines is unresolved for Push 2 and Push 3 alike.
+
+## Rollback
+
+Close Live and `Push3.exe`, then remove the helper override with this
+project's Wine:
+
+```bash
+WINEPREFIX="$HOME/.wine-ableton" \
+  "$HOME/.local/opt/wine-d2d1-nspa-11.13/bin/wine" reg delete \
+  'HKCU\Software\Wine\AppDefaults\Push3.exe\DllOverrides' \
+  /v libusb-1.0 /f
+```
+
+Do not leave the override enabled when using a Wine runtime without patch
+0065.
+
+## Limits
+
+- All patch 0032 limits apply: PE32+ x86-64 only, bulk transfers only,
+  `flags == 0`, no isochronous packets, no hotplug delivery.
+- `libusb_bulk_transfer` blocks the calling thread for up to the caller's
+  timeout, matching libusb's documented behaviour.
+- The interface guard accepts 0 through 255; the helper's own device and
+  interface selection remains the only filter.
+- Push 3's audio and MIDI interfaces stay with `snd-usb-audio` and are not
+  bridged.
+- The xPort protocol is undocumented. The bridge moves its bytes and nothing
+  more.
+- Move is a different device and is not covered.

--- a/patches/0065-libusb-1.0-extend-the-host-bridge-for-Push-3.patch
+++ b/patches/0065-libusb-1.0-extend-the-host-bridge-for-Push-3.patch
@@ -1,0 +1,223 @@
+Subject: libusb-1.0: extend the host bridge for Push 3
+
+---
+ dlls/libusb-1.0/libusb-1.0.spec |    4 ++
+ dlls/libusb-1.0/libusb.c        |   72 ++++++++++++++++++++++++++++++++++++++-
+ dlls/libusb-1.0/unixlib.c       |   25 ++++++++++++--
+ dlls/libusb-1.0/unixlib.h       |   13 +++++++
+ 4 files changed, 111 insertions(+), 3 deletions(-)
+
+diff --git a/dlls/libusb-1.0/libusb-1.0.spec b/dlls/libusb-1.0/libusb-1.0.spec
+index 2b1d14a..6a4b4aa 100644
+--- a/dlls/libusb-1.0/libusb-1.0.spec
++++ b/dlls/libusb-1.0/libusb-1.0.spec
+@@ -1,4 +1,5 @@
+ 4   stdcall libusb_alloc_transfer(long)
++8   stdcall libusb_bulk_transfer(ptr long ptr long ptr long)
+ 10  stdcall libusb_cancel_transfer(ptr)
+ 12  stdcall libusb_claim_interface(ptr long)
+ 16  stdcall libusb_close(ptr)
+@@ -9,8 +10,11 @@
+ 72  stdcall libusb_get_device_descriptor(ptr ptr)
+ 74  stdcall libusb_get_device_list(ptr ptr)
+ 110 stdcall libusb_handle_events_timeout(ptr ptr)
++116 stdcall libusb_hotplug_deregister_callback(ptr long)
++118 stdcall libusb_hotplug_register_callback(ptr long long long long long ptr ptr ptr)
+ 120 stdcall libusb_init(ptr)
+ 132 stdcall libusb_open(ptr ptr)
+ 140 stdcall libusb_release_interface(ptr long)
+ 154 varargs libusb_set_option(ptr long)
++159 stdcall libusb_strerror(long)
+ 161 stdcall libusb_submit_transfer(ptr)
+diff --git a/dlls/libusb-1.0/libusb.c b/dlls/libusb-1.0/libusb.c
+index cea773b..467a519 100644
+--- a/dlls/libusb-1.0/libusb.c
++++ b/dlls/libusb-1.0/libusb.c
+@@ -118,6 +118,11 @@ struct libusb_iso_packet_descriptor
+ struct libusb_transfer;
+ typedef void (WINAPI *libusb_transfer_cb_fn)(struct libusb_transfer *transfer);
+ 
++typedef int libusb_hotplug_callback_handle;
++typedef int (WINAPI *libusb_hotplug_callback_fn)(struct libusb_context *context,
++                                                 struct libusb_device *device,
++                                                 int event, void *user_data);
++
+ struct libusb_transfer
+ {
+     struct libusb_device_handle *dev_handle;
+@@ -411,7 +416,8 @@ static int interface_operation(struct libusb_device_handle *handle, int interfac
+     struct libusb_interface_params params = {0};
+     NTSTATUS status;
+ 
+-    if (!handle || interface_number != 0) return LIBUSB_ERROR_INVALID_PARAM;
++    if (!handle || interface_number < 0 || interface_number > 255)
++        return LIBUSB_ERROR_INVALID_PARAM;
+     params.handle = handle->native;
+     params.interface_number = interface_number;
+     status = WINE_UNIX_CALL(func, &params);
+@@ -539,6 +545,29 @@ int WINAPI libusb_handle_events_timeout(struct libusb_context *context, const st
+     return params.result;
+ }
+ 
++int WINAPI libusb_bulk_transfer(struct libusb_device_handle *handle, unsigned char endpoint,
++                                unsigned char *data, int length, int *transferred,
++                                unsigned int timeout)
++{
++    struct libusb_bulk_transfer_params params = {0};
++    NTSTATUS status;
++
++    TRACE("%p, %#x, %p, %d, %p, %u\n", handle, endpoint, data, length, transferred, timeout);
++
++    if (transferred) *transferred = 0;
++    if (!handle || length < 0 || (length && !data)) return LIBUSB_ERROR_INVALID_PARAM;
++
++    params.handle = handle->native;
++    params.buffer = (UINT_PTR)data;
++    params.timeout = timeout;
++    params.length = length;
++    params.endpoint = endpoint;
++    status = UNIX_CALL(libusb_bulk_transfer, &params);
++    if (unix_call_failed(status, "libusb_bulk_transfer")) return LIBUSB_ERROR_OTHER;
++    if (transferred) *transferred = params.transferred;
++    return params.result;
++}
++
+ const char * WINAPI libusb_error_name(int error)
+ {
+     switch (error)
+@@ -561,6 +590,47 @@ const char * WINAPI libusb_error_name(int error)
+     }
+ }
+ 
++const char * WINAPI libusb_strerror(int error)
++{
++    switch (error)
++    {
++        case LIBUSB_SUCCESS: return "Success";
++        case LIBUSB_ERROR_IO: return "Input/Output Error";
++        case LIBUSB_ERROR_INVALID_PARAM: return "Invalid parameter";
++        case LIBUSB_ERROR_ACCESS: return "Access denied (insufficient permissions)";
++        case LIBUSB_ERROR_NO_DEVICE: return "No such device (it may have been disconnected)";
++        case LIBUSB_ERROR_NOT_FOUND: return "Entity not found";
++        case LIBUSB_ERROR_BUSY: return "Resource busy";
++        case LIBUSB_ERROR_TIMEOUT: return "Operation timed out";
++        case LIBUSB_ERROR_OVERFLOW: return "Overflow";
++        case LIBUSB_ERROR_PIPE: return "Pipe error";
++        case LIBUSB_ERROR_INTERRUPTED: return "System call interrupted (perhaps due to signal)";
++        case LIBUSB_ERROR_NO_MEM: return "Insufficient memory";
++        case LIBUSB_ERROR_NOT_SUPPORTED: return "Operation not supported or unimplemented on this platform";
++        default: return "Other error";
++    }
++}
++
++int WINAPI libusb_hotplug_register_callback(struct libusb_context *context, int events, int flags,
++                                            int vendor_id, int product_id, int dev_class,
++                                            libusb_hotplug_callback_fn callback, void *user_data,
++                                            libusb_hotplug_callback_handle *callback_handle)
++{
++    TRACE("%p, %#x, %#x, %04x, %04x, %d, %p, %p, %p\n", context, events, flags, vendor_id,
++          product_id, dev_class, callback, user_data, callback_handle);
++
++    /* Ableton's Windows libusb 1.0.23 build reports no hotplug support, so the
++     * helper already handles this result and polls the device list instead. */
++    if (callback_handle) *callback_handle = 0;
++    return LIBUSB_ERROR_NOT_SUPPORTED;
++}
++
++void WINAPI libusb_hotplug_deregister_callback(struct libusb_context *context,
++                                               libusb_hotplug_callback_handle callback_handle)
++{
++    TRACE("%p, %d\n", context, callback_handle);
++}
++
+ BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, void *reserved)
+ {
+     if (reason == DLL_PROCESS_ATTACH)
+diff --git a/dlls/libusb-1.0/unixlib.c b/dlls/libusb-1.0/unixlib.c
+index 28aeabd..3261158 100644
+--- a/dlls/libusb-1.0/unixlib.c
++++ b/dlls/libusb-1.0/unixlib.c
+@@ -212,7 +212,7 @@ static NTSTATUS wrap_libusb_claim_interface(void *args)
+ {
+     struct libusb_interface_params *params = args;
+ 
+-    if (params->interface_number != 0)
++    if (params->interface_number < 0 || params->interface_number > 255)
+         params->result = LIBUSB_ERROR_INVALID_PARAM;
+     else
+         params->result = libusb_claim_interface(device_handle_from_handle(params->handle),
+@@ -224,7 +224,7 @@ static NTSTATUS wrap_libusb_release_interface(void *args)
+ {
+     struct libusb_interface_params *params = args;
+ 
+-    if (params->interface_number != 0)
++    if (params->interface_number < 0 || params->interface_number > 255)
+         params->result = LIBUSB_ERROR_INVALID_PARAM;
+     else
+         params->result = libusb_release_interface(device_handle_from_handle(params->handle),
+@@ -367,6 +367,26 @@ static NTSTATUS wrap_libusb_handle_events_timeout(void *args)
+     return STATUS_SUCCESS;
+ }
+ 
++static NTSTATUS wrap_libusb_bulk_transfer(void *args)
++{
++    struct libusb_bulk_transfer_params *params = args;
++    int transferred = 0;
++
++    if (!params->handle || params->length < 0 || (params->length && !params->buffer))
++    {
++        params->transferred = 0;
++        params->result = LIBUSB_ERROR_INVALID_PARAM;
++        return STATUS_SUCCESS;
++    }
++
++    params->result = libusb_bulk_transfer(device_handle_from_handle(params->handle),
++                                          params->endpoint,
++                                          (unsigned char *)(uintptr_t)params->buffer,
++                                          params->length, &transferred, params->timeout);
++    params->transferred = transferred;
++    return STATUS_SUCCESS;
++}
++
+ const unixlib_entry_t __wine_unix_call_funcs[] =
+ {
+     [unix_process_attach] = wrap_process_attach,
+@@ -386,6 +406,7 @@ const unixlib_entry_t __wine_unix_call_funcs[] =
+     [unix_libusb_submit_transfer] = wrap_libusb_submit_transfer,
+     [unix_libusb_cancel_transfer] = wrap_libusb_cancel_transfer,
+     [unix_libusb_handle_events_timeout] = wrap_libusb_handle_events_timeout,
++    [unix_libusb_bulk_transfer] = wrap_libusb_bulk_transfer,
+ };
+ 
+ C_ASSERT(ARRAYSIZE(__wine_unix_call_funcs) == unix_funcs_count);
+diff --git a/dlls/libusb-1.0/unixlib.h b/dlls/libusb-1.0/unixlib.h
+index 750dc18..a08db5a 100644
+--- a/dlls/libusb-1.0/unixlib.h
++++ b/dlls/libusb-1.0/unixlib.h
+@@ -153,6 +153,18 @@ struct libusb_handle_events_timeout_params
+     INT32 result;
+ };
+ 
++struct libusb_bulk_transfer_params
++{
++    UINT64 handle;
++    UINT64 buffer;
++    UINT32 timeout;
++    INT32 length;
++    INT32 transferred;
++    UINT8 endpoint;
++    UINT8 reserved[3];
++    INT32 result;
++};
++
+ struct libusb_transfer_callback_params
+ {
+     struct dispatch_callback_params dispatch;
+@@ -181,6 +193,7 @@ enum libusb_unix_funcs
+     unix_libusb_submit_transfer,
+     unix_libusb_cancel_transfer,
+     unix_libusb_handle_events_timeout,
++    unix_libusb_bulk_transfer,
+     unix_funcs_count,
+ };
+ 

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -60,5 +60,6 @@ eb85bc3dc958314b299ebe45dc690ed3e9958d7beea82647513964ca0531a1b6  0059-wined3d-q
 a07f7ecb2c3a568d8eeae9a42df558cea4d8e279e5bdeb0af67a6649086973f7  0062-winex11-keep-a-selected-top-level-class-offscreen.patch
 0a7fb762e4bef288556f2118c318f6e99fe5532bb61058ccdb6d7732bf42ba27  0063-comdlg32-reveal-explorer-select-folder-targets-throu.patch
 81e02eeac88e6eda5da8044cd5bf74a197b2742f77c46da54e61dbf300031bd3  0064-shell32-route-explorer-folder-open-commands-to-the-h.patch
+61fa9b5531a69b84f556d4e99e506918d06365e1cbfce11f08df1c99d1fb09ff  0065-libusb-1.0-extend-the-host-bridge-for-Push-3.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -139,6 +139,7 @@ FINGERPRINTS='
 0063|ascii|lib/wine/x86_64-unix/comdlg32.so|org.freedesktop.FileManager1
 0064|ascii|lib/wine/x86_64-unix/comdlg32.so|ShowFolders
 0064|ascii|lib/wine/x86_64-windows/shell32.dll|__wine_portal_open_folder
+0065|ascii|lib/wine/x86_64-windows/libusb-1.0.dll|Operation not supported or unimplemented on this platform
 pipeasio/0001|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-clamp-sample-rate
 pipeasio/0002|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-midi-timebase
 '

--- a/scripts/container-build.sh
+++ b/scripts/container-build.sh
@@ -65,13 +65,13 @@ bridge_unix="$PREFIX_ROOT/lib/wine/x86_64-unix/libusb-1.0.so"
 portal_unix="$PREFIX_ROOT/lib/wine/x86_64-unix/comdlg32.so"
 i386_bridge_pe="$PREFIX_ROOT/lib/wine/i386-windows/libusb-1.0.dll"
 i386_bridge_unix="$PREFIX_ROOT/lib/wine/i386-unix/libusb-1.0.so"
-[ -f "$bridge_pe" ] || { echo "!! Push 2 bridge PE missing: $bridge_pe" >&2; exit 1; }
-[ -f "$bridge_unix" ] || { echo "!! Push 2 bridge Unix side missing: $bridge_unix" >&2; exit 1; }
+[ -f "$bridge_pe" ] || { echo "!! Push bridge PE missing: $bridge_pe" >&2; exit 1; }
+[ -f "$bridge_unix" ] || { echo "!! Push bridge Unix side missing: $bridge_unix" >&2; exit 1; }
 [ -f "$portal_unix" ] || { echo "!! comdlg32 (XDG portal) missing: $portal_unix" >&2; exit 1; }
-[ ! -e "$i386_bridge_pe" ] || { echo "!! Push 2 bridge unexpectedly built for i386: $i386_bridge_pe" >&2; exit 1; }
-[ ! -e "$i386_bridge_unix" ] || { echo "!! Push 2 bridge unexpectedly built for i386: $i386_bridge_unix" >&2; exit 1; }
+[ ! -e "$i386_bridge_pe" ] || { echo "!! Push bridge unexpectedly built for i386: $i386_bridge_pe" >&2; exit 1; }
+[ ! -e "$i386_bridge_unix" ] || { echo "!! Push bridge unexpectedly built for i386: $i386_bridge_unix" >&2; exit 1; }
 
-expected_exports=$'4 libusb_alloc_transfer\n10 libusb_cancel_transfer\n12 libusb_claim_interface\n16 libusb_close\n26 libusb_error_name\n32 libusb_exit\n40 libusb_free_device_list\n50 libusb_free_transfer\n72 libusb_get_device_descriptor\n74 libusb_get_device_list\n110 libusb_handle_events_timeout\n120 libusb_init\n132 libusb_open\n140 libusb_release_interface\n154 libusb_set_option\n161 libusb_submit_transfer'
+expected_exports=$'4 libusb_alloc_transfer\n8 libusb_bulk_transfer\n10 libusb_cancel_transfer\n12 libusb_claim_interface\n16 libusb_close\n26 libusb_error_name\n32 libusb_exit\n40 libusb_free_device_list\n50 libusb_free_transfer\n72 libusb_get_device_descriptor\n74 libusb_get_device_list\n110 libusb_handle_events_timeout\n116 libusb_hotplug_deregister_callback\n118 libusb_hotplug_register_callback\n120 libusb_init\n132 libusb_open\n140 libusb_release_interface\n154 libusb_set_option\n159 libusb_strerror\n161 libusb_submit_transfer'
 actual_exports="$(llvm-readobj --coff-exports "$bridge_pe" | awk '
     /^Export / { ordinal = ""; name = "" }
     /Ordinal:/ { ordinal = $2 }
@@ -79,7 +79,7 @@ actual_exports="$(llvm-readobj --coff-exports "$bridge_pe" | awk '
     /^}/ && name != "" { print ordinal, name }
 ')"
 if [ "$actual_exports" != "$expected_exports" ]; then
-    echo "!! Push 2 bridge export/ordinal mismatch" >&2
+    echo "!! Push bridge export/ordinal mismatch" >&2
     diff -u <(printf '%s\n' "$expected_exports") <(printf '%s\n' "$actual_exports") || true
     exit 1
 fi

--- a/scripts/setup-prefix.sh
+++ b/scripts/setup-prefix.sh
@@ -602,7 +602,7 @@ EOF
     echo "   seeded $pipeasio_cfg (2 in / 2 out, fixed 256-frame buffer)"
 fi
 
-echo "== [5/5] set portal policy and scope the Push USB bridge to its helpers =="
+echo "== [5/5] set portal policy and select the builtin USB bridge for Live and the Push helpers =="
 # Default only: a policy the user set with set-file-portal-policy survives re-runs.
 if ! wine reg query 'HKCU\Software\Wine\X11 Driver' /v FileDialogPortal >/dev/null 2>&1; then
   wine reg add 'HKCU\Software\Wine\X11 Driver' \
@@ -614,6 +614,17 @@ wine reg query "$push2_key" /v libusb-1.0
 push3_key='HKCU\Software\Wine\AppDefaults\Push3.exe\DllOverrides'
 wine reg add "$push3_key" /v libusb-1.0 /t REG_SZ /d builtin /f
 wine reg query "$push3_key" /v libusb-1.0
+# Live scans USB in its own process before it starts Push3.exe; the native libusb DLL
+# finds no devices under Wine. Requires the patch 0065 bridge: the 0032 bridge lacks
+# libusb_bulk_transfer and libusb_strerror, and Live fails to load. Live 11 imports are
+# unverified, so Live 11 executables keep the native DLL.
+for live_exe in 'Ableton Live 12 Suite.exe' 'Ableton Live 12 Standard.exe' \
+                'Ableton Live 12 Intro.exe' 'Ableton Live 12 Lite.exe' \
+                'Ableton Live 12 Trial.exe' 'Ableton Live 12 Beta.exe'; do
+    wine reg add "HKCU\\Software\\Wine\\AppDefaults\\${live_exe}\\DllOverrides" \
+        /v libusb-1.0 /t REG_SZ /d builtin /f
+done
+wine reg query 'HKCU\Software\Wine\AppDefaults\Ableton Live 12 Suite.exe\DllOverrides' /v libusb-1.0
 
 # Ableton's tlsetupfx.exe (kernel USB driver installer) faults under Wine and pops a winedbg
 # dialog mid-install; this runtime has no IFEO Debugger hook to neuter it, so nothing is set here.

--- a/scripts/setup-prefix.sh
+++ b/scripts/setup-prefix.sh
@@ -602,7 +602,7 @@ EOF
     echo "   seeded $pipeasio_cfg (2 in / 2 out, fixed 256-frame buffer)"
 fi
 
-echo "== [5/5] set portal policy and scope Push 2 bridge to its helper =="
+echo "== [5/5] set portal policy and scope the Push USB bridge to its helpers =="
 # Default only: a policy the user set with set-file-portal-policy survives re-runs.
 if ! wine reg query 'HKCU\Software\Wine\X11 Driver' /v FileDialogPortal >/dev/null 2>&1; then
   wine reg add 'HKCU\Software\Wine\X11 Driver' \
@@ -611,6 +611,9 @@ fi
 push2_key='HKCU\Software\Wine\AppDefaults\Push2DisplayProcess.exe\DllOverrides'
 wine reg add "$push2_key" /v libusb-1.0 /t REG_SZ /d builtin /f
 wine reg query "$push2_key" /v libusb-1.0
+push3_key='HKCU\Software\Wine\AppDefaults\Push3.exe\DllOverrides'
+wine reg add "$push3_key" /v libusb-1.0 /t REG_SZ /d builtin /f
+wine reg query "$push3_key" /v libusb-1.0
 
 # Ableton's tlsetupfx.exe (kernel USB driver installer) faults under Wine and pops a winedbg
 # dialog mid-install; this runtime has no IFEO Debugger hook to neuter it, so nothing is set here.

--- a/tools/push3usb.c
+++ b/tools/push3usb.c
@@ -1,0 +1,456 @@
+#define _POSIX_C_SOURCE 200809L
+
+/*
+ * Safe host-libusb probe for the Ableton Push 3 vendor interfaces.
+ *
+ * Push 3 exposes two vendor-specific interfaces: 0 (display) and 6 (xPort).
+ * This probe never detaches a kernel driver, changes the USB configuration,
+ * resets the device, or writes to either OUT endpoint.  Its strongest test
+ * submits one bulk IN transfer and immediately cancels it.  The xPort
+ * protocol is unknown, so the probe submits a transfer on the xPort IN
+ * endpoint only when --cancel-in-xport requests it.
+ */
+
+#include <libusb.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define PUSH3_VENDOR_ID 0x2982
+#define PUSH3_PRODUCT_ID 0x1969
+#define PUSH3_MAX_PACKET_SIZE 512
+
+struct vendor_interface
+{
+    int number;
+    uint8_t in_endpoint;
+    uint8_t out_endpoint;
+    const char *name;
+};
+
+static const struct vendor_interface vendor_interfaces[] =
+{
+    { 0, 0x81, 0x01, "display" },
+    { 6, 0x84, 0x04, "xport" },
+};
+
+#define VENDOR_INTERFACE_COUNT \
+    (sizeof(vendor_interfaces) / sizeof(vendor_interfaces[0]))
+
+enum probe_mode
+{
+    MODE_ENUMERATE,
+    MODE_CLAIM,
+    MODE_CANCEL_DISPLAY,
+    MODE_CANCEL_XPORT,
+};
+
+struct completion_state
+{
+    int done;
+    unsigned int count;
+    enum libusb_transfer_status status;
+    int actual_length;
+};
+
+enum cancel_result
+{
+    CANCEL_OK,
+    CANCEL_UNRESOLVED,
+};
+
+static const char *transfer_status_name(enum libusb_transfer_status status)
+{
+    switch (status)
+    {
+        case LIBUSB_TRANSFER_COMPLETED: return "completed";
+        case LIBUSB_TRANSFER_ERROR: return "error";
+        case LIBUSB_TRANSFER_TIMED_OUT: return "timed out";
+        case LIBUSB_TRANSFER_CANCELLED: return "cancelled";
+        case LIBUSB_TRANSFER_STALL: return "stalled";
+        case LIBUSB_TRANSFER_NO_DEVICE: return "no device";
+        case LIBUSB_TRANSFER_OVERFLOW: return "overflow";
+    }
+    return "unknown";
+}
+
+static void LIBUSB_CALL transfer_complete(struct libusb_transfer *transfer)
+{
+    struct completion_state *state = transfer->user_data;
+
+    state->count++;
+    state->status = transfer->status;
+    state->actual_length = transfer->actual_length;
+    state->done = 1;
+}
+
+static int monotonic_milliseconds(int64_t *milliseconds)
+{
+    struct timespec now;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &now) < 0)
+        return LIBUSB_ERROR_OTHER;
+    *milliseconds = (int64_t)now.tv_sec * 1000 + now.tv_nsec / 1000000;
+    return 0;
+}
+
+static int check_vendor_interface(libusb_device *device,
+        const struct vendor_interface *vi)
+{
+    struct libusb_config_descriptor *config = NULL;
+    const struct libusb_interface_descriptor *descriptor;
+    bool found_in = false, found_out = false;
+    int ret, i;
+
+    ret = libusb_get_active_config_descriptor(device, &config);
+    if (ret < 0)
+    {
+        fprintf(stderr, "active configuration: %s\n", libusb_error_name(ret));
+        return ret;
+    }
+
+    if (config->bConfigurationValue != 1 ||
+        config->bNumInterfaces <= vi->number ||
+        !config->interface[vi->number].num_altsetting)
+    {
+        fprintf(stderr, "unexpected active configuration or interface table\n");
+        libusb_free_config_descriptor(config);
+        return LIBUSB_ERROR_NOT_FOUND;
+    }
+
+    descriptor = &config->interface[vi->number].altsetting[0];
+    if (descriptor->bInterfaceNumber != vi->number ||
+        descriptor->bInterfaceClass != LIBUSB_CLASS_VENDOR_SPEC)
+    {
+        fprintf(stderr, "interface %d is not the expected vendor interface\n",
+                vi->number);
+        libusb_free_config_descriptor(config);
+        return LIBUSB_ERROR_NOT_FOUND;
+    }
+
+    for (i = 0; i < descriptor->bNumEndpoints; ++i)
+    {
+        const struct libusb_endpoint_descriptor *endpoint = &descriptor->endpoint[i];
+        const uint8_t transfer_type = endpoint->bmAttributes & LIBUSB_TRANSFER_TYPE_MASK;
+
+        if (transfer_type != LIBUSB_TRANSFER_TYPE_BULK ||
+            endpoint->wMaxPacketSize != PUSH3_MAX_PACKET_SIZE)
+            continue;
+        if (endpoint->bEndpointAddress == vi->in_endpoint)
+            found_in = true;
+        if (endpoint->bEndpointAddress == vi->out_endpoint)
+            found_out = true;
+    }
+
+    libusb_free_config_descriptor(config);
+
+    if (!found_in || !found_out)
+    {
+        fprintf(stderr, "expected bulk endpoints on interface %d were not found\n",
+                vi->number);
+        return LIBUSB_ERROR_NOT_FOUND;
+    }
+    printf("interface=%d name=%s class=vendor endpoints=in:0x%02x,out:0x%02x packet=512\n",
+            vi->number, vi->name, (unsigned int)vi->in_endpoint,
+            (unsigned int)vi->out_endpoint);
+    return 0;
+}
+
+static int cancel_in_transfer(libusb_context *context,
+        libusb_device_handle *handle, uint8_t endpoint)
+{
+    struct completion_state *state = NULL;
+    struct libusb_transfer *transfer = NULL;
+    unsigned char *buffer = NULL;
+    int64_t deadline, now;
+    int cancel_ret, event_ret = 0, ret;
+
+    state = calloc(1, sizeof(*state));
+    buffer = calloc(PUSH3_MAX_PACKET_SIZE, 1);
+    transfer = libusb_alloc_transfer(0);
+    if (!state || !buffer || !transfer)
+    {
+        fprintf(stderr, "could not allocate cancellation state\n");
+        if (transfer)
+            libusb_free_transfer(transfer);
+        free(buffer);
+        free(state);
+        return LIBUSB_ERROR_NO_MEM;
+    }
+
+    libusb_fill_bulk_transfer(transfer, handle, endpoint,
+            buffer, PUSH3_MAX_PACKET_SIZE, transfer_complete, state, 1000);
+
+    ret = libusb_submit_transfer(transfer);
+    if (ret < 0)
+    {
+        fprintf(stderr, "submit IN transfer: %s\n", libusb_error_name(ret));
+        libusb_free_transfer(transfer);
+        free(buffer);
+        free(state);
+        return ret;
+    }
+
+    cancel_ret = libusb_cancel_transfer(transfer);
+    if (cancel_ret < 0)
+        fprintf(stderr, "cancel IN transfer: %s; awaiting terminal callback\n",
+                libusb_error_name(cancel_ret));
+
+    if (monotonic_milliseconds(&now) < 0)
+        event_ret = LIBUSB_ERROR_OTHER;
+    else
+        deadline = now + 6000;
+
+    while (!state->done && !event_ret)
+    {
+        struct timeval timeout;
+
+        if (monotonic_milliseconds(&now) < 0)
+        {
+            event_ret = LIBUSB_ERROR_OTHER;
+            break;
+        }
+        if (now >= deadline)
+            break;
+
+        timeout.tv_sec = 0;
+        timeout.tv_usec = (deadline - now > 100 ? 100 : deadline - now) * 1000;
+        ret = libusb_handle_events_timeout_completed(context, &timeout, &state->done);
+        if (ret == LIBUSB_ERROR_INTERRUPTED)
+            continue;
+        if (ret < 0)
+        {
+            fprintf(stderr, "handle events: %s\n", libusb_error_name(ret));
+            event_ret = ret;
+        }
+    }
+
+    if (!state->done)
+    {
+        /*
+         * The transfer may still be owned by libusb.  Deliberately leak all
+         * USB state until process exit rather than freeing active storage.
+         */
+        fprintf(stderr, "terminal callback did not arrive; abandoning USB cleanup safely\n");
+        return CANCEL_UNRESOLVED;
+    }
+
+    /* Keep callback storage alive for a 250 ms diagnostic drain window. */
+    if (monotonic_milliseconds(&now) < 0)
+        event_ret = LIBUSB_ERROR_OTHER;
+    else
+        deadline = now + 250;
+    while (!event_ret)
+    {
+        struct timeval timeout;
+
+        if (monotonic_milliseconds(&now) < 0)
+        {
+            event_ret = LIBUSB_ERROR_OTHER;
+            break;
+        }
+        if (now >= deadline)
+            break;
+
+        timeout.tv_sec = 0;
+        timeout.tv_usec = (deadline - now) * 1000;
+        ret = libusb_handle_events_timeout(context, &timeout);
+        if (ret == LIBUSB_ERROR_INTERRUPTED)
+            continue;
+        if (ret < 0)
+            event_ret = ret;
+    }
+
+    printf("cancel-callback endpoint=0x%02x count=%u status=%s actual_length=%d\n",
+            (unsigned int)endpoint, state->count,
+            transfer_status_name(state->status), state->actual_length);
+
+    libusb_free_transfer(transfer);
+
+    if (cancel_ret < 0)
+        ret = cancel_ret;
+    else if (event_ret < 0)
+        ret = event_ret;
+    else if (state->count != 1 || state->status != LIBUSB_TRANSFER_CANCELLED ||
+             state->actual_length != 0)
+        ret = LIBUSB_ERROR_OTHER;
+    else
+        ret = CANCEL_OK;
+
+    if (ret == CANCEL_OK)
+        printf("cancel-test=ok\n");
+
+    free(buffer);
+    free(state);
+    return ret;
+}
+
+static void usage(const char *program)
+{
+    fprintf(stderr, "usage: %s [--enumerate|--claim|--cancel-in|--cancel-in-xport]\n",
+            program);
+}
+
+int main(int argc, char **argv)
+{
+    libusb_context *context = NULL;
+    libusb_device **devices = NULL;
+    libusb_device *push = NULL;
+    libusb_device_handle *handle = NULL;
+    struct libusb_device_descriptor descriptor;
+    bool claimed[VENDOR_INTERFACE_COUNT] = { false };
+    bool abandon_usb = false;
+    enum probe_mode mode;
+    size_t first, last, j;
+    ssize_t count, i;
+    int ret = EXIT_FAILURE, usb_ret;
+
+    if (argc == 1 || (argc == 2 && !strcmp(argv[1], "--enumerate")))
+        mode = MODE_ENUMERATE;
+    else if (argc == 2 && !strcmp(argv[1], "--claim"))
+        mode = MODE_CLAIM;
+    else if (argc == 2 && !strcmp(argv[1], "--cancel-in"))
+        mode = MODE_CANCEL_DISPLAY;
+    else if (argc == 2 && !strcmp(argv[1], "--cancel-in-xport"))
+        mode = MODE_CANCEL_XPORT;
+    else
+    {
+        usage(argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    usb_ret = libusb_init(&context);
+    if (usb_ret < 0)
+    {
+        fprintf(stderr, "libusb_init: %s\n", libusb_error_name(usb_ret));
+        return EXIT_FAILURE;
+    }
+
+    count = libusb_get_device_list(context, &devices);
+    if (count < 0)
+    {
+        fprintf(stderr, "device list: %s\n", libusb_error_name((int)count));
+        goto done;
+    }
+
+    for (i = 0; i < count; ++i)
+    {
+        if (libusb_get_device_descriptor(devices[i], &descriptor) < 0)
+            continue;
+        if (descriptor.idVendor == PUSH3_VENDOR_ID &&
+            descriptor.idProduct == PUSH3_PRODUCT_ID)
+        {
+            push = devices[i];
+            break;
+        }
+    }
+
+    if (!push)
+    {
+        fprintf(stderr, "Push 3 2982:1969 not found\n");
+        goto done;
+    }
+
+    printf("device=2982:1969 bus=%03u address=%03u configurations=%u\n",
+            libusb_get_bus_number(push), libusb_get_device_address(push),
+            descriptor.bNumConfigurations);
+
+    for (j = 0; j < VENDOR_INTERFACE_COUNT; ++j)
+    {
+        usb_ret = check_vendor_interface(push, &vendor_interfaces[j]);
+        if (usb_ret < 0)
+            goto done;
+    }
+
+    if (mode == MODE_ENUMERATE)
+    {
+        ret = EXIT_SUCCESS;
+        goto done;
+    }
+
+    usb_ret = libusb_open(push, &handle);
+    if (usb_ret < 0)
+    {
+        fprintf(stderr, "open: %s\n", libusb_error_name(usb_ret));
+        goto done;
+    }
+
+    if (mode == MODE_CLAIM)
+    {
+        first = 0;
+        last = VENDOR_INTERFACE_COUNT - 1;
+    }
+    else if (mode == MODE_CANCEL_DISPLAY)
+        first = last = 0;
+    else
+        first = last = 1;
+
+    for (j = first; j <= last; ++j)
+    {
+        const struct vendor_interface *vi = &vendor_interfaces[j];
+
+        usb_ret = libusb_kernel_driver_active(handle, vi->number);
+        if (usb_ret < 0)
+        {
+            fprintf(stderr, "kernel driver query: %s\n", libusb_error_name(usb_ret));
+            goto done;
+        }
+        if (usb_ret != 0)
+        {
+            fprintf(stderr, "refusing to detach kernel driver from interface %d\n",
+                    vi->number);
+            goto done;
+        }
+
+        usb_ret = libusb_claim_interface(handle, vi->number);
+        if (usb_ret < 0)
+        {
+            fprintf(stderr, "claim interface %d: %s\n", vi->number,
+                    libusb_error_name(usb_ret));
+            goto done;
+        }
+        claimed[j] = true;
+        printf("claim=ok interface=%d kernel-driver=none\n", vi->number);
+    }
+
+    if (mode == MODE_CANCEL_DISPLAY || mode == MODE_CANCEL_XPORT)
+    {
+        usb_ret = cancel_in_transfer(context, handle,
+                vendor_interfaces[first].in_endpoint);
+        if (usb_ret == CANCEL_UNRESOLVED)
+        {
+            abandon_usb = true;
+            goto done;
+        }
+        if (usb_ret < 0)
+            goto done;
+    }
+
+    ret = EXIT_SUCCESS;
+
+done:
+    if (abandon_usb)
+        return EXIT_FAILURE;
+
+    for (j = VENDOR_INTERFACE_COUNT; j-- > 0;)
+    {
+        if (!claimed[j])
+            continue;
+        usb_ret = libusb_release_interface(handle, vendor_interfaces[j].number);
+        printf("release=%s interface=%d\n",
+                usb_ret < 0 ? libusb_error_name(usb_ret) : "ok",
+                vendor_interfaces[j].number);
+        if (usb_ret < 0)
+            ret = EXIT_FAILURE;
+    }
+    if (handle)
+        libusb_close(handle);
+    if (devices)
+        libusb_free_device_list(devices, 1);
+    libusb_exit(context);
+    return ret;
+}


### PR DESCRIPTION
With help from @Version33, this patch extends the Ableton USB <-> Linux host instrument bridge to support the tethered Ableton Push 3, released exactly three years ago on 2 August, 2023. (Happy birthday Push 3!) 

Push3.exe imports four functions the Push 2 bridge does not export: `libusb_bulk_transfer` (forwarded to the host as one blocking call), `libusb_strerror` (standard message strings), and two hotplug functions.  As such, the new patch for the bridge enables it to accept interfaces 0 through 255 so the helper can reach the Push 3's `xPort` interface alongside the display.

`setup-prefix.sh`  deploys the builtin to `Push3.exe`, matching the Push 2 override. `tools/push3usb.c` is used to probe a real Push 3, and it is based off `push2usb.c`. 

As I do not have a Push 3, this PR can only be merged when someone (@Version33?) demonstrates the compatibility witha real device.