### PR TITLE
ableton-linkd: quiet logging + allowing installers to kill blocking ableton-wine processes pre-upgrade

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -29,6 +29,38 @@ This workaround is only needed for affected plugins. See the
 [Pianoteq investigation](notes/ABLETON-WINE-PIANOTEQ-DPI-GHOST-BUG.md) for the
 confirmed failure mode.
 
+## Live's "Enable GPU Renderer" setting is greyed out
+
+If you're experiencing performance issues or high CPU usage when idle, Live
+may not be using your GPU. By default, Live will always offload the UI to
+your GPU for maximum performance, but will only do so when it recognises
+the name of your GPU. On Linux, GPUs will 'tell' Live their name without
+any external interference, and because Live is anticipating that interference,
+it may not recognise the GPU's name and refuse to use the GPU.
+
+To confirm this problem, open **Settings > Display & Input**. 
+If **Enable GPU Renderer** is greyed out, and the note under it names a 
+graphics card that is not the one in your computer, then you're seeing this
+exact problem. 
+
+To solve it: **update this project**.
+
+Download [the latest installer](https://github.com/shibco/ableton-linux/releases/latest/download/install-ableton-latest.run)
+and run the update. It keeps your Live installation, your license, and
+your projects:
+
+```bash
+sh ~/Downloads/install-ableton-latest.run --update
+```
+
+Start Live, open **Settings > Display & Input**, and turn on **Enable GPU
+Renderer**. Live now names your real graphics card, and the setting stays
+on.
+
+If the setting is still greyed out on 2026.08.01.1 or newer,
+[open an issue](https://github.com/shibco/ableton-linux/issues) and
+include your graphics card model.
+
 ## Live 11: Max for Live fails after the first launch
 
 After running Live 11 once, close Live and run:

--- a/notes/ABLETON-WINE-LINK.md
+++ b/notes/ABLETON-WINE-LINK.md
@@ -65,8 +65,9 @@ tempo or beat position after construction.
 
 Its modes are:
 
-- No arguments: run in the foreground and write status to stderr every ten
-  seconds. The systemd unit uses this mode.
+- No arguments: run in the foreground and write to stderr when the peer
+  count, tempo, or transport state changes. The systemd unit uses this mode.
+  A quiet session writes nothing.
 - `--daemon`: run in the background and write
   `~/.log/ableton-linkd/ableton-linkd.log`. The launchers use this mode.
 - `--probe [seconds]`: join, wait up to ten seconds by default, print
@@ -74,6 +75,10 @@ Its modes are:
   peer.
 - `--tempo BPM`: set only the construction tempo used when this process
   creates a new session.
+- `--verbose` (or `ABLETON_LINKD_VERBOSE=1`): also write a status line every
+  ten seconds. Before 2026.08 this was unconditional. Under the systemd unit
+  it wrote 8640 identical journal lines a day. That read as a stuck process
+  and invited force quits.
 
 The Live, Max, and beta launchers start `ableton-linkd --daemon` when the
 binary exists and no process with that name is running. `ABLETON_LINKD`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -105,25 +105,28 @@ for p in $(runtime_pids); do
     esac
 done
 if ableton_up; then
-    echo "== stopping running Ableton processes ($(runtime_pids | wc -l)) =="
+    echo "== stop processes using the installed runtime =="
+    echo "   $(runtime_pids | wc -l) found"
     # Closing Live discards unsaved work, so require an explicit yes.
     # -r and -w cannot ask that: they stat a 0666 device node and pass
     # even with no controlling terminal, and the printf would then fail
     # ENXIO and abort the install under set -e. Opening it is the only
-    # honest test. A timeout, an EOF or a missing terminal all mean
-    # nobody consented, so refuse. Leftover wineserver and winedevice.exe
-    # without Live have nothing to save and never reach this.
+    # honest test. Anything but y - a timeout, an EOF, a bare Enter, a
+    # missing terminal - means nobody consented, so refuse. Leftover
+    # wineserver and winedevice.exe without Live have nothing to save and
+    # never reach this.
     if [ "$live_up" -eq 1 ]; then
         if { : >/dev/tty; } 2>/dev/null; then
-            printf "Live is still open and updating will close it. Save your work, then press Enter to continue (Ctrl-C to abort): " > /dev/tty
-            if ! read -r -t 60 _ < /dev/tty; then
-                printf '\n' > /dev/tty 2>/dev/null || true
-                echo "!! no confirmation after 60s: close Live and rerun" >&2
-                exit 1
-            fi
+            echo "!! Live is running. Updating will force-close it. Save your work before continuing." >&2
+            printf "Force-close Live? [y/N] " > /dev/tty
+            ans=""
+            read -r -t 60 ans < /dev/tty || printf '\n' > /dev/tty 2>/dev/null || true
+            case "$ans" in
+                y|Y|yes|Yes|YES) ;;
+                *) exit 1 ;;
+            esac
         else
-            echo "!! Live is running and there is no terminal to confirm on:" >&2
-            echo "   close Live, or rerun this installer from a terminal" >&2
+            echo "!! Live is running; no terminal to confirm on. Close Live, or rerun from a terminal." >&2
             exit 1
         fi
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -95,10 +95,7 @@ for p in $(runtime_pids); do
     esac
 done
 if ableton_up; then
-    echo "== stopping running Ableton processes =="
-    runtime_pids | while read -r p; do
-        printf '%s %s\n' "$p" "$(tr -s '\0' ' ' < "/proc/$p/cmdline" 2>/dev/null)"
-    done
+    echo "== stopping running Ableton processes ($(runtime_pids | wc -l)) =="
     # Closing Live discards unsaved work, so require an explicit yes.
     # -r and -w cannot ask that: they stat a 0666 device node and pass
     # even with no controlling terminal, and the printf would then fail

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -58,36 +58,67 @@ fi
 # Anything still running from the installed runtime holds the old files
 # open. Stop it all instead of refusing: ask the prefix's wineserver to
 # take the whole session down (Live and its helpers are its clients), and
-# pkill only what survives that or runs when no wineserver binary is
-# there to call. ableton-linkd is not part of the runtime and is handled
-# at its own install step below.
+# signal the processes directly only when that is unavailable or leaves
+# something behind. ableton-linkd is not part of the runtime and is
+# handled at its own install step below.
+
+# Every process running from the installed runtime. Wine's in-prefix
+# helpers show a Windows path in argv (C:\windows\system32\...), so no
+# command-line pattern reaches them, and a pattern also catches unrelated
+# processes that merely mention the path. /proc/PID/exe is the binary
+# itself: bin/wineserver, or the wine-preloader every in-prefix process
+# runs from.
+runtime_pids()
+{
+    local d
+    for d in /proc/[0-9]*; do
+        case "$(readlink "$d/exe" 2>/dev/null)" in
+            "$OPT/$NAME"/*) printf '%s\n' "${d#/proc/}" ;;
+        esac
+    done
+}
+# Live's exe resolves to the same wine-preloader, so runtime_pids covers
+# it; the name match stays as a second opinion, since detection failing
+# open here means installing over a running runtime.
 ableton_up()
 {
-    # Two patterns: Live's exe processes do not carry the runtime path on
-    # their command line, the support processes do.
-    pgrep -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' >/dev/null 2>&1 || \
-        pgrep -f "$OPT/$NAME" >/dev/null 2>&1
+    [ -n "$(runtime_pids)" ] || \
+        pgrep -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' >/dev/null 2>&1
 }
+# Live itself, as opposed to the support processes: the prompt below is
+# about unsaved work and only Live has any. Scoped to this runtime, so a
+# Live under an unrelated Wine install is neither prompted for nor killed.
 live_up=0
-if pgrep -af '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' >/dev/null 2>&1; then
-    live_up=1
-fi
-if [ "$live_up" -eq 1 ] || pgrep -af "$OPT/$NAME" >/dev/null 2>&1; then
+for p in $(runtime_pids); do
+    case "$(tr -s '\0' ' ' < "/proc/$p/cmdline" 2>/dev/null)" in
+        *"Ableton Live"*.exe*) live_up=1; break ;;
+    esac
+done
+if ableton_up; then
     echo "== stopping running Ableton processes =="
-    pgrep -af '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' || true
-    pgrep -af "$OPT/$NAME" || true
-    # Closing Live discards unsaved work, so ask first. Leftover wineserver
-    # and winedevice.exe without Live have nothing to save: no prompt.
-    # /dev/tty rather than stdin: the .run wrapper feeds the script through
-    # a pipe. Without a terminal there is nobody to ask; proceed. The -r/-w
-    # tests pass even with no controlling terminal (they check the device
-    # mode, not an open), so the open itself is the real gate: when it
-    # fails, the group falls through to || true instead of tripping set -e.
-    if [ "$live_up" -eq 1 ] && [ -r /dev/tty ] && [ -w /dev/tty ]; then
-        {
-            printf "You're updating and Live is still open. Make sure you've saved everything and press Enter to continue."
-            read -r _
-        } 2>/dev/null < /dev/tty > /dev/tty || true
+    runtime_pids | while read -r p; do
+        printf '%s %s\n' "$p" "$(tr -s '\0' ' ' < "/proc/$p/cmdline" 2>/dev/null)"
+    done
+    # Closing Live discards unsaved work, so require an explicit yes.
+    # -r and -w cannot ask that: they stat a 0666 device node and pass
+    # even with no controlling terminal, and the printf would then fail
+    # ENXIO and abort the install under set -e. Opening it is the only
+    # honest test. A timeout, an EOF or a missing terminal all mean
+    # nobody consented, so refuse. Leftover wineserver and winedevice.exe
+    # without Live have nothing to save and never reach this.
+    if [ "$live_up" -eq 1 ]; then
+        if { : >/dev/tty; } 2>/dev/null; then
+            printf "Live is still open and updating will close it. Save your work, then press Enter to continue (Ctrl-C to abort): " > /dev/tty
+            if ! read -r -t 60 _ < /dev/tty; then
+                printf '\n' > /dev/tty 2>/dev/null || true
+                echo "!! no confirmation after 60s: close Live and rerun" >&2
+                exit 1
+            fi
+        else
+            echo "!! Live is running and there is no terminal to confirm on:" >&2
+            echo "   close Live, or rerun this installer from a terminal" >&2
+            exit 1
+        fi
     fi
     if [ -x "$OPT/$NAME/bin/wineserver" ]; then
         WINEPREFIX="${ABLETON_WINEPREFIX:-$HOME/.wine-ableton}" \
@@ -98,14 +129,14 @@ if [ "$live_up" -eq 1 ] || pgrep -af "$OPT/$NAME" >/dev/null 2>&1; then
         done
     fi
     if ableton_up; then
+        runtime_pids | xargs -r kill 2>/dev/null || true
         pkill -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' 2>/dev/null || true
-        pkill -f "$OPT/$NAME" 2>/dev/null || true
         for _ in $(seq 1 10); do
             ableton_up || break
             sleep 0.5
         done
+        runtime_pids | xargs -r kill -9 2>/dev/null || true
         pkill -9 -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' 2>/dev/null || true
-        pkill -9 -f "$OPT/$NAME" 2>/dev/null || true
     fi
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -36,12 +36,22 @@ cleanup()
         if [ -n "$launcher_backup" ] && [ -e "$launcher_backup" ]; then
             cp -a "$launcher_backup" "$BIN/ableton-live" || true
         fi
-        echo "!! install failed; previous runtime restored" >&2
+        if [ "$promoted" -eq 1 ] || [ -n "$backup" ] || [ -n "$launcher_backup" ]; then
+            echo "!! install failed; previous runtime restored" >&2
+        else
+            echo "!! install aborted; nothing was changed" >&2
+        fi
     fi
     [ -z "$stage" ] || rm -rf "$stage"
     exit "$rc"
 }
 trap cleanup EXIT
+# Without these, a signal reaches the EXIT trap with $? still 0 and the
+# rollback above is skipped: an interrupt between the two promotion mv's
+# would leave no runtime installed and say nothing. The confirmation
+# prompt is a 60 second window inviting exactly that Ctrl-C.
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # tarball: prefer dist/ (freshly built), else a release tarball dropped in root
 tarball="$(ls "$root"/dist/${NAME}-*.tar.zst 2>/dev/null | sort -V | tail -1 || true)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,10 +55,37 @@ else
     echo "   (no .sha256 next to tarball: skipping)"
 fi
 
-if pgrep -af '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' >/dev/null 2>&1 || \
-   pgrep -af "$OPT/$NAME" >/dev/null 2>&1; then
-    echo "!! the installed Ableton Wine is still running: close Live, wait a few seconds, and rerun" >&2
-    exit 1
+# Anything still running from the installed runtime holds the old files
+# open. Stop it all instead of refusing: Live and its helpers first, then
+# the prefix's wineserver, then force-kill whatever is left under
+# $OPT/$NAME. ableton-linkd is not part of the runtime and is handled at
+# its own install step below.
+live_up=0
+if pgrep -af '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' >/dev/null 2>&1; then
+    live_up=1
+fi
+if [ "$live_up" -eq 1 ] || pgrep -af "$OPT/$NAME" >/dev/null 2>&1; then
+    echo "== stopping running Ableton processes =="
+    pgrep -af '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' || true
+    pgrep -af "$OPT/$NAME" || true
+    # Closing Live discards unsaved work, so ask first. Leftover wineserver
+    # and winedevice.exe without Live have nothing to save: no prompt.
+    # /dev/tty rather than stdin: the .run wrapper feeds the script through
+    # a pipe. Without a terminal there is nobody to ask; proceed.
+    if [ "$live_up" -eq 1 ] && [ -r /dev/tty ] && [ -w /dev/tty ]; then
+        printf "You're updating and Live is still open. Make sure you've saved everything and press Enter to continue." > /dev/tty
+        read -r _ < /dev/tty || true
+    fi
+    pkill -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' 2>/dev/null || true
+    if [ -x "$OPT/$NAME/bin/wineserver" ]; then
+        WINEPREFIX="${ABLETON_WINEPREFIX:-$HOME/.wine-ableton}" \
+            "$OPT/$NAME/bin/wineserver" -k 2>/dev/null || true
+    fi
+    for _ in $(seq 1 20); do
+        pgrep -f "$OPT/$NAME" >/dev/null 2>&1 || break
+        sleep 0.5
+    done
+    pkill -9 -f "$OPT/$NAME" 2>/dev/null || true
 fi
 
 echo "== stage and validate patched Wine =="
@@ -184,8 +211,21 @@ done
 # timeline survive a Live restart (notes/ABLETON-WINE-LINK-FIRSTCLASS.md).
 # The launcher auto-starts it. The .run wrapper calls setup-link.sh once after
 # this install; repository installs may call the staged script directly.
+# Stop a running daemon before replacing the binary, else the old process
+# keeps running from the deleted inode and the update takes effect only
+# after a reboot. SIGTERM is a clean exit for it, so Restart=on-failure
+# does not undo the stop.
+linkd_active=0
+if systemctl --user is-active --quiet ableton-linkd.service 2>/dev/null; then
+    linkd_active=1
+    systemctl --user stop ableton-linkd.service 2>/dev/null || true
+fi
+pkill -x ableton-linkd 2>/dev/null || true   # launcher-started instance, no unit
 install -m755 "$linkd" "$HOME/.local/share/ableton-wine/ableton-linkd"
 install -m644 "$linkd_unit" "$HOME/.local/share/ableton-wine/ableton-linkd.service"
+if [ "$linkd_active" -eq 1 ]; then
+    systemctl --user start ableton-linkd.service 2>/dev/null || true
+fi
 # Keep the setup command installed for retries after a firewall or
 # hook-removal failure.
 install -m755 "$here/setup-link.sh" "$HOME/.local/share/ableton-wine/setup-link.sh"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -56,10 +56,18 @@ else
 fi
 
 # Anything still running from the installed runtime holds the old files
-# open. Stop it all instead of refusing: Live and its helpers first, then
-# the prefix's wineserver, then force-kill whatever is left under
-# $OPT/$NAME. ableton-linkd is not part of the runtime and is handled at
-# its own install step below.
+# open. Stop it all instead of refusing: ask the prefix's wineserver to
+# take the whole session down (Live and its helpers are its clients), and
+# pkill only what survives that or runs when no wineserver binary is
+# there to call. ableton-linkd is not part of the runtime and is handled
+# at its own install step below.
+ableton_up()
+{
+    # Two patterns: Live's exe processes do not carry the runtime path on
+    # their command line, the support processes do.
+    pgrep -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' >/dev/null 2>&1 || \
+        pgrep -f "$OPT/$NAME" >/dev/null 2>&1
+}
 live_up=0
 if pgrep -af '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' >/dev/null 2>&1; then
     live_up=1
@@ -71,21 +79,34 @@ if [ "$live_up" -eq 1 ] || pgrep -af "$OPT/$NAME" >/dev/null 2>&1; then
     # Closing Live discards unsaved work, so ask first. Leftover wineserver
     # and winedevice.exe without Live have nothing to save: no prompt.
     # /dev/tty rather than stdin: the .run wrapper feeds the script through
-    # a pipe. Without a terminal there is nobody to ask; proceed.
+    # a pipe. Without a terminal there is nobody to ask; proceed. The -r/-w
+    # tests pass even with no controlling terminal (they check the device
+    # mode, not an open), so the open itself is the real gate: when it
+    # fails, the group falls through to || true instead of tripping set -e.
     if [ "$live_up" -eq 1 ] && [ -r /dev/tty ] && [ -w /dev/tty ]; then
-        printf "You're updating and Live is still open. Make sure you've saved everything and press Enter to continue." > /dev/tty
-        read -r _ < /dev/tty || true
+        {
+            printf "You're updating and Live is still open. Make sure you've saved everything and press Enter to continue."
+            read -r _
+        } 2>/dev/null < /dev/tty > /dev/tty || true
     fi
-    pkill -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' 2>/dev/null || true
     if [ -x "$OPT/$NAME/bin/wineserver" ]; then
         WINEPREFIX="${ABLETON_WINEPREFIX:-$HOME/.wine-ableton}" \
             "$OPT/$NAME/bin/wineserver" -k 2>/dev/null || true
+        for _ in $(seq 1 20); do
+            ableton_up || break
+            sleep 0.5
+        done
     fi
-    for _ in $(seq 1 20); do
-        pgrep -f "$OPT/$NAME" >/dev/null 2>&1 || break
-        sleep 0.5
-    done
-    pkill -9 -f "$OPT/$NAME" 2>/dev/null || true
+    if ableton_up; then
+        pkill -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' 2>/dev/null || true
+        pkill -f "$OPT/$NAME" 2>/dev/null || true
+        for _ in $(seq 1 10); do
+            ableton_up || break
+            sleep 0.5
+        done
+        pkill -9 -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' 2>/dev/null || true
+        pkill -9 -f "$OPT/$NAME" 2>/dev/null || true
+    fi
 fi
 
 echo "== stage and validate patched Wine =="

--- a/tools/ableton-linkd.cpp
+++ b/tools/ableton-linkd.cpp
@@ -19,13 +19,20 @@
  * jack_link remains an option for JACK-only apps.
  *
  * Modes:
- *   (no args)     foreground: status line to stderr every 10 s plus
- *                 peer/tempo/start-stop change callbacks
+ *   (no args)     foreground: log on peer/tempo/start-stop changes only
  *   --daemon      fork to background, log to ~/.log/ableton-linkd/ableton-linkd.log
  *   --probe [s]   join, wait up to s seconds (default 10), print
  *                 "peers: N" and "tempo: T.T", exit 0 iff N >= 1
  *   --tempo BPM   initial tempo when founding a session (default 120.0)
+ *   --verbose     also log a status line every 10 s (the pre-2026.08 default;
+ *                 ABLETON_LINKD_VERBOSE=1 does the same)
  *   --help        usage
+ *
+ * Logging is event-driven by default. The change callbacks cover peers,
+ * tempo and transport, so a quiet session writes nothing. The periodic
+ * status line used to be unconditional. Under the systemd unit that was
+ * 8640 identical journal lines a day. It read as a stuck process and
+ * invited force quits, so it is now opt-in via --verbose.
  *
  * SIGTERM/SIGINT shut down cleanly: Link is disabled (a byebye goes out on
  * the wire) and the process exits 0.
@@ -207,7 +214,7 @@ int run_probe(double tempo, int secs)
 }
 
 /* Foreground and --daemon: anchor the session until signalled. */
-int run_anchor(double tempo, bool as_daemon)
+int run_anchor(double tempo, bool as_daemon, bool verbose)
 {
     if (as_daemon) {
         std::string log_dir;
@@ -229,7 +236,7 @@ int run_anchor(double tempo, bool as_daemon)
     while (!g_quit) {
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
         const auto now = std::chrono::steady_clock::now();
-        if (now - last_status >= kStatusPeriod) {
+        if (verbose && now - last_status >= kStatusPeriod) {
             print_status(link);
             last_status = now;
         }
@@ -245,15 +252,18 @@ void print_usage(const char* argv0)
     std::printf(
         "ableton-linkd: native Ableton Link session anchor and probe\n"
         "\n"
-        "usage: %s [--tempo BPM] [--daemon | --probe [secs] | --help]\n"
+        "usage: %s [--tempo BPM] [--verbose] [--daemon | --probe [secs] | --help]\n"
         "\n"
-        "  (no options)   run in the foreground; status lines to stderr every 10 s\n"
+        "  (no options)   run in the foreground; log to stderr on peer, tempo and\n"
+        "                 start-stop changes\n"
         "  --daemon       fork to the background, log to\n"
         "                 ~/.log/ableton-linkd/ableton-linkd.log\n"
         "  --probe [s]    join, wait up to s seconds (default %d), print \"peers: N\"\n"
         "                 and \"tempo: T.T\"; exit 0 iff at least one peer was seen\n"
         "  --tempo BPM    initial tempo when founding a session (default 120.0,\n"
         "                 valid range %.0f-%.0f)\n"
+        "  --verbose      also log a status line every 10 s\n"
+        "                 (ABLETON_LINKD_VERBOSE=1 does the same)\n"
         "  --help         this text\n"
         "\n"
         "Strictly passive: after construction it never changes the session tempo\n"
@@ -281,6 +291,8 @@ int main(int argc, char** argv)
     bool as_daemon = false;
     bool probe = false;
     int probe_secs = kDefaultProbeSecs;
+    const char* verbose_env = std::getenv("ABLETON_LINKD_VERBOSE");
+    bool verbose = verbose_env && *verbose_env && std::strcmp(verbose_env, "0") != 0;
 
     for (int i = 1; i < argc; ++i) {
         const std::string arg = argv[i];
@@ -289,6 +301,8 @@ int main(int argc, char** argv)
             return 0;
         } else if (arg == "--daemon") {
             as_daemon = true;
+        } else if (arg == "--verbose") {
+            verbose = true;
         } else if (arg == "--probe") {
             probe = true;
             /* optional value: --probe 15 */
@@ -323,5 +337,6 @@ int main(int argc, char** argv)
         return 2;
     }
 
-    return probe ? run_probe(tempo, probe_secs) : run_anchor(tempo, as_daemon);
+    return probe ? run_probe(tempo, probe_secs)
+                 : run_anchor(tempo, as_daemon, verbose);
 }


### PR DESCRIPTION
Two fixes in one because they were kinda related:

A user asked why `ableton-linkd` needed to be force quit, but kept restarting automatically. After reviewing this (and finding a separate issue of `ableton-linkd` being overly chatty). What I realised after a few clarifying messages with the reporter, was that they were trying to update ableton-linux and couldn't because it was blocked by still-running ableton-wine processes. So the user hunted down and killed the one visible "ableton" process, linkd, which the unit brought straight back.

This PR includes two things"
1. `ableton-linkd` now now longer prints the same messages over and over, and logging is now event-driven. You can restore the old behaviour with `--verbose` if you want that for some reason.
2. The installer now stops Live, the prefix wineserver, and any leftover runtime processes itself, asking for confirmation first when Live is open in a terminal session. It also stops `ableton-linkd` before swapping its binary and restarts it after, so updates actually take effect instead of the old process running from a deleted `inode` until reboot.