### PR TITLE
Streamline a new installation of Live

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -29,6 +29,38 @@ This workaround is only needed for affected plugins. See the
 [Pianoteq investigation](notes/ABLETON-WINE-PIANOTEQ-DPI-GHOST-BUG.md) for the
 confirmed failure mode.
 
+## Live's "Enable GPU Renderer" setting is greyed out
+
+If you're experiencing performance issues or high CPU usage when idle, Live
+may not be using your GPU. By default, Live will always offload the UI to
+your GPU for maximum performance, but will only do so when it recognises
+the name of your GPU. On Linux, GPUs will 'tell' Live their name without
+any external interference, and because Live is anticipating that interference,
+it may not recognise the GPU's name and refuse to use the GPU.
+
+To confirm this problem, open **Settings > Display & Input**. 
+If **Enable GPU Renderer** is greyed out, and the note under it names a 
+graphics card that is not the one in your computer, then you're seeing this
+exact problem. 
+
+To solve it: **update this project**.
+
+Download [the latest installer](https://github.com/shibco/ableton-linux/releases/latest/download/install-ableton-latest.run)
+and run the update. It keeps your Live installation, your license, and
+your projects:
+
+```bash
+sh ~/Downloads/install-ableton-latest.run --update
+```
+
+Start Live, open **Settings > Display & Input**, and turn on **Enable GPU
+Renderer**. Live now names your real graphics card, and the setting stays
+on.
+
+If the setting is still greyed out on 2026.08.01.1 or newer,
+[open an issue](https://github.com/shibco/ableton-linux/issues) and
+include your graphics card model.
+
 ## Live 11: Max for Live fails after the first launch
 
 After running Live 11 once, close Live and run:

--- a/scripts/setup-prefix.sh
+++ b/scripts/setup-prefix.sh
@@ -270,7 +270,12 @@ case "$dpi_mode" in
 esac
 
 echo "== [1/5] initialise prefix at $WINEPREFIX =="
-wineboot -u
+# While updating the prefix, wineboot offers Wine's Mono and Gecko installers. This runtime
+# vendors neither, so on a machine with no cached package it opens a modal "Wine Mono
+# Installer" prompt; nothing answers it in an unattended run and the wineserver -w below then
+# never returns. Live needs neither - ableton-live and max9 already disable both on every
+# launch - so disable them here and wineboot stops asking.
+WINEDLLOVERRIDES="mscoree,mshtml=" wineboot -u
 "$WINESERVER" -w
 
 if [ "$refresh" -eq 1 ]; then

--- a/scripts/setup-prefix.sh
+++ b/scripts/setup-prefix.sh
@@ -648,12 +648,14 @@ cat <<EOF
 Remaining steps (you supply Ableton + your own license):
 
   1. Install Live (any edition) through THIS wine (plain wine reads
-     WINEPREFIX, not the ABLETON_* launcher variables). The flags let the
-     installer run by itself and skip Ableton's Windows USB audio driver,
-     which does nothing on Linux:
+     WINEPREFIX, not the ABLETON_* launcher variables). For Live 12 the flags
+     let the installer run by itself and skip Ableton's Windows USB audio
+     driver, which does nothing on Linux:
        WINEPREFIX=$WINEPREFIX \\
-       $WINE_ROOT/bin/wine "/path/to/Ableton Live NN Edition Installer.exe" \\
+       $WINE_ROOT/bin/wine "/path/to/Ableton Live 12 Edition Installer.exe" \\
        /SILENT /SUPPRESSMSGBOXES /NORESTART '/MERGETASKS=!audiodriver'
+     Live 11's installer is a different kind and ignores those flags; run it
+     without them and click through its window.
 
   2. Launch:            ableton-live
   3. Authorize Live with your own account (binds to this prefix's MachineGuid).

--- a/scripts/setup-prefix.sh
+++ b/scripts/setup-prefix.sh
@@ -648,9 +648,12 @@ cat <<EOF
 Remaining steps (you supply Ableton + your own license):
 
   1. Install Live (any edition) through THIS wine (plain wine reads
-     WINEPREFIX, not the ABLETON_* launcher variables):
+     WINEPREFIX, not the ABLETON_* launcher variables). The flags let the
+     installer run by itself and skip Ableton's Windows USB audio driver,
+     which does nothing on Linux:
        WINEPREFIX=$WINEPREFIX \\
-       $WINE_ROOT/bin/wine "/path/to/Ableton Live NN Edition Installer.exe"
+       $WINE_ROOT/bin/wine "/path/to/Ableton Live NN Edition Installer.exe" \\
+       /SILENT /SUPPRESSMSGBOXES /NORESTART '/MERGETASKS=!audiodriver'
 
   2. Launch:            ableton-live
   3. Authorize Live with your own account (binds to this prefix's MachineGuid).

--- a/scripts/setup-prefix.sh
+++ b/scripts/setup-prefix.sh
@@ -613,7 +613,11 @@ wine reg add "$push2_key" /v libusb-1.0 /t REG_SZ /d builtin /f
 wine reg query "$push2_key" /v libusb-1.0
 
 # Ableton's tlsetupfx.exe (kernel USB driver installer) faults under Wine and pops a winedbg
-# dialog mid-install; this runtime has no IFEO Debugger hook to neuter it, so nothing is set here.
+# dialog mid-install - twice, on every Live 11 install. The fault is harmless: the installer
+# records it (0x80070643), carries on, and Live installs fine (issue 111), but two unexplained
+# "Program Error" boxes make a working install look broken. Suppress the dialog only: winedbg
+# still runs and still writes the backtrace to stderr.
+wine reg add 'HKCU\Software\Wine\WineDbg' /v ShowCrashDialog /t REG_DWORD /d 0 /f
 
 # winemenubuilder's entries assume `wine` on PATH (never true here) and are dead buttons: disable
 # it and delete entries it already wrote for this prefix (matched by WINEPREFIX=; install.sh's entries can't match).

--- a/scripts/setup-run-header.sh
+++ b/scripts/setup-run-header.sh
@@ -336,18 +336,27 @@ if [ "$manual_install" -eq 0 ]; then
         fi
     fi
     if [ -n "$live_exe" ]; then
-        say "-- installing Ableton Live; a progress window opens, no clicks needed"
-        say "   (Live is large, so this can take several minutes)"
-        # run from the installer's own directory so its relative payload lookups resolve.
-        # Ableton's installer is Inno Setup: /SILENT keeps the progress bar but asks
-        # nothing, /SUPPRESSMSGBOXES /NORESTART cover the rest. The audiodriver task
-        # installs Ableton's Windows USB kernel driver, which cannot load under Wine
-        # (audio goes through PipeASIO), so deselect it with /MERGETASKS.
+        # Live 12 ships Inno Setup, Live 11 a WiX Burn bundle. Burn ignores /MERGETASKS and
+        # /SUPPRESSMSGBOXES, and reads /SILENT as /quiet - no window at all - so the Inno set
+        # on Live 11 installs the USB audio driver anyway and loses the wizard. /MERGETASKS
+        # drops that task: a Windows USB kernel driver Wine cannot load (audio is PipeASIO).
+        # Burn first - `.wixburn` is a PE section ~630 bytes in, so 4k settles it however big
+        # the installer is; the Inno marker is ~680 KB in. Process substitution, not a pipe:
+        # grep -q exits early, head takes SIGPIPE, and pipefail would report 141.
+        live_flags=()
+        if ! grep -qaF '.wixburn' <(head -c 4k -- "$live_exe") \
+             && grep -qa 'Inno Setup' <(head -c 4M -- "$live_exe"); then
+            live_flags=(/SILENT /SUPPRESSMSGBOXES /NORESTART '/MERGETASKS=!audiodriver')
+            say "-- installing Ableton Live; a progress window opens, no clicks needed"
+            say "   (Live is large, so this can take several minutes)"
+        else
+            say "-- starting the Ableton installer; from here just click through its window"
+        fi
+        # run from the installer's own directory so its relative payload lookups resolve
         if ( cd "$(dirname -- "$live_exe")" && \
                  WINEPREFIX="$HOME/.wine-ableton" \
                  "$HOME/.local/opt/$RUNTIME_NAME/bin/wine" \
-                 "./$(basename -- "$live_exe")" \
-                 /SILENT /SUPPRESSMSGBOXES /NORESTART '/MERGETASKS=!audiodriver' ); then
+                 "./$(basename -- "$live_exe")" "${live_flags[@]}" ); then
             live_installed=1
         else
             say "!! the Ableton installer exited with an error; instructions below"
@@ -372,7 +381,8 @@ else
     say "       cd ~/live-installer && WINEPREFIX=~/.wine-ableton \\"
     say "           ~/.local/opt/$RUNTIME_NAME/bin/wine ./*.exe \\"
     say "           /SILENT /SUPPRESSMSGBOXES /NORESTART '/MERGETASKS=!audiodriver'"
-    say "     (the flags let it install by itself and skip a Windows-only driver)"
+    say "     (Live 12: the flags let it install by itself and skip a Windows-only driver;"
+    say "      Live 11: drop them and click through its installer window instead)"
 fi
 say "Launch Live:   ~/.local/bin/ableton-live"
 say "Then, inside Live:"

--- a/scripts/setup-run-header.sh
+++ b/scripts/setup-run-header.sh
@@ -336,12 +336,18 @@ if [ "$manual_install" -eq 0 ]; then
         fi
     fi
     if [ -n "$live_exe" ]; then
-        say "-- starting the Ableton installer; from here just click through its window"
-        # run from the installer's own directory so its relative payload lookups resolve
+        say "-- installing Ableton Live; a progress window opens, no clicks needed"
+        say "   (Live is large, so this can take several minutes)"
+        # run from the installer's own directory so its relative payload lookups resolve.
+        # Ableton's installer is Inno Setup: /SILENT keeps the progress bar but asks
+        # nothing, /SUPPRESSMSGBOXES /NORESTART cover the rest. The audiodriver task
+        # installs Ableton's Windows USB kernel driver, which cannot load under Wine
+        # (audio goes through PipeASIO), so deselect it with /MERGETASKS.
         if ( cd "$(dirname -- "$live_exe")" && \
                  WINEPREFIX="$HOME/.wine-ableton" \
                  "$HOME/.local/opt/$RUNTIME_NAME/bin/wine" \
-                 "./$(basename -- "$live_exe")" ); then
+                 "./$(basename -- "$live_exe")" \
+                 /SILENT /SUPPRESSMSGBOXES /NORESTART '/MERGETASKS=!audiodriver' ); then
             live_installed=1
         else
             say "!! the Ableton installer exited with an error; instructions below"
@@ -364,7 +370,9 @@ else
     say "       (no unzip? try: bsdtar -xf FILE.zip -C ~/live-installer)"
     say "  2) run the installer through this Wine, from inside that directory:"
     say "       cd ~/live-installer && WINEPREFIX=~/.wine-ableton \\"
-    say "           ~/.local/opt/$RUNTIME_NAME/bin/wine ./*.exe"
+    say "           ~/.local/opt/$RUNTIME_NAME/bin/wine ./*.exe \\"
+    say "           /SILENT /SUPPRESSMSGBOXES /NORESTART '/MERGETASKS=!audiodriver'"
+    say "     (the flags let it install by itself and skip a Windows-only driver)"
 fi
 say "Launch Live:   ~/.local/bin/ableton-live"
 say "Then, inside Live:"


### PR DESCRIPTION
This PR updates the ableton-linux-installer.run to automatically install live with a SILENT flag.
Additionally, as per multiple reports (such as #111) of the harmless (yet concerning!) USB Audio driver install failure, this PR also suppresses the installation of Live's Windows USB Audio driver all together.

Thanks to @HurleybirdJr for the ideas, this is directly incorporating their research.
