### PR TITLE
Defeating the Wine vs Live GPU Denylist problem, take 3 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Graphics cards missing from Wine's table keep their real identity even when
   the driver reports no video memory (Wine patch 0067). Wine reads that figure
   from an optional graphics-driver feature, and a driver that does not offer it
-  used to cost the card its identity, falling back to the invented 2012 one.
+  used to make Wine report the card under the invented 2012 identity instead.
 - Added `WINE_D3D_FORCE_GPU_RENDERING=1`, which offers Live's GPU renderer on
   the older Intel graphics Live refuses by model (Wine patch 0068). Run
   `WINE_D3D_FORCE_GPU_RENDERING=1 ableton-live` to try it. Diagnostics sent to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@
   device's ID number, not its name, and the number Wine invents for a model
   it cannot identify belongs to a 2012 part Live refuses. Wine now reports
   the real device.
+- Graphics cards missing from Wine's table keep their real identity even when
+  the driver reports no video memory (Wine patch 0067). Wine reads that figure
+  from a source only NVIDIA's driver provides, so on Intel and AMD it was
+  always absent and the card fell back to the invented 2012 identity.
+- Added `WINE_D3D_FORCE_GPU_RENDERING=1`, which offers Live's GPU renderer on
+  the older Intel graphics Live refuses by model (Wine patch 0068). Run
+  `WINE_D3D_FORCE_GPU_RENDERING=1 ableton-live` to try it. Diagnostics sent to
+  Ableton then carry an inaccurate GPU model, and Live's device name marks the
+  substitution so Ableton engineering can see it, for example
+  "Intel(R) HD Graphics 4000 (reporting as Intel(R) UHD Graphics 630)".
 
 ## 2026.08.01.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- Live's GPU renderer is available on the Intel graphics built into 2015
+  through 2019 processors (Wine patch 0066). Wine's device table skipped 24
+  of those models, among them the UHD Graphics 630 in the Core i5-8400
+  through i7-8700, and reported each as "Intel(R) HD Graphics 4000", so the
+  Preferences dialog greyed out "Enable GPU Renderer". Live matches the
+  device's ID number, not its name, and the number Wine invents for a model
+  it cannot identify belongs to a 2012 part Live refuses. Wine now reports
+  the real device.
+
 ## 2026.08.01.1
 
 - Live's GPU renderer is available again on Intel graphics newer than 2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
   the real device.
 - Graphics cards missing from Wine's table keep their real identity even when
   the driver reports no video memory (Wine patch 0067). Wine reads that figure
-  from a source only NVIDIA's driver provides, so on Intel and AMD it was
-  always absent and the card fell back to the invented 2012 identity.
+  from an optional graphics-driver feature, and a driver that does not offer it
+  used to cost the card its identity, falling back to the invented 2012 one.
 - Added `WINE_D3D_FORCE_GPU_RENDERING=1`, which offers Live's GPU renderer on
   the older Intel graphics Live refuses by model (Wine patch 0068). Run
   `WINE_D3D_FORCE_GPU_RENDERING=1 ableton-live` to try it. Diagnostics sent to

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -29,6 +29,38 @@ This workaround is only needed for affected plugins. See the
 [Pianoteq investigation](notes/ABLETON-WINE-PIANOTEQ-DPI-GHOST-BUG.md) for the
 confirmed failure mode.
 
+## Live's "Enable GPU Renderer" setting is greyed out
+
+If you're experiencing performance issues or high CPU usage when idle, Live
+may not be using your GPU. By default, Live will always offload the UI to
+your GPU for maximum performance, but will only do so when it recognises
+the name of your GPU. On Linux, GPUs will 'tell' Live their name without
+any external interference, and because Live is anticipating that interference,
+it may not recognise the GPU's name and refuse to use the GPU.
+
+To confirm this problem, open **Settings > Display & Input**. 
+If **Enable GPU Renderer** is greyed out, and the note under it names a 
+graphics card that is not the one in your computer, then you're seeing this
+exact problem. 
+
+To solve it: **update this project**.
+
+Download [the latest installer](https://github.com/shibco/ableton-linux/releases/latest/download/install-ableton-latest.run)
+and run the update. It keeps your Live installation, your license, and
+your projects:
+
+```bash
+sh ~/Downloads/install-ableton-latest.run --update
+```
+
+Start Live, open **Settings > Display & Input**, and turn on **Enable GPU
+Renderer**. Live now names your real graphics card, and the setting stays
+on.
+
+If the setting is still greyed out on 2026.08.01.1 or newer,
+[open an issue](https://github.com/shibco/ableton-linux/issues) and
+include your graphics card model.
+
 ## Live 11: Max for Live fails after the first launch
 
 After running Live 11 once, close Live and run:

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -59,9 +59,21 @@ Start Live, open **Settings > Display & Input**, and turn on **Enable GPU
 Renderer**. Live now names your real graphics card, and the setting stays
 on.
 
-If the setting is still greyed out on 2026.08.01.1 or newer,
-[open an issue](https://github.com/shibco/ableton-linux/issues) and
-include your graphics card model.
+If you still have problems, you can force this with:
+
+```bash
+WINE_D3D_FORCE_GPU_RENDERING=1 ableton-live
+```
+
+If you run this flag, any diagnostics you send to Ableton will contain
+inaccurate details about your GPU. We have added additional clarification so
+crash reports, etc sent to Ableton engineering will clearly mark that your
+GPU is being 'seen' by Live as a different model.
+
+Start Live without the flag to go back.
+
+If problems continue, [open an issue](https://github.com/shibco/ableton-linux/issues)
+and include your graphics card model.
 
 ## Live 11: Max for Live fails after the first launch
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -34,9 +34,11 @@ confirmed failure mode.
 If you're experiencing performance issues or high CPU usage when idle, Live
 may not be using your GPU. By default, Live will always offload the UI to
 your GPU for maximum performance, but will only do so when it recognises
-the name of your GPU. On Linux, GPUs will 'tell' Live their name without
-any external interference, and because Live is anticipating that interference,
-it may not recognise the GPU's name and refuse to use the GPU.
+your GPU. Every graphics chip identifies itself by a model number, and Live
+keeps a list of old models it refuses to use. That number reaches Live
+through Wine, and when Wine does not recognise your GPU it sends the number
+of a 2012 model instead, which is on Live's list. Live then refuses a GPU
+far newer than the one it thinks it sees.
 
 To confirm this problem, open **Settings > Display & Input**. 
 If **Enable GPU Renderer** is greyed out, and the note under it names a 

--- a/notes/ABLETON-WINE-GPU-RENDERER.md
+++ b/notes/ABLETON-WINE-GPU-RENDERER.md
@@ -197,9 +197,92 @@ entry takes precedence over 0061, and the "(MTL)" suffix in 0057's
 entry is what passes Live's check. A traced launch from that machine
 confirming the exact rejected name is still open.
 
+The two paragraphs above explain the refusal by the reported name.
+That explanation is wrong, and the subsection below replaces it.
+
 To check a machine: open Preferences > Display & Input. "Enable GPU
 Renderer" must be a switch, not greyed out with the HD 4000 reason
 text.
+
+### Live matches ID numbers, not names (2026-08-02, patch 0066)
+
+Every graphics chip reports two numbers: a vendor number and a device
+number. Intel's vendor number is `0x8086`; a UHD Graphics 630 reports
+device number `0x3e92`.
+
+Live reads only those numbers. A vendor other than Intel is allowed. A
+device number among 101 listed numbers, all Intel parts sold between
+roughly 2004 and 2014, is refused. Anything else is allowed. The name
+appears only in the message Live displays, which is why the refusal
+reads as a judgement about "Intel(R) HD Graphics 4000". Established
+2026-08-02 by reading `Ableton Live 12 Suite.exe`.
+
+That rules out the earlier account of stickyfran's Meteor Lake laptop,
+which blamed the missing "(MTL)" suffix in 0061's synthesised name. A
+suffix cannot matter to a check that never reads names.
+
+The refused number is one Wine invents. When Wine cannot identify a
+card it guesses from the driver's advertised features, and for Intel it
+always guesses device `0x0162`, "Intel(R) HD Graphics 4000", which is on
+Live's list. Every unidentified Intel card therefore arrives wearing a
+refused identity, however new it is.
+
+Two gaps let a modern card reach that guess.
+
+First, Wine's device table covers 2015 to 2019 Intel unevenly: it holds
+the mobile UHD 630 and one desktop UHD 630 but not `0x3e92`, the desktop
+UHD 630 in the i5-8400 through i7-8700, nor 23 other parts. Patch 0066
+adds them.
+
+Second, patch 0061 describes an unlisted card from its driver's own
+name, but stands down when the driver reports no video memory. Wine
+reaches the driver through EGL or GLX and picks EGL by default
+(`use_egl = TRUE`, `dlls/winex11.drv/x11drv_main.c`). On EGL it reads
+video memory only from `GL_NVX_gpu_memory_info`
+(`dlls/win32u/opengl.c`), which NVIDIA's driver provides and Mesa does
+not. Intel and AMD machines on EGL report zero, 0061 stands down, and
+the invented `0x0162` goes through. A table entry is immune, being
+consulted first.
+
+The maintainer's machine reports its real card, which implies it uses
+GLX. What decides the interface per machine is not established, and that
+is why the fault looks intermittent across similar hardware. No
+`WINEDEBUG=+d3d` trace from an affected machine has been captured.
+
+Patch 0066 closes the first gap. The second needs its own change, so
+that an unidentified card never inherits a refused identity, with a
+launcher switch for anyone who needs the renderer off.
+
+Reported 2026-08-02: HP EliteDesk 800 G4 (i5-8500, UHD 630, `0x3e92`) on
+release 2026.08.01.1, "Enable GPU Renderer" greyed out naming the
+invented HD 4000.
+
+#### Reading a machine's log
+
+```bash
+grep -a "TD3dSurface: Adapter\|GPU Renderer:\|Can't use GPU" \
+  ~/.wine-ableton/drive_c/users/*/AppData/Roaming/Ableton/Live*/Preferences/Log.txt | tail
+```
+
+An `Adapter:` line carries the pair Live received: `(8086:0162)` is the
+invented identity, `(8086:3e92)` the real one. It appears only while
+Live draws through Direct3D, so it is absent both with
+`-_ForceGdiBackend` set and after Live has refused the renderer: 0 lines
+across 129 launches with the flag, 32 across the 33 after removing it. A
+`Can't use GPU renderer:` line records a refusal, but Live writes it
+only when the preference is already on, so its absence proves nothing at
+the default of off.
+
+The fastest datum from a reporter is a screenshot of Settings > Display
+& Input. "Unexplained slow UI at zoom-level 100% and/or crashes" means
+the ID pair was refused. "Gpu rendering is incompatible with
+_ForceGdiBackend" means the legacy flag is still set. "Cannot fetch
+IDXGIAdapter1" means Live found no adapter.
+
+Use `find ~/.wine-ableton -name Options.txt` to check for that flag
+file. In fish a wildcard matching nothing aborts the whole command, so a
+`grep` on a glob path reports the flag as absent in a way that looks
+like an error.
 
 ## Related
 
@@ -208,6 +291,7 @@ text.
 - [Patch 0053](../patches/0053-winex11-export-the-app-minimum-tracking-size-as-PMin.patch)
 - [Patch 0055](../patches/0055-dxgi-prefer-GL-present-for-top-level-swapchain-devic.patch)
 - [Patch 0057](../patches/0057-wined3d-add-Intel-graphics-devices-from-Ice-Lake-to-.patch)
+- [Patch 0066](../patches/0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch)
 - Resize trace from the diagnosis session:
   `~/Projects/Code/ableton/live-resize-trace-gpu-20260727.log`
   (machine-local)

--- a/notes/ABLETON-WINE-GPU-RENDERER.md
+++ b/notes/ABLETON-WINE-GPU-RENDERER.md
@@ -235,27 +235,28 @@ UHD 630 in the i5-8400 through i7-8700, nor 23 other parts. Patch 0066
 adds them.
 
 Second, patch 0061 describes an unlisted card from its driver's own
-name, but stands down when the driver reports no video memory. Wine
-reaches the driver through EGL or GLX and picks EGL by default
+name, but skips the synthesis when the driver reports no video memory.
+Wine reaches the driver through EGL or GLX and picks EGL by default
 (`use_egl = TRUE`, `dlls/winex11.drv/x11drv_main.c`). On EGL it reads
 video memory only from `GL_NVX_gpu_memory_info`
 (`dlls/win32u/opengl.c`). A driver that does not expose that extension
-reports zero, 0061 stands down, and the invented `0x0162` goes through.
-A table entry is immune, being consulted first.
+reports zero, the synthesis is skipped, and wined3d reports the
+invented `0x0162` instead. The table is consulted before either, so a
+card with a table entry is unaffected.
 
 Mesa implements the extension per driver, not universally. Measured
 2026-08-03 on an RX 7900 XT, Mesa 26.1.6, fresh prefix with no `UseEGL`
 override and `trace:wgl:egl_init` in the log: radeonsi on EGL reported
-20 GB, so 0061 fires there and the card keeps its real identity. That
+20 GB, so 0061 runs there and the card keeps its real identity. That
 also rules out the earlier reading of the maintainer's machine as
 implying GLX — a machine can report its real card on EGL. Whether iris
 exposes the extension is untested; no `WINEDEBUG=+d3d` trace from an
-affected machine has been captured, so what the reporting EliteDesk
-actually did is still open.
+affected machine has been captured, so the reporting EliteDesk's own
+video-memory report is still unknown.
 
 Patch 0066 closes the first gap. The second needs its own change, so
-that an unidentified card never inherits a refused identity, with a
-launcher switch for anyone who needs the renderer off.
+that an unidentified card is never reported under a device ID Live
+refuses, with a launcher switch for anyone who needs the renderer off.
 
 Reported 2026-08-02: HP EliteDesk 800 G4 (i5-8500, UHD 630, `0x3e92`) on
 release 2026.08.01.1, "Enable GPU Renderer" greyed out naming the
@@ -265,12 +266,13 @@ invented HD 4000.
 
 Patch 0067 removes the video-memory precondition on 0061's synthesised
 description. The precondition assumed a missing figure was worse than
-the fallback's approximation; where the driver supplies none, that
-assumption costs an unlisted card its real identity for an attribute
-that has nothing to do with identifying it. A neutral figure stands in
-when the driver reports none, so the outcome no longer depends on which
-drivers implement `GL_NVX_gpu_memory_info`. Together with 0066 this ends
-the whack-a-mole for cards Wine can identify at all.
+the fallback's approximation; where the driver supplies none, the card
+is instead reported under the wrong device ID, over an attribute
+unrelated to identifying it. The patch reports a neutral figure when
+the driver supplies none, so the outcome no longer depends on which
+drivers implement `GL_NVX_gpu_memory_info`. Together with 0066 this
+covers every card Wine can identify, without adding a table entry per
+card.
 
 Patch 0068 covers the cards Live genuinely lists.
 `WINE_D3D_FORCE_GPU_RENDERING=1` reports baseline device

--- a/notes/ABLETON-WINE-GPU-RENDERER.md
+++ b/notes/ABLETON-WINE-GPU-RENDERER.md
@@ -239,15 +239,19 @@ name, but stands down when the driver reports no video memory. Wine
 reaches the driver through EGL or GLX and picks EGL by default
 (`use_egl = TRUE`, `dlls/winex11.drv/x11drv_main.c`). On EGL it reads
 video memory only from `GL_NVX_gpu_memory_info`
-(`dlls/win32u/opengl.c`), which NVIDIA's driver provides and Mesa does
-not. Intel and AMD machines on EGL report zero, 0061 stands down, and
-the invented `0x0162` goes through. A table entry is immune, being
-consulted first.
+(`dlls/win32u/opengl.c`). A driver that does not expose that extension
+reports zero, 0061 stands down, and the invented `0x0162` goes through.
+A table entry is immune, being consulted first.
 
-The maintainer's machine reports its real card, which implies it uses
-GLX. What decides the interface per machine is not established, and that
-is why the fault looks intermittent across similar hardware. No
-`WINEDEBUG=+d3d` trace from an affected machine has been captured.
+Mesa implements the extension per driver, not universally. Measured
+2026-08-03 on an RX 7900 XT, Mesa 26.1.6, fresh prefix with no `UseEGL`
+override and `trace:wgl:egl_init` in the log: radeonsi on EGL reported
+20 GB, so 0061 fires there and the card keeps its real identity. That
+also rules out the earlier reading of the maintainer's machine as
+implying GLX — a machine can report its real card on EGL. Whether iris
+exposes the extension is untested; no `WINEDEBUG=+d3d` trace from an
+affected machine has been captured, so what the reporting EliteDesk
+actually did is still open.
 
 Patch 0066 closes the first gap. The second needs its own change, so
 that an unidentified card never inherits a refused identity, with a
@@ -261,11 +265,12 @@ invented HD 4000.
 
 Patch 0067 removes the video-memory precondition on 0061's synthesised
 description. The precondition assumed a missing figure was worse than
-the fallback's approximation; on the EGL backend Mesa never supplies
-one, so the assumption cost every unlisted Intel and AMD card its real
-identity. A neutral figure stands in when the driver reports none.
-Together with 0066 this ends the whack-a-mole for cards Wine can
-identify at all.
+the fallback's approximation; where the driver supplies none, that
+assumption costs an unlisted card its real identity for an attribute
+that has nothing to do with identifying it. A neutral figure stands in
+when the driver reports none, so the outcome no longer depends on which
+drivers implement `GL_NVX_gpu_memory_info`. Together with 0066 this ends
+the whack-a-mole for cards Wine can identify at all.
 
 Patch 0068 covers the cards Live genuinely lists.
 `WINE_D3D_FORCE_GPU_RENDERING=1` reports baseline device

--- a/notes/ABLETON-WINE-GPU-RENDERER.md
+++ b/notes/ABLETON-WINE-GPU-RENDERER.md
@@ -257,6 +257,39 @@ Reported 2026-08-02: HP EliteDesk 800 G4 (i5-8500, UHD 630, `0x3e92`) on
 release 2026.08.01.1, "Enable GPU Renderer" greyed out naming the
 invented HD 4000.
 
+#### Forcing the renderer past the list (2026-08-02, patches 0067 and 0068)
+
+Patch 0067 removes the video-memory precondition on 0061's synthesised
+description. The precondition assumed a missing figure was worse than
+the fallback's approximation; on the EGL backend Mesa never supplies
+one, so the assumption cost every unlisted Intel and AMD card its real
+identity. A neutral figure stands in when the driver reports none.
+Together with 0066 this ends the whack-a-mole for cards Wine can
+identify at all.
+
+Patch 0068 covers the cards Live genuinely lists.
+`WINE_D3D_FORCE_GPU_RENDERING=1` reports baseline device
+`0x3e9b` in place of the card's own, so the gate passes. Vendor, driver
+and video memory are untouched, and the description keeps the real name
+with the substitution named after it:
+
+    Intel(R) HD Graphics 4000 (reporting as Intel(R) UHD Graphics 630)
+
+The card's identity is accompanied, never replaced, so the substitution
+shows up wherever the description does: Live's `TD3dSurface: Adapter:`
+line, its Preferences dialog, and any report that carries either. Live's
+usage log records `graphics_device_name` from a separate query that
+still reports the true device, so what Ableton receives identifies the
+real card and marks the substituted one.
+
+Intel only, since no other vendor is gated this way, and off by default,
+since applications besides Live read the device ID.
+
+Whether these pre-2014 parts actually run the renderer well under Mesa
+is unknown. Ableton's list was drawn against Intel's Windows drivers,
+and the fallback for a refused user is the GDI renderer at about 59% of
+a core, so the trade is worth offering. Reports decide the default.
+
 #### Reading a machine's log
 
 ```bash

--- a/patches/0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
+++ b/patches/0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
@@ -24,10 +24,18 @@ matter how modern the real device is.
 The synthesised-description path (patch 0061) was meant to cover table
 misses, but it declines to run when the driver reports no video
 memory, and on the EGL x11 backend - the default - win32u fills video
-memory only from GL_NVX_gpu_memory_info, which Mesa does not expose.
-An Intel or AMD machine on the EGL backend reports zero and falls
+memory only from GL_NVX_gpu_memory_info (dlls/win32u/opengl.c). A
+driver that does not expose that extension reports zero and falls
 through to the fabricated 0x0162 anyway. A table entry is immune to
-that guard. Loosening the guard is a separate change.
+that guard, being consulted first. Loosening the guard is a separate
+change.
+
+How far that reaches is not established. Mesa implements the extension
+per driver: radeonsi on Mesa 26.1.6 does expose it, and an RX 7900 XT
+on the EGL backend was measured reporting 20 GB, so 0061 fires there.
+Whether iris exposes it on the reporting machine is unknown - no
+WINEDEBUG=+d3d trace from that machine has been captured. The table
+entry this patch adds does not depend on the answer.
 
 Verified by compiling the patched table: all 24 IDs resolve to their
 pci.ids names, the table holds no duplicate vendor+device pair, and no

--- a/patches/0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
+++ b/patches/0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
@@ -1,0 +1,138 @@
+Subject: wined3d: add the missing Intel devices from Skylake to Amber
+ Lake
+
+The device table covers the Gen9 families unevenly: Skylake is complete
+except HD Graphics 535, Kaby Lake lacks its GT1, GT3 and workstation
+parts, and Coffee Lake has three of its seventeen devices - the mobile
+H UHD 630, one desktop UHD 630, and the Whiskey Lake UHD 620 - but not
+the other desktop UHD 630 (0x3e92: i5-8400 through i7-8700, the
+highest-volume desktop processors of 2018), the 9th-gen refresh
+(0x3e98), the GT1 and GT3e parts, Whiskey Lake GT1, or the second
+Amber Lake ID. 24 devices in all; IDs and names from the pci.ids
+database.
+
+A miss in this table costs more than a wrong name. Ableton Live 12
+gates its GPU renderer on the reported PCI ID: it fetches
+IDXGIAdapter1's DXGI_ADAPTER_DESC1 and, for VendorId 0x8086, refuses
+any DeviceId found on an internal list of 101 pre-2014 Intel devices
+(established by disassembling the check; the device name is used only
+in the refusal message). On a table miss wined3d's feature-level
+fallback fabricates CARD_INTEL_IVBD, device 0x0162 - which is on that
+list. Every table miss therefore disables Live's GPU renderer, no
+matter how modern the real device is.
+
+The synthesised-description path (patch 0061) was meant to cover table
+misses, but it declines to run when the driver reports no video
+memory, and on the EGL x11 backend - the default - win32u fills video
+memory only from GL_NVX_gpu_memory_info, which Mesa does not expose.
+An Intel or AMD machine on the EGL backend reports zero and falls
+through to the fabricated 0x0162 anyway. A table entry is immune to
+that guard. Loosening the guard is a separate change.
+
+Verified by compiling the patched table: all 24 IDs resolve to their
+pci.ids names, the table holds no duplicate vendor+device pair, and no
+new ID is on Live's list. Field report: HP EliteDesk 800 G4 (i5-8500,
+UHD 630 0x3e92) on release 2026.08.01.1, "Enable GPU Renderer" greyed
+out with the fabricated HD 4000 named in the reason text.
+
+Also correct the comment above the Ice Lake block: Live's list matches
+PCI device IDs, not names.
+
+Origin: local fix for the 2026-08-02 UHD 630 field report
+(ableton-linux). The missing IDs and the fallback behaviour apply
+upstream as well.
+---
+ dlls/wined3d/directx.c         | 28 ++++++++++++++++++++++++++--
+ dlls/wined3d/wined3d_private.h | 24 ++++++++++++++++++++++++
+ 2 files changed, 50 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/wined3d/directx.c b/dlls/wined3d/directx.c
+index 0decb19..3bab15d 100644
+--- a/dlls/wined3d/directx.c
++++ b/dlls/wined3d/directx.c
+@@ -648,6 +648,7 @@ static const struct wined3d_gpu_description gpu_description_table[] =
+     {HW_VENDOR_INTEL,      CARD_INTEL_HD520_2,             "Intel(R) HD Graphics 520",                                  DRIVER_INTEL_HD4000,  2048},
+     {HW_VENDOR_INTEL,      CARD_INTEL_HD530_1,             "Intel(R) HD Graphics 530",                                  DRIVER_INTEL_HD4000,  2048},
+     {HW_VENDOR_INTEL,      CARD_INTEL_HD530_2,             "Intel(R) HD Graphics 530",                                  DRIVER_INTEL_HD4000,  2048},
++    {HW_VENDOR_INTEL,      CARD_INTEL_HD535,               "Intel(R) HD Graphics 535",                                  DRIVER_INTEL_HD4000,  2048},
+     {HW_VENDOR_INTEL,      CARD_INTEL_HDP530,              "Intel(R) HD Graphics P530",                                 DRIVER_INTEL_HD4000,  2048},
+     {HW_VENDOR_INTEL,      CARD_INTEL_I540,                "Intel(R) Iris(TM) Graphics 540",                            DRIVER_INTEL_HD4000,  2048},
+     {HW_VENDOR_INTEL,      CARD_INTEL_I550,                "Intel(R) Iris(TM) Graphics 550",                            DRIVER_INTEL_HD4000,  2048},
+@@ -666,10 +667,33 @@ static const struct wined3d_gpu_description gpu_description_table[] =
+     {HW_VENDOR_INTEL,      CARD_INTEL_HD630_2,             "Intel(R) HD Graphics 630",                                  DRIVER_INTEL_HD4000,  3072},
+     {HW_VENDOR_INTEL,      CARD_INTEL_UHD630_1,            "Intel(R) UHD Graphics 630",                                 DRIVER_INTEL_HD4000,  3072},
+     {HW_VENDOR_INTEL,      CARD_INTEL_UHD630_2,            "Intel(R) UHD Graphics 630",                                 DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_HD610_1,             "Intel(R) HD Graphics 610",                                  DRIVER_INTEL_HD4000,  2048},
++    {HW_VENDOR_INTEL,      CARD_INTEL_HD610_2,             "Intel(R) HD Graphics 610",                                  DRIVER_INTEL_HD4000,  2048},
++    {HW_VENDOR_INTEL,      CARD_INTEL_HD610_3,             "Intel(R) HD Graphics 610",                                  DRIVER_INTEL_HD4000,  2048},
++    {HW_VENDOR_INTEL,      CARD_INTEL_HD620_2,             "Intel(R) HD Graphics 620",                                  DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_HD635,               "Intel(R) HD Graphics 635",                                  DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_HDP630,              "Intel(R) HD Graphics P630",                                 DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_IP640,               "Intel(R) Iris(R) Plus Graphics 640",                        DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_IP650,               "Intel(R) Iris(R) Plus Graphics 650",                        DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_UHD615,              "Intel(R) UHD Graphics 615",                                 DRIVER_INTEL_HD4000,  2048},
++    {HW_VENDOR_INTEL,      CARD_INTEL_UHD617_2,            "Intel(R) UHD Graphics 617",                                 DRIVER_INTEL_HD4000,  2048},
++    {HW_VENDOR_INTEL,      CARD_INTEL_UHD610_1,            "Intel(R) UHD Graphics 610",                                 DRIVER_INTEL_HD4000,  2048},
++    {HW_VENDOR_INTEL,      CARD_INTEL_UHD610_2,            "Intel(R) UHD Graphics 610",                                 DRIVER_INTEL_HD4000,  2048},
++    {HW_VENDOR_INTEL,      CARD_INTEL_UHD610_3,            "Intel(R) UHD Graphics 610",                                 DRIVER_INTEL_HD4000,  2048},
++    {HW_VENDOR_INTEL,      CARD_INTEL_UHD610_4,            "Intel(R) UHD Graphics 610",                                 DRIVER_INTEL_HD4000,  2048},
++    {HW_VENDOR_INTEL,      CARD_INTEL_UHD620_3,            "Intel(R) UHD Graphics 620",                                 DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_UHD630_3,            "Intel(R) UHD Graphics 630",                                 DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_UHD630_4,            "Intel(R) UHD Graphics 630",                                 DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_UHDP630_1,           "Intel(R) UHD Graphics P630",                                DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_UHDP630_2,           "Intel(R) UHD Graphics P630",                                DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_UHDP630_3,           "Intel(R) UHD Graphics P630",                                DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_IP645,               "Intel(R) Iris(R) Plus Graphics 645",                        DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_IP655_1,             "Intel(R) Iris(R) Plus Graphics 655",                        DRIVER_INTEL_HD4000,  3072},
++    {HW_VENDOR_INTEL,      CARD_INTEL_IP655_2,             "Intel(R) Iris(R) Plus Graphics 655",                        DRIVER_INTEL_HD4000,  3072},
+     /* Ice Lake and newer. Without an entry here wined3d reports these
+      * devices through the generic Intel fallback ("Intel(R) HD Graphics
+-     * 4000"), which Ableton Live 12 blacklists by name, disabling its
+-     * GPU renderer (issue 84). */
++     * 4000", device 0x0162), whose PCI device ID is on Ableton Live 12's
++     * GPU denylist, disabling its GPU renderer (issue 84). */
+     /* Ice Lake */
+     {HW_VENDOR_INTEL,      CARD_INTEL_ICL_1,               "Intel(R) Iris(R) Plus Graphics (ICL)",                      DRIVER_INTEL_HD4000,  2048},
+     {HW_VENDOR_INTEL,      CARD_INTEL_ICL_2,               "Intel(R) Iris(R) Plus Graphics (ICL)",                      DRIVER_INTEL_HD4000,  2048},
+diff --git a/dlls/wined3d/wined3d_private.h b/dlls/wined3d/wined3d_private.h
+index 21c4adc..1aeef07 100644
+--- a/dlls/wined3d/wined3d_private.h
++++ b/dlls/wined3d/wined3d_private.h
+@@ -2433,6 +2433,7 @@ enum wined3d_pci_device
+     CARD_INTEL_HD520_2              = 0x1921,
+     CARD_INTEL_HD530_1              = 0x1912,
+     CARD_INTEL_HD530_2              = 0x191b,
++    CARD_INTEL_HD535                = 0x1923,
+     CARD_INTEL_HDP530               = 0x191d,
+     CARD_INTEL_I540                 = 0x1926,
+     CARD_INTEL_I550                 = 0x1927,
+@@ -2451,6 +2452,29 @@ enum wined3d_pci_device
+     CARD_INTEL_HD630_2              = 0x591b,
+     CARD_INTEL_UHD630_1             = 0x3e9b,
+     CARD_INTEL_UHD630_2             = 0x3e91,
++    CARD_INTEL_HD610_1              = 0x5902,
++    CARD_INTEL_HD610_2              = 0x5906,
++    CARD_INTEL_HD610_3              = 0x590b,
++    CARD_INTEL_HD620_2              = 0x5921,
++    CARD_INTEL_HD635                = 0x5923,
++    CARD_INTEL_HDP630               = 0x591d,
++    CARD_INTEL_IP640                = 0x5926,
++    CARD_INTEL_IP650                = 0x5927,
++    CARD_INTEL_UHD615               = 0x591c,
++    CARD_INTEL_UHD617_2             = 0x87ca,
++    CARD_INTEL_UHD610_1             = 0x3e90,
++    CARD_INTEL_UHD610_2             = 0x3e93,
++    CARD_INTEL_UHD610_3             = 0x3e9c,
++    CARD_INTEL_UHD610_4             = 0x3ea1,
++    CARD_INTEL_UHD620_3             = 0x3ea9,
++    CARD_INTEL_UHD630_3             = 0x3e92,
++    CARD_INTEL_UHD630_4             = 0x3e98,
++    CARD_INTEL_UHDP630_1            = 0x3e94,
++    CARD_INTEL_UHDP630_2            = 0x3e96,
++    CARD_INTEL_UHDP630_3            = 0x3e9a,
++    CARD_INTEL_IP645                = 0x3ea6,
++    CARD_INTEL_IP655_1              = 0x3ea5,
++    CARD_INTEL_IP655_2              = 0x3ea8,
+     CARD_INTEL_ICL_1                = 0x8a51,
+     CARD_INTEL_ICL_2                = 0x8a52,
+     CARD_INTEL_CMLU                 = 0x9b41,

--- a/patches/0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
+++ b/patches/0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
@@ -11,8 +11,8 @@ highest-volume desktop processors of 2018), the 9th-gen refresh
 Amber Lake ID. 24 devices in all; IDs and names from the pci.ids
 database.
 
-A miss in this table costs more than a wrong name. Ableton Live 12
-gates its GPU renderer on the reported PCI ID: it fetches
+A miss in this table does more than produce a wrong name. Ableton
+Live 12 gates its GPU renderer on the reported PCI ID: it fetches
 IDXGIAdapter1's DXGI_ADAPTER_DESC1 and, for VendorId 0x8086, refuses
 any DeviceId found on an internal list of 101 pre-2014 Intel devices
 (established by disassembling the check; the device name is used only
@@ -22,20 +22,20 @@ list. Every table miss therefore disables Live's GPU renderer, no
 matter how modern the real device is.
 
 The synthesised-description path (patch 0061) was meant to cover table
-misses, but it declines to run when the driver reports no video
-memory, and on the EGL x11 backend - the default - win32u fills video
-memory only from GL_NVX_gpu_memory_info (dlls/win32u/opengl.c). A
-driver that does not expose that extension reports zero and falls
-through to the fabricated 0x0162 anyway. A table entry is immune to
-that guard, being consulted first. Loosening the guard is a separate
-change.
+misses, but it does not run when the driver reports no video memory,
+and on the EGL x11 backend - the default - win32u fills video memory
+only from GL_NVX_gpu_memory_info (dlls/win32u/opengl.c). A driver that
+does not expose that extension reports zero and falls through to the
+fabricated 0x0162 anyway. The table is consulted before that guard, so
+a card with a table entry is unaffected by it. Loosening the guard is
+a separate change.
 
-How far that reaches is not established. Mesa implements the extension
-per driver: radeonsi on Mesa 26.1.6 does expose it, and an RX 7900 XT
-on the EGL backend was measured reporting 20 GB, so 0061 fires there.
-Whether iris exposes it on the reporting machine is unknown - no
-WINEDEBUG=+d3d trace from that machine has been captured. The table
-entry this patch adds does not depend on the answer.
+How many drivers this affects is not established. Mesa implements the
+extension per driver: radeonsi on Mesa 26.1.6 does expose it, and an
+RX 7900 XT on the EGL backend was measured reporting 20 GB, so 0061
+runs there. Whether iris exposes it on the reporting machine is
+unknown - no WINEDEBUG=+d3d trace from that machine has been captured.
+The table entry this patch adds does not depend on the answer.
 
 Verified by compiling the patched table: all 24 IDs resolve to their
 pci.ids names, the table holds no duplicate vendor+device pair, and no

--- a/patches/0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
+++ b/patches/0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
@@ -1,25 +1,24 @@
 Subject: wined3d: synthesise a GPU description without a
  video-memory report
 
-The synthesised description declines when the driver reports no video
-memory, on the reasoning that reporting zero bytes is worse than the
-feature-level fallback's table approximation. That trade only holds
+wined3d skips the synthesised description when the driver reports no
+video memory, on the reasoning that reporting zero bytes is worse than
+the feature-level fallback's table approximation. That trade only holds
 where a memory figure is available at all, and on the default EGL
 backend that depends entirely on the driver: win32u fills the figure
 solely from GL_NVX_gpu_memory_info (dlls/win32u/opengl.c), which Mesa
 implements per driver rather than universally. radeonsi on Mesa 26.1.6
 exposes it - an RX 7900 XT on EGL was measured reporting 20 GB - so the
-guard is no obstacle there. A driver that does not expose it reports
-zero.
+guard passes there. A driver that does not expose it reports zero.
 
 Such a machine takes the fallback, which names a card from roughly
 2010 - and for Intel that is device 0x0162, "Intel(R) HD Graphics
 4000". Ableton Live 12 refuses that PCI ID, so a correctly working
 modern GPU would lose Live's GPU renderer purely because the
-video-memory attribute was unavailable. Which drivers land there is not
-established, and no WINEDEBUG=+d3d trace from an affected machine has
-been captured; this removes the dependency rather than relying on the
-answer.
+video-memory attribute was unavailable. Which drivers lack the
+extension is not established, and no WINEDEBUG=+d3d trace from an
+affected machine has been captured; this patch removes the dependency
+rather than relying on the answer.
 
 Report the real device instead, and carry a neutral video-memory figure
 of the same order as the table's integrated-graphics entries when the

--- a/patches/0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
+++ b/patches/0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
@@ -5,15 +5,21 @@ The synthesised description declines when the driver reports no video
 memory, on the reasoning that reporting zero bytes is worse than the
 feature-level fallback's table approximation. That trade only holds
 where a memory figure is available at all, and on the default EGL
-backend it never is for Mesa: win32u fills the figure solely from
-GL_NVX_gpu_memory_info (dlls/win32u/opengl.c), which NVIDIA's driver
-provides and Mesa does not.
+backend that depends entirely on the driver: win32u fills the figure
+solely from GL_NVX_gpu_memory_info (dlls/win32u/opengl.c), which Mesa
+implements per driver rather than universally. radeonsi on Mesa 26.1.6
+exposes it - an RX 7900 XT on EGL was measured reporting 20 GB - so the
+guard is no obstacle there. A driver that does not expose it reports
+zero.
 
-So every Intel and AMD machine on the EGL backend takes the fallback,
-which names a card from roughly 2010 - and for Intel that is device
-0x0162, "Intel(R) HD Graphics 4000". Ableton Live 12 refuses that PCI
-ID, so a correctly working modern GPU loses Live's GPU renderer purely
-because the video-memory attribute was unavailable.
+Such a machine takes the fallback, which names a card from roughly
+2010 - and for Intel that is device 0x0162, "Intel(R) HD Graphics
+4000". Ableton Live 12 refuses that PCI ID, so a correctly working
+modern GPU would lose Live's GPU renderer purely because the
+video-memory attribute was unavailable. Which drivers land there is not
+established, and no WINEDEBUG=+d3d trace from an affected machine has
+been captured; this removes the dependency rather than relying on the
+answer.
 
 Report the real device instead, and carry a neutral video-memory figure
 of the same order as the table's integrated-graphics entries when the

--- a/patches/0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
+++ b/patches/0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
@@ -1,0 +1,76 @@
+Subject: wined3d: synthesise a GPU description without a
+ video-memory report
+
+The synthesised description declines when the driver reports no video
+memory, on the reasoning that reporting zero bytes is worse than the
+feature-level fallback's table approximation. That trade only holds
+where a memory figure is available at all, and on the default EGL
+backend it never is for Mesa: win32u fills the figure solely from
+GL_NVX_gpu_memory_info (dlls/win32u/opengl.c), which NVIDIA's driver
+provides and Mesa does not.
+
+So every Intel and AMD machine on the EGL backend takes the fallback,
+which names a card from roughly 2010 - and for Intel that is device
+0x0162, "Intel(R) HD Graphics 4000". Ableton Live 12 refuses that PCI
+ID, so a correctly working modern GPU loses Live's GPU renderer purely
+because the video-memory attribute was unavailable.
+
+Report the real device instead, and carry a neutral video-memory figure
+of the same order as the table's integrated-graphics entries when the
+driver supplies none. wined3d_driver_info_init() already prefers a
+queried figure over the description's, so a machine that does report
+video memory is unaffected.
+---
+ dlls/wined3d/adapter_gl.c | 15 +++++++--------
+ dlls/wined3d/wined3d_gl.h |  4 ++++
+ 2 files changed, 11 insertions(+), 8 deletions(-)
+
+diff --git a/dlls/wined3d/adapter_gl.c b/dlls/wined3d/adapter_gl.c
+index 3cbffc7..40b9753 100644
+--- a/dlls/wined3d/adapter_gl.c
++++ b/dlls/wined3d/adapter_gl.c
+@@ -1040,7 +1040,12 @@ static const struct wined3d_gpu_description *synthesise_gpu_description(struct w
+     ctx->synthetic_gpu_description.device = device;
+     ctx->synthetic_gpu_description.description = ctx->synthetic_description;
+     ctx->synthetic_gpu_description.driver = guess_display_driver(vendor);
+-    ctx->synthetic_gpu_description.vidmem = ctx->vram_bytes / (1024 * 1024);
++    /* wined3d_driver_info_init() falls back to this when the driver reports
++     * no video memory, so a zero here would be reported as a card with no
++     * memory at all. Carry a neutral figure of the same order as the table's
++     * integrated-graphics entries instead. */
++    ctx->synthetic_gpu_description.vidmem = ctx->vram_bytes
++            ? ctx->vram_bytes / (1024 * 1024) : WINED3D_SYNTHETIC_VIDMEM_MB;
+ 
+     TRACE("Device %04x:%04x is not in the description table; reporting it as %s.\n",
+             vendor, device, debugstr_a(ctx->synthetic_description));
+@@ -1071,14 +1076,8 @@ static const struct wined3d_gpu_description *query_gpu_description(const struct
+         /* A real PCI ID is 16 bits. Mesa reports 0xffffffff for a renderer
+          * that is not a PCI device at all - llvmpipe, for instance - and
+          * those have no business being described as a graphics card, so
+-         * leave them to the existing feature-level fallback.
+-         *
+-         * The attributes are queried independently, so also require the video
+-         * memory: a description built without it would report zero bytes of
+-         * video memory, where the feature-level fallback at least carries the
+-         * table's approximation. */
++         * leave them to the existing feature-level fallback. */
+         if (!(gpu_description = wined3d_get_gpu_description(vendor, device)) && gl_renderer
+-                && ctx->vram_bytes
+                 && (unsigned int)vendor < PCI_VENDOR_NONE && (unsigned int)device < PCI_DEVICE_NONE)
+             gpu_description = synthesise_gpu_description(ctx, vendor, device, gl_renderer);
+     }
+diff --git a/dlls/wined3d/wined3d_gl.h b/dlls/wined3d/wined3d_gl.h
+index 6f83605..8510773 100644
+--- a/dlls/wined3d/wined3d_gl.h
++++ b/dlls/wined3d/wined3d_gl.h
+@@ -796,6 +796,10 @@ void wined3d_ffp_blitter_create(struct wined3d_blitter **next, const struct wine
+ struct wined3d_blitter *wined3d_glsl_blitter_create(struct wined3d_blitter **next, const struct wined3d_device *device);
+ void wined3d_raw_blitter_create(struct wined3d_blitter **next, const struct wined3d_gl_info *gl_info);
+ 
++/* Reported when a synthesised description has no video-memory figure from
++ * the driver. */
++#define WINED3D_SYNTHETIC_VIDMEM_MB 2048
++
+ struct wined3d_caps_gl_ctx
+ {
+     HDC dc;

--- a/patches/0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
+++ b/patches/0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
@@ -1,0 +1,131 @@
+Subject: wined3d: add WINE_D3D_FORCE_GPU_RENDERING, disclosed in
+ the device name
+
+Ableton Live 12 decides whether to offer its GPU renderer from the PCI
+device ID alone: for vendor 0x8086 it refuses any ID on an internal list
+of 101 Intel devices sold between 2004 and 2014, and the reported name
+plays no part in the decision. That list was drawn up against Intel's
+Windows drivers for those parts. Mesa's drivers for the same silicon are
+a different and far better maintained implementation, and the fallback a
+refused user gets is Live's GDI renderer, which costs about 59% of a CPU
+core in normal use. Whether the trade is worth taking is the user's call
+to make, not ours to make for them.
+
+Setting WINE_D3D_FORCE_GPU_RENDERING=1 substitutes a baseline device ID
+that is on no such list. The vendor, driver and video-memory figure are
+untouched, and the description keeps the card's real name followed by
+the name of the device being reported:
+
+  Intel(R) HD Graphics 4000 (reporting as Intel(R) UHD Graphics 630)
+
+so the substitution is visible everywhere the description surfaces -
+Live's log, its Preferences dialog, any screenshot of either, and any
+report sent onward. The card's own identity is never replaced, only
+accompanied, and the composed string stays inside DXGI_ADAPTER_DESC1's
+128-character field.
+
+The substitution applies to Intel only, since no other vendor is gated
+this way, and it leaves a card that already reports the baseline alone.
+Off by default: applications other than Live read the device ID too, so
+this belongs to a user who has decided they want it.
+---
+ dlls/wined3d/adapter_gl.c | 62 +++++++++++++++++++++++++++++++++++++++
+ dlls/wined3d/wined3d_gl.h |  5 ++++
+ 2 files changed, 67 insertions(+)
+
+diff --git a/dlls/wined3d/adapter_gl.c b/dlls/wined3d/adapter_gl.c
+index 40b9753..65b301d 100644
+--- a/dlls/wined3d/adapter_gl.c
++++ b/dlls/wined3d/adapter_gl.c
+@@ -1053,6 +1053,65 @@ static const struct wined3d_gpu_description *synthesise_gpu_description(struct w
+     return &ctx->synthetic_gpu_description;
+ }
+ 
++/* Report a different PCI device ID than the card's own, keeping the card's
++ * real name and disclosing the substitution in it.
++ *
++ * Ableton Live 12 decides whether to offer its GPU renderer from the PCI
++ * device ID alone: for vendor 0x8086 it refuses any ID on an internal list of
++ * 101 Intel devices sold between 2004 and 2014, and the reported name plays no
++ * part in the decision. The list was drawn up against Intel's Windows drivers
++ * for those parts. Mesa's drivers for the same silicon are a different and
++ * far better maintained implementation, so a user may reasonably want to try
++ * the renderer anyway; the alternative is Live's GDI renderer, which costs
++ * about 59% of a CPU core in normal use.
++ *
++ * Setting WINE_D3D_FORCE_GPU_RENDERING=1 substitutes a baseline device ID that
++ * appears on no such list. The vendor, the driver and the video-memory figure
++ * stay as they are, and the description keeps the card's real name followed by
++ * the name of the device being reported, so the substitution is visible
++ * wherever the description surfaces - Live's own log, its Preferences dialog
++ * and any screenshot of either. Nothing is hidden from the user or from
++ * Ableton.
++ *
++ * Applications other than Live gate on the device ID too, so this is a blunt
++ * instrument: it is off by default and belongs to a user who has decided the
++ * trade is worth it. */
++static const struct wined3d_gpu_description *substitute_gpu_device_id(struct wined3d_caps_gl_ctx *ctx,
++        const struct wined3d_gpu_description *gpu_description)
++{
++    const struct wined3d_gpu_description *baseline;
++    const char *env;
++
++    if (!(env = getenv("WINE_D3D_FORCE_GPU_RENDERING")) || strcmp(env, "1"))
++        return gpu_description;
++
++    /* Only Intel is gated by device ID in the case this exists for, and a
++     * substitution costs accuracy, so leave every other vendor alone. */
++    if (gpu_description->vendor != HW_VENDOR_INTEL)
++    {
++        TRACE("Not substituting a device ID for vendor %04x.\n", gpu_description->vendor);
++        return gpu_description;
++    }
++
++    if (!(baseline = wined3d_get_gpu_description(HW_VENDOR_INTEL, CARD_INTEL_UHD630_1))
++            || gpu_description->device == CARD_INTEL_UHD630_1)
++        return gpu_description;
++
++    snprintf(ctx->forced_description, sizeof(ctx->forced_description), "%s (reporting as %s)",
++            gpu_description->description, baseline->description);
++
++    ctx->forced_gpu_description = *gpu_description;
++    ctx->forced_gpu_description.device = baseline->device;
++    ctx->forced_gpu_description.description = ctx->forced_description;
++
++    WARN("WINE_D3D_FORCE_GPU_RENDERING is set; reporting device %04x:%04x as %04x:%04x, %s.\n",
++            gpu_description->vendor, gpu_description->device,
++            ctx->forced_gpu_description.vendor, ctx->forced_gpu_description.device,
++            debugstr_a(ctx->forced_description));
++
++    return &ctx->forced_gpu_description;
++}
++
+ static const struct wined3d_gpu_description *query_gpu_description(const struct wined3d_gl_info *gl_info,
+         struct wined3d_caps_gl_ctx *ctx, const char *gl_renderer)
+ {
+@@ -1085,6 +1144,9 @@ static const struct wined3d_gpu_description *query_gpu_description(const struct
+     if ((gpu_description_override = wined3d_get_user_override_gpu_description(vendor, device)))
+         gpu_description = gpu_description_override;
+ 
++    if (gpu_description)
++        gpu_description = substitute_gpu_device_id(ctx, gpu_description);
++
+     return gpu_description;
+ }
+ 
+diff --git a/dlls/wined3d/wined3d_gl.h b/dlls/wined3d/wined3d_gl.h
+index 8510773..f5fc241 100644
+--- a/dlls/wined3d/wined3d_gl.h
++++ b/dlls/wined3d/wined3d_gl.h
+@@ -819,6 +819,11 @@ struct wined3d_caps_gl_ctx
+      * outlives wined3d_adapter_init_gl_caps(), so it cannot be a local. */
+     struct wined3d_gpu_description synthetic_gpu_description;
+     char synthetic_description[128];
++    /* Backing store for a description whose device ID was substituted under
++     * WINE_D3D_FORCE_GPU_RENDERING. Holds two card names and the connecting
++     * text, and DXGI_ADAPTER_DESC1 truncates at 128 characters anyway. */
++    struct wined3d_gpu_description forced_gpu_description;
++    char forced_description[192];
+     UINT64 vram_bytes;
+ };
+ 

--- a/patches/0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
+++ b/patches/0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
@@ -29,15 +29,15 @@ this way, and it leaves a card that already reports the baseline alone.
 Off by default: applications other than Live read the device ID too, so
 this belongs to a user who has decided they want it.
 ---
- dlls/wined3d/adapter_gl.c | 64 +++++++++++++++++++++++++++++++++++++++
+ dlls/wined3d/adapter_gl.c | 73 +++++++++++++++++++++++++++++++++++++++
  dlls/wined3d/wined3d_gl.h |  5 +++
- 2 files changed, 69 insertions(+)
+ 2 files changed, 78 insertions(+)
 
 diff --git a/dlls/wined3d/adapter_gl.c b/dlls/wined3d/adapter_gl.c
-index 40b9753..a09264b 100644
+index 40b9753..9ce2732 100644
 --- a/dlls/wined3d/adapter_gl.c
 +++ b/dlls/wined3d/adapter_gl.c
-@@ -1053,6 +1053,65 @@ static const struct wined3d_gpu_description *synthesise_gpu_description(struct w
+@@ -1053,6 +1053,74 @@ static const struct wined3d_gpu_description *synthesise_gpu_description(struct w
      return &ctx->synthetic_gpu_description;
  }
  
@@ -69,6 +69,8 @@ index 40b9753..a09264b 100644
 +{
 +    const struct wined3d_gpu_description *baseline;
 +    const char *env;
++    size_t tail;
++    int room;
 +
 +    if (!(env = getenv("WINE_D3D_FORCE_GPU_RENDERING")) || strcmp(env, "1"))
 +        return gpu_description;
@@ -85,8 +87,15 @@ index 40b9753..a09264b 100644
 +            || gpu_description->device == CARD_INTEL_UHD630_1)
 +        return gpu_description;
 +
-+    snprintf(ctx->forced_description, sizeof(ctx->forced_description), "%s (reporting as %s)",
-+            gpu_description->description, baseline->description);
++    /* DXGI_ADAPTER_DESC1 truncates the description at 128 characters and the
++     * disclosure is its tail, so bound the card's own name to leave room:
++     * whatever else is lost, the substitution must still be readable. */
++    tail = strlen(" (reporting as )") + strlen(baseline->description);
++    room = sizeof(ctx->forced_description) > tail + 1
++            ? (int)(sizeof(ctx->forced_description) - 1 - tail) : 0;
++
++    snprintf(ctx->forced_description, sizeof(ctx->forced_description), "%.*s (reporting as %s)",
++            room, gpu_description->description, baseline->description);
 +
 +    ctx->forced_gpu_description = *gpu_description;
 +    ctx->forced_gpu_description.device = baseline->device;
@@ -103,7 +112,7 @@ index 40b9753..a09264b 100644
  static const struct wined3d_gpu_description *query_gpu_description(const struct wined3d_gl_info *gl_info,
          struct wined3d_caps_gl_ctx *ctx, const char *gl_renderer)
  {
-@@ -3882,6 +3941,11 @@ static BOOL wined3d_adapter_init_gl_caps(struct wined3d_adapter_gl *adapter_gl,
+@@ -3882,6 +3950,11 @@ static BOOL wined3d_adapter_init_gl_caps(struct wined3d_adapter_gl *adapter_gl,
              return FALSE;
          }
      }
@@ -116,7 +125,7 @@ index 40b9753..a09264b 100644
  
      adapter->vram_bytes_used = 0;
 diff --git a/dlls/wined3d/wined3d_gl.h b/dlls/wined3d/wined3d_gl.h
-index 8510773..f5fc241 100644
+index 8510773..7d3aa62 100644
 --- a/dlls/wined3d/wined3d_gl.h
 +++ b/dlls/wined3d/wined3d_gl.h
 @@ -819,6 +819,11 @@ struct wined3d_caps_gl_ctx
@@ -124,10 +133,10 @@ index 8510773..f5fc241 100644
      struct wined3d_gpu_description synthetic_gpu_description;
      char synthetic_description[128];
 +    /* Backing store for a description whose device ID was substituted under
-+     * WINE_D3D_FORCE_GPU_RENDERING. Holds two card names and the connecting
-+     * text, and DXGI_ADAPTER_DESC1 truncates at 128 characters anyway. */
++     * WINE_D3D_FORCE_GPU_RENDERING. Sized to DXGI_ADAPTER_DESC1's field so
++     * that what fits here is what the application reads. */
 +    struct wined3d_gpu_description forced_gpu_description;
-+    char forced_description[192];
++    char forced_description[128];
      UINT64 vram_bytes;
  };
  

--- a/patches/0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
+++ b/patches/0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
@@ -29,12 +29,12 @@ this way, and it leaves a card that already reports the baseline alone.
 Off by default: applications other than Live read the device ID too, so
 this belongs to a user who has decided they want it.
 ---
- dlls/wined3d/adapter_gl.c | 62 +++++++++++++++++++++++++++++++++++++++
- dlls/wined3d/wined3d_gl.h |  5 ++++
- 2 files changed, 67 insertions(+)
+ dlls/wined3d/adapter_gl.c | 64 +++++++++++++++++++++++++++++++++++++++
+ dlls/wined3d/wined3d_gl.h |  5 +++
+ 2 files changed, 69 insertions(+)
 
 diff --git a/dlls/wined3d/adapter_gl.c b/dlls/wined3d/adapter_gl.c
-index 40b9753..65b301d 100644
+index 40b9753..a09264b 100644
 --- a/dlls/wined3d/adapter_gl.c
 +++ b/dlls/wined3d/adapter_gl.c
 @@ -1053,6 +1053,65 @@ static const struct wined3d_gpu_description *synthesise_gpu_description(struct w
@@ -103,16 +103,18 @@ index 40b9753..65b301d 100644
  static const struct wined3d_gpu_description *query_gpu_description(const struct wined3d_gl_info *gl_info,
          struct wined3d_caps_gl_ctx *ctx, const char *gl_renderer)
  {
-@@ -1085,6 +1144,9 @@ static const struct wined3d_gpu_description *query_gpu_description(const struct
-     if ((gpu_description_override = wined3d_get_user_override_gpu_description(vendor, device)))
-         gpu_description = gpu_description_override;
- 
-+    if (gpu_description)
-+        gpu_description = substitute_gpu_device_id(ctx, gpu_description);
+@@ -3882,6 +3941,11 @@ static BOOL wined3d_adapter_init_gl_caps(struct wined3d_adapter_gl *adapter_gl,
+             return FALSE;
+         }
+     }
++    /* Both branches above settle a description, and the feature-level fallback
++     * settles the fabricated CARD_INTEL_IVBD that the substitution exists to
++     * replace, so substitute here rather than inside query_gpu_description. */
++    caps_gl_ctx->gpu_description = substitute_gpu_device_id(caps_gl_ctx, caps_gl_ctx->gpu_description);
 +
-     return gpu_description;
- }
+     fixup_extensions(gl_info, caps_gl_ctx, gl_renderer_str, gl_vendor);
  
+     adapter->vram_bytes_used = 0;
 diff --git a/dlls/wined3d/wined3d_gl.h b/dlls/wined3d/wined3d_gl.h
 index 8510773..f5fc241 100644
 --- a/dlls/wined3d/wined3d_gl.h

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -11,8 +11,10 @@ narrative — 5 merge conflicts, three build breaks the clean rebase didn't
 catch, a build.sh/pipefail tooling gotcha — is in
 `notes/ABLETON-WINE-11.11-TO-11.13-BASE-BUMP.md`.
 
-The current Wine series contains 62 files, numbered 0001 through 0064.
-Patches 0027 and 0044 are intentionally absent.
+The current Wine series contains 63 files, numbered 0001 through 0066.
+Patches 0027 and 0044 are intentionally absent; 0065 is reserved by the
+open Push 3 (PR 117) and fullscreen (PR 114) work, which both claim the
+number.
 
 ## Applying the series
 
@@ -184,15 +186,18 @@ Apply them in sequence with the rest of the series.
   composite over live siblings (issue 57).
 - `0057`: identify Intel GPUs from Ice Lake through Lunar Lake, plus the
   Arc A-series cards. Without an entry wined3d reports each of them as
-  "Intel(R) HD Graphics 4000", which Live 12 rejects for D3D11, exactly
-  as 0035 describes for Battlemage. Device IDs come from the pci.ids
-  database; devices still missing fall through to 0061's synthesised
-  description instead. A table entry takes precedence over 0061, and for
-  Meteor Lake it has to: 0061 synthesises the device's real Windows
-  name, "Intel(R) Arc(tm) Graphics", and a 0061-only build stayed
-  greyed out on the issue 84 machine (PR 105 comments, 2026-07-31). The
-  "(MTL)" suffix in the table name is what passes Live's check. See
-  issue 84 and `notes/ABLETON-WINE-GPU-RENDERER.md`.
+  fabricated device `0x0162`, "Intel(R) HD Graphics 4000", a PCI ID
+  Live 12 rejects for D3D11, exactly as 0035 describes for Battlemage.
+  Device IDs come from the pci.ids database; devices still missing fall
+  through to 0061's synthesised
+  description instead. A table entry takes precedence over 0061, and on
+  the default EGL x11 backend it has to: a 0061-only build stayed
+  greyed out on the issue 84 machine (PR 105 comments, 2026-07-31)
+  because that backend reports zero video memory on Mesa and 0061's
+  synthesis declines to run. The "(MTL)" suffix was first blamed, but
+  Live's check reads only PCI device IDs, never names (established by
+  disassembly 2026-08-02; see 0066). See issue 84 and
+  `notes/ABLETON-WINE-GPU-RENDERER.md`.
 - `0058`: fall back to the GDI present path for any frame whose
   present-time client rect disagrees with the captured destination
   rect. The direct GL path (0055) y-flips against a client rect
@@ -215,10 +220,13 @@ Apply them in sequence with the rest of the series.
 - `0061`: describe a GPU that is not in wined3d's device table using the name
   the driver reports for itself, rather than guessing a card from the feature
   level. Without it an RX 7900 XT is reported as "ATI Radeon HD 5600 Series"
-  and every Intel GPU newer than the table as "Intel(R) HD Graphics 4000" —
-  the string Live rejects, which is what 0035 worked around one device at a
-  time. The Vulkan back end already behaves this way. See issue 84 and
-  `notes/ABLETON-WINE-GPU-RENDERER.md`.
+  and every Intel GPU newer than the table as "Intel(R) HD Graphics 4000",
+  fabricated device `0x0162`, a PCI ID on Live's GPU denylist, which is
+  what 0035 worked around one device at a time. The Vulkan back end
+  already behaves this way. Caveat found 2026-08-02: the synthesis
+  requires a non-zero video-memory report and the default EGL x11
+  backend has none on Mesa, so it does not fire there (see 0066). See
+  issue 84 and `notes/ABLETON-WINE-GPU-RENDERER.md`.
 - `0062`: let the launcher keep one exact top-level Windows class on
   winex11's offscreen-composited path. The Live launcher selects
   `Ableton Live Window Class`, preventing M4L child visibility from
@@ -238,3 +246,15 @@ Apply them in sequence with the rest of the series.
   only intercepted in its `/select` form, so the library panel still
   spawned Wine Explorer. Fallbacks: the 0063 reveal ladder, then Wine
   Explorer. See `notes/ABLETON-WINE-SHOW-IN-EXPLORER.md`.
+- `0066`: add the 24 Intel graphics devices missing between Skylake and
+  Amber Lake: the Kaby Lake GT1, GT3 and workstation parts, the Coffee
+  Lake desktop line (including UHD 630 `0x3e92`, the i5-8400 through
+  i7-8700), the 9th-gen refresh, the CFL-U Iris Plus parts, Whiskey
+  Lake GT1, and the second Amber Lake ID. Live's GPU gate denylists 101
+  pre-2014 PCI device IDs and reads no names (established by
+  disassembly 2026-08-02), and a table miss fabricates denylisted
+  device `0x0162`, so each missing entry disabled the GPU renderer.
+  0061 does not rescue the default EGL backend, where Mesa reports zero
+  video memory and the synthesis declines; a table entry bypasses that
+  guard. Field report: HP EliteDesk 800 G4 (i5-8500, `0x3e92`) on
+  2026.08.01.1. See `notes/ABLETON-WINE-GPU-RENDERER.md`.

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -11,7 +11,7 @@ narrative — 5 merge conflicts, three build breaks the clean rebase didn't
 catch, a build.sh/pipefail tooling gotcha — is in
 `notes/ABLETON-WINE-11.11-TO-11.13-BASE-BUMP.md`.
 
-The current Wine series contains 63 files, numbered 0001 through 0066.
+The current Wine series contains 65 files, numbered 0001 through 0068.
 Patches 0027 and 0044 are intentionally absent; 0065 is reserved by the
 open Push 3 (PR 117) and fullscreen (PR 114) work, which both claim the
 number.
@@ -258,3 +258,24 @@ Apply them in sequence with the rest of the series.
   video memory and the synthesis declines; a table entry bypasses that
   guard. Field report: HP EliteDesk 800 G4 (i5-8500, `0x3e92`) on
   2026.08.01.1. See `notes/ABLETON-WINE-GPU-RENDERER.md`.
+- `0067`: build the synthesised description (0061) even when the driver
+  reports no video memory. The guard assumed a missing figure is worse
+  than the feature-level fallback's approximation, but on the default
+  EGL backend Mesa never supplies one: win32u fills it solely from
+  `GL_NVX_gpu_memory_info`, an NVIDIA-only extension. Every Intel and
+  AMD machine on EGL therefore took the fallback, and for Intel that
+  means fabricated device `0x0162`, which Live refuses. A neutral
+  video-memory figure stands in when the driver supplies none; a
+  machine that does report one is unaffected. See
+  `notes/ABLETON-WINE-GPU-RENDERER.md`.
+- `0068`: add `WINE_D3D_FORCE_GPU_RENDERING=1`, which reports a
+  baseline Intel device ID in place of the card's own so Live's GPU
+  gate passes on hardware its denylist covers. The card's real name is
+  kept and the substitution is named in the description, for example
+  `Intel(R) HD Graphics 4000 (reporting as Intel(R) UHD Graphics 630)`,
+  so it is visible in Live's log, its Preferences dialog and any
+  screenshot. Vendor, driver and video memory are untouched; Intel
+  only; off by default. Ableton's list was drawn against Intel's
+  Windows drivers, and Mesa's drivers for the same silicon are a
+  different implementation, so whether to take the trade is the user's
+  call. See `notes/ABLETON-WINE-GPU-RENDERER.md`.

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -193,7 +193,7 @@ Apply them in sequence with the rest of the series.
   takes precedence over 0061, and on the issue 84 machine it had to: a
   0061-only build stayed greyed out there (PR 105 comments,
   2026-07-31), consistent with that machine's driver reporting no video
-  memory, which makes 0061's synthesis decline. The "(MTL)" suffix was
+  memory, which skips 0061's synthesis. The "(MTL)" suffix was
   first blamed, but Live's check reads only PCI device IDs, never names
   (established by disassembly 2026-08-02; see 0066). See issue 84 and
   `notes/ABLETON-WINE-GPU-RENDERER.md`.
@@ -226,7 +226,7 @@ Apply them in sequence with the rest of the series.
   requires a non-zero video-memory report, and on the default EGL x11
   backend that figure comes only from `GL_NVX_gpu_memory_info`, which
   Mesa implements per driver — so on a driver without it the synthesis
-  does not fire (see 0066, 0067). See issue 84 and
+  does not run (see 0066, 0067). See issue 84 and
   `notes/ABLETON-WINE-GPU-RENDERER.md`.
 - `0062`: let the launcher keep one exact top-level Windows class on
   winex11's offscreen-composited path. The Live launcher selects
@@ -255,21 +255,23 @@ Apply them in sequence with the rest of the series.
   pre-2014 PCI device IDs and reads no names (established by
   disassembly 2026-08-02), and a table miss fabricates denylisted
   device `0x0162`, so each missing entry disabled the GPU renderer.
-  0061 does not rescue a driver that reports no video memory, since the
-  synthesis declines there; a table entry bypasses that guard, being
-  consulted first. Field report: HP EliteDesk 800 G4 (i5-8500,
-  `0x3e92`) on 2026.08.01.1. See `notes/ABLETON-WINE-GPU-RENDERER.md`.
+  0061 does not help a driver that reports no video memory, since the
+  synthesis is skipped there; the table is consulted before that guard,
+  so a card with a table entry is unaffected by it. Field report: HP
+  EliteDesk 800 G4 (i5-8500, `0x3e92`) on 2026.08.01.1. See
+  `notes/ABLETON-WINE-GPU-RENDERER.md`.
 - `0067`: build the synthesised description (0061) even when the driver
   reports no video memory. The guard assumed a missing figure is worse
   than the feature-level fallback's approximation, but on the default
   EGL backend win32u fills it solely from `GL_NVX_gpu_memory_info`,
   which Mesa implements per driver. radeonsi on Mesa 26.1.6 does expose
-  it (an RX 7900 XT on EGL measured 20 GB), so the guard is no obstacle
-  there; a driver without it reports zero, takes the fallback, and for
-  Intel that means fabricated device `0x0162`, which Live refuses.
-  Which drivers land there is not established. A neutral video-memory
-  figure stands in when the driver supplies none; a machine that does
-  report one is unaffected. See `notes/ABLETON-WINE-GPU-RENDERER.md`.
+  it (an RX 7900 XT on EGL measured 20 GB), so the guard passes there;
+  a driver without it reports zero, takes the fallback, and for Intel
+  that means fabricated device `0x0162`, which Live refuses. Which
+  drivers lack the extension is not established. 0067 reports a neutral
+  video-memory figure when the driver supplies none; a machine that
+  does report one is unaffected. See
+  `notes/ABLETON-WINE-GPU-RENDERER.md`.
 - `0068`: add `WINE_D3D_FORCE_GPU_RENDERING=1`, which reports a
   baseline Intel device ID in place of the card's own so Live's GPU
   gate passes on hardware its denylist covers. The card's real name is

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -189,14 +189,13 @@ Apply them in sequence with the rest of the series.
   fabricated device `0x0162`, "Intel(R) HD Graphics 4000", a PCI ID
   Live 12 rejects for D3D11, exactly as 0035 describes for Battlemage.
   Device IDs come from the pci.ids database; devices still missing fall
-  through to 0061's synthesised
-  description instead. A table entry takes precedence over 0061, and on
-  the default EGL x11 backend it has to: a 0061-only build stayed
-  greyed out on the issue 84 machine (PR 105 comments, 2026-07-31)
-  because that backend reports zero video memory on Mesa and 0061's
-  synthesis declines to run. The "(MTL)" suffix was first blamed, but
-  Live's check reads only PCI device IDs, never names (established by
-  disassembly 2026-08-02; see 0066). See issue 84 and
+  through to 0061's synthesised description instead. A table entry
+  takes precedence over 0061, and on the issue 84 machine it had to: a
+  0061-only build stayed greyed out there (PR 105 comments,
+  2026-07-31), consistent with that machine's driver reporting no video
+  memory, which makes 0061's synthesis decline. The "(MTL)" suffix was
+  first blamed, but Live's check reads only PCI device IDs, never names
+  (established by disassembly 2026-08-02; see 0066). See issue 84 and
   `notes/ABLETON-WINE-GPU-RENDERER.md`.
 - `0058`: fall back to the GDI present path for any frame whose
   present-time client rect disagrees with the captured destination
@@ -224,9 +223,11 @@ Apply them in sequence with the rest of the series.
   fabricated device `0x0162`, a PCI ID on Live's GPU denylist, which is
   what 0035 worked around one device at a time. The Vulkan back end
   already behaves this way. Caveat found 2026-08-02: the synthesis
-  requires a non-zero video-memory report and the default EGL x11
-  backend has none on Mesa, so it does not fire there (see 0066). See
-  issue 84 and `notes/ABLETON-WINE-GPU-RENDERER.md`.
+  requires a non-zero video-memory report, and on the default EGL x11
+  backend that figure comes only from `GL_NVX_gpu_memory_info`, which
+  Mesa implements per driver — so on a driver without it the synthesis
+  does not fire (see 0066, 0067). See issue 84 and
+  `notes/ABLETON-WINE-GPU-RENDERER.md`.
 - `0062`: let the launcher keep one exact top-level Windows class on
   winex11's offscreen-composited path. The Live launcher selects
   `Ableton Live Window Class`, preventing M4L child visibility from
@@ -254,20 +255,21 @@ Apply them in sequence with the rest of the series.
   pre-2014 PCI device IDs and reads no names (established by
   disassembly 2026-08-02), and a table miss fabricates denylisted
   device `0x0162`, so each missing entry disabled the GPU renderer.
-  0061 does not rescue the default EGL backend, where Mesa reports zero
-  video memory and the synthesis declines; a table entry bypasses that
-  guard. Field report: HP EliteDesk 800 G4 (i5-8500, `0x3e92`) on
-  2026.08.01.1. See `notes/ABLETON-WINE-GPU-RENDERER.md`.
+  0061 does not rescue a driver that reports no video memory, since the
+  synthesis declines there; a table entry bypasses that guard, being
+  consulted first. Field report: HP EliteDesk 800 G4 (i5-8500,
+  `0x3e92`) on 2026.08.01.1. See `notes/ABLETON-WINE-GPU-RENDERER.md`.
 - `0067`: build the synthesised description (0061) even when the driver
   reports no video memory. The guard assumed a missing figure is worse
   than the feature-level fallback's approximation, but on the default
-  EGL backend Mesa never supplies one: win32u fills it solely from
-  `GL_NVX_gpu_memory_info`, an NVIDIA-only extension. Every Intel and
-  AMD machine on EGL therefore took the fallback, and for Intel that
-  means fabricated device `0x0162`, which Live refuses. A neutral
-  video-memory figure stands in when the driver supplies none; a
-  machine that does report one is unaffected. See
-  `notes/ABLETON-WINE-GPU-RENDERER.md`.
+  EGL backend win32u fills it solely from `GL_NVX_gpu_memory_info`,
+  which Mesa implements per driver. radeonsi on Mesa 26.1.6 does expose
+  it (an RX 7900 XT on EGL measured 20 GB), so the guard is no obstacle
+  there; a driver without it reports zero, takes the fallback, and for
+  Intel that means fabricated device `0x0162`, which Live refuses.
+  Which drivers land there is not established. A neutral video-memory
+  figure stands in when the driver supplies none; a machine that does
+  report one is unaffected. See `notes/ABLETON-WINE-GPU-RENDERER.md`.
 - `0068`: add `WINE_D3D_FORCE_GPU_RENDERING=1`, which reports a
   baseline Intel device ID in place of the card's own so Live's GPU
   gate passes on hardware its denylist covers. The card's real name is

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -62,6 +62,6 @@ a07f7ecb2c3a568d8eeae9a42df558cea4d8e279e5bdeb0af67a6649086973f7  0062-winex11-k
 81e02eeac88e6eda5da8044cd5bf74a197b2742f77c46da54e61dbf300031bd3  0064-shell32-route-explorer-folder-open-commands-to-the-h.patch
 6815d113dd11260058c74a5cba213625e732337d563aa0c6481476ced9eedb9c  0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
 8055ef9cb8ee075bde27da01da5e7f4c9ce63c84d1e44916885b6d0c40ec05f2  0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
-19837a23cd2757458a1ed1f6535d5007c4a9ed58ddceed4d259f795b6dc17b11  0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
+867a9fd70a61eff0eeeb51765eebb9b1bc39b63468360d8801fbc960ca97e343  0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -61,5 +61,7 @@ a07f7ecb2c3a568d8eeae9a42df558cea4d8e279e5bdeb0af67a6649086973f7  0062-winex11-k
 0a7fb762e4bef288556f2118c318f6e99fe5532bb61058ccdb6d7732bf42ba27  0063-comdlg32-reveal-explorer-select-folder-targets-throu.patch
 81e02eeac88e6eda5da8044cd5bf74a197b2742f77c46da54e61dbf300031bd3  0064-shell32-route-explorer-folder-open-commands-to-the-h.patch
 6815d113dd11260058c74a5cba213625e732337d563aa0c6481476ced9eedb9c  0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
+8055ef9cb8ee075bde27da01da5e7f4c9ce63c84d1e44916885b6d0c40ec05f2  0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
+19837a23cd2757458a1ed1f6535d5007c4a9ed58ddceed4d259f795b6dc17b11  0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -62,6 +62,6 @@ a07f7ecb2c3a568d8eeae9a42df558cea4d8e279e5bdeb0af67a6649086973f7  0062-winex11-k
 81e02eeac88e6eda5da8044cd5bf74a197b2742f77c46da54e61dbf300031bd3  0064-shell32-route-explorer-folder-open-commands-to-the-h.patch
 6815d113dd11260058c74a5cba213625e732337d563aa0c6481476ced9eedb9c  0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
 8055ef9cb8ee075bde27da01da5e7f4c9ce63c84d1e44916885b6d0c40ec05f2  0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
-867a9fd70a61eff0eeeb51765eebb9b1bc39b63468360d8801fbc960ca97e343  0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
+7374abf4910b3da7b6b8592efcd167bb2f8b8c6abdb9c84761147b54f3e4d5dd  0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -60,8 +60,8 @@ eb85bc3dc958314b299ebe45dc690ed3e9958d7beea82647513964ca0531a1b6  0059-wined3d-q
 a07f7ecb2c3a568d8eeae9a42df558cea4d8e279e5bdeb0af67a6649086973f7  0062-winex11-keep-a-selected-top-level-class-offscreen.patch
 0a7fb762e4bef288556f2118c318f6e99fe5532bb61058ccdb6d7732bf42ba27  0063-comdlg32-reveal-explorer-select-folder-targets-throu.patch
 81e02eeac88e6eda5da8044cd5bf74a197b2742f77c46da54e61dbf300031bd3  0064-shell32-route-explorer-folder-open-commands-to-the-h.patch
-d7301fb19b7b6a509ea4648234053127ba40ea2c2b0425887c9e215cc6832fdc  0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
-d93dd82d0e6bf6e3c370dd7f4b8e46473fe55beb50be36b852c83243beecb873  0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
+fd604cd284936df87e0b4ed93936104e99bfdc64dc9cf5f61c0324e6ceff7e31  0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
+b65877e816921195b1b0f45b901dc512b0c1111b9ea3e034e73aaa57362596b2  0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
 7374abf4910b3da7b6b8592efcd167bb2f8b8c6abdb9c84761147b54f3e4d5dd  0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -60,8 +60,8 @@ eb85bc3dc958314b299ebe45dc690ed3e9958d7beea82647513964ca0531a1b6  0059-wined3d-q
 a07f7ecb2c3a568d8eeae9a42df558cea4d8e279e5bdeb0af67a6649086973f7  0062-winex11-keep-a-selected-top-level-class-offscreen.patch
 0a7fb762e4bef288556f2118c318f6e99fe5532bb61058ccdb6d7732bf42ba27  0063-comdlg32-reveal-explorer-select-folder-targets-throu.patch
 81e02eeac88e6eda5da8044cd5bf74a197b2742f77c46da54e61dbf300031bd3  0064-shell32-route-explorer-folder-open-commands-to-the-h.patch
-6815d113dd11260058c74a5cba213625e732337d563aa0c6481476ced9eedb9c  0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
-8055ef9cb8ee075bde27da01da5e7f4c9ce63c84d1e44916885b6d0c40ec05f2  0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
+d7301fb19b7b6a509ea4648234053127ba40ea2c2b0425887c9e215cc6832fdc  0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
+d93dd82d0e6bf6e3c370dd7f4b8e46473fe55beb50be36b852c83243beecb873  0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
 7374abf4910b3da7b6b8592efcd167bb2f8b8c6abdb9c84761147b54f3e4d5dd  0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -60,5 +60,6 @@ eb85bc3dc958314b299ebe45dc690ed3e9958d7beea82647513964ca0531a1b6  0059-wined3d-q
 a07f7ecb2c3a568d8eeae9a42df558cea4d8e279e5bdeb0af67a6649086973f7  0062-winex11-keep-a-selected-top-level-class-offscreen.patch
 0a7fb762e4bef288556f2118c318f6e99fe5532bb61058ccdb6d7732bf42ba27  0063-comdlg32-reveal-explorer-select-folder-targets-throu.patch
 81e02eeac88e6eda5da8044cd5bf74a197b2742f77c46da54e61dbf300031bd3  0064-shell32-route-explorer-folder-open-commands-to-the-h.patch
+6815d113dd11260058c74a5cba213625e732337d563aa0c6481476ced9eedb9c  0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/scripts/ableton-live
+++ b/scripts/ableton-live
@@ -6,7 +6,10 @@
 #            ABLETON_LIVE_VERSION=11|12 (restrict discovery to one major version),
 #            ABLETON_RT=off (skip the realtime probe; run Live under normal scheduling),
 #            ABLETON_LINKD=/path/to/ableton-linkd (Ableton Link session anchor override),
-#            WINE_X11_FORCE_OFFSCREEN_CLASS=off (disable the M4L selection-flicker fix).
+#            WINE_X11_FORCE_OFFSCREEN_CLASS=off (disable the M4L selection-flicker fix),
+#            WINE_D3D_FORCE_GPU_RENDERING=1 (report a baseline Intel GPU so Live offers its
+#              GPU renderer on hardware its own list refuses; the real card name is kept and
+#              the substitution is shown in the device name Live displays).
 set -u
 # Clear inherited Wine variables so this launch uses only the patched build.
 unset WINELOADER WINEDLLPATH WINEDLLOVERRIDES WINEARCH

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -141,6 +141,7 @@ FINGERPRINTS='
 0064|ascii|lib/wine/x86_64-unix/comdlg32.so|ShowFolders
 0064|ascii|lib/wine/x86_64-windows/shell32.dll|__wine_portal_open_folder
 0066|ascii|lib/wine/x86_64-windows/wined3d.dll|Intel(R) UHD Graphics P630
+0068|ascii|lib/wine/x86_64-windows/wined3d.dll|WINE_D3D_FORCE_GPU_RENDERING
 pipeasio/0001|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-clamp-sample-rate
 pipeasio/0002|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-midi-timebase
 '
@@ -184,6 +185,7 @@ STAMP_ONLY='
 0052|logic-only (DT_HIDEPREFIX on the menu bar DrawTextW call; no new string literal)
 0053|logic-only (WM_GETMINMAXINFO minimum exported as PMinSize hints; no new string literal)
 0054|logic-only (per-string SystemLink font fallback in draw_menu_item, plus the calc_menu_item_size CJK-measurement fix; no new string literal)
+0067|logic-only (drops the video-memory precondition on 0061's synthesised description; reuses 0061's own string literal)
 '
 wide_pattern() {  # ascii string -> PCRE matching its UTF-16LE bytes
     printf '%s' "$1" | od -An -v -tx1 | tr -d '\n' | tr -s ' ' ' ' \

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -185,7 +185,7 @@ STAMP_ONLY='
 0052|logic-only (DT_HIDEPREFIX on the menu bar DrawTextW call; no new string literal)
 0053|logic-only (WM_GETMINMAXINFO minimum exported as PMinSize hints; no new string literal)
 0054|logic-only (per-string SystemLink font fallback in draw_menu_item, plus the calc_menu_item_size CJK-measurement fix; no new string literal)
-0067|logic-only (drops the video-memory precondition on 0061's synthesised description; reuses 0061's own string literal)
+0067|logic-only (drops the video-memory precondition on the 0061 synthesised description; reuses the 0061 string literal)
 '
 wide_pattern() {  # ascii string -> PCRE matching its UTF-16LE bytes
     printf '%s' "$1" | od -An -v -tx1 | tr -d '\n' | tr -s ' ' ' ' \

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -72,6 +72,7 @@ declare -A SERIES_GAPS=(
     [0027]="retired 2026-07-14 — gitignore housekeeping, no artifact effect"
     [0044]="reserved 2026-07-24 for the issue 57 parked-pane reblit gate; shipped as 0056 instead"
     [0057]="reserved 2026-07-30 for the Intel GPU identification fix on fix/intel-gpu"
+    [0065]="reserved 2026-08-02 for the open Push 3 (PR 117) and fullscreen (PR 114) work; both claim the number and one must renumber at merge"
 )
 seq_expect=1
 for f in $(awk '{print $2}' "$SERIES" | grep -v '^pipeasio/' | sort); do
@@ -139,6 +140,7 @@ FINGERPRINTS='
 0063|ascii|lib/wine/x86_64-unix/comdlg32.so|org.freedesktop.FileManager1
 0064|ascii|lib/wine/x86_64-unix/comdlg32.so|ShowFolders
 0064|ascii|lib/wine/x86_64-windows/shell32.dll|__wine_portal_open_folder
+0066|ascii|lib/wine/x86_64-windows/wined3d.dll|Intel(R) UHD Graphics P630
 pipeasio/0001|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-clamp-sample-rate
 pipeasio/0002|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-midi-timebase
 '


### PR DESCRIPTION
Patch 0061 was meant to cover table misses by describing a card from its driver's own name, but it stands down when the driver reports no video memory. 

But, of course, this didn't fix all possible circumstances, did it?

Turns out I was wrong because I thought that Live's denylist is based on the device name. It seems like it isn't, and that instead it's based off the graphics device's PCI ID

Wine's device table skips 24 Intel devices between Skylake and Amber Lake, because why wouldn't Wine do this? Amazing stuff. 

Among those skipped are entries like `UHD Graphics 630 0x3e92`, and other non-niche devices. When the device is not in the table, wined3d guesses a card identifier from its reported feature level, and for Intel that guess seems to be device `0x0162`, "`Intel(R) HD Graphics 4000`". Which we have already determined is a beautiful central star of Live's GPU denylist.