### PR TITLE
PR124: Review/pr124 followups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
   the real device.
 - Graphics cards missing from Wine's table keep their real identity even when
   the driver reports no video memory (Wine patch 0067). Wine reads that figure
-  from a source only NVIDIA's driver provides, so on Intel and AMD it was
-  always absent and the card fell back to the invented 2012 identity.
+  from an optional graphics-driver feature, and a driver that does not offer it
+  used to cost the card its identity, falling back to the invented 2012 one.
 - Added `WINE_D3D_FORCE_GPU_RENDERING=1`, which offers Live's GPU renderer on
   the older Intel graphics Live refuses by model (Wine patch 0068). Run
   `WINE_D3D_FORCE_GPU_RENDERING=1 ableton-live` to try it. Diagnostics sent to

--- a/notes/ABLETON-WINE-GPU-RENDERER.md
+++ b/notes/ABLETON-WINE-GPU-RENDERER.md
@@ -239,15 +239,19 @@ name, but stands down when the driver reports no video memory. Wine
 reaches the driver through EGL or GLX and picks EGL by default
 (`use_egl = TRUE`, `dlls/winex11.drv/x11drv_main.c`). On EGL it reads
 video memory only from `GL_NVX_gpu_memory_info`
-(`dlls/win32u/opengl.c`), which NVIDIA's driver provides and Mesa does
-not. Intel and AMD machines on EGL report zero, 0061 stands down, and
-the invented `0x0162` goes through. A table entry is immune, being
-consulted first.
+(`dlls/win32u/opengl.c`). A driver that does not expose that extension
+reports zero, 0061 stands down, and the invented `0x0162` goes through.
+A table entry is immune, being consulted first.
 
-The maintainer's machine reports its real card, which implies it uses
-GLX. What decides the interface per machine is not established, and that
-is why the fault looks intermittent across similar hardware. No
-`WINEDEBUG=+d3d` trace from an affected machine has been captured.
+Mesa implements the extension per driver, not universally. Measured
+2026-08-03 on an RX 7900 XT, Mesa 26.1.6, fresh prefix with no `UseEGL`
+override and `trace:wgl:egl_init` in the log: radeonsi on EGL reported
+20 GB, so 0061 fires there and the card keeps its real identity. That
+also rules out the earlier reading of the maintainer's machine as
+implying GLX — a machine can report its real card on EGL. Whether iris
+exposes the extension is untested; no `WINEDEBUG=+d3d` trace from an
+affected machine has been captured, so what the reporting EliteDesk
+actually did is still open.
 
 Patch 0066 closes the first gap. The second needs its own change, so
 that an unidentified card never inherits a refused identity, with a
@@ -261,11 +265,12 @@ invented HD 4000.
 
 Patch 0067 removes the video-memory precondition on 0061's synthesised
 description. The precondition assumed a missing figure was worse than
-the fallback's approximation; on the EGL backend Mesa never supplies
-one, so the assumption cost every unlisted Intel and AMD card its real
-identity. A neutral figure stands in when the driver reports none.
-Together with 0066 this ends the whack-a-mole for cards Wine can
-identify at all.
+the fallback's approximation; where the driver supplies none, that
+assumption costs an unlisted card its real identity for an attribute
+that has nothing to do with identifying it. A neutral figure stands in
+when the driver reports none, so the outcome no longer depends on which
+drivers implement `GL_NVX_gpu_memory_info`. Together with 0066 this ends
+the whack-a-mole for cards Wine can identify at all.
 
 Patch 0068 covers the cards Live genuinely lists.
 `WINE_D3D_FORCE_GPU_RENDERING=1` reports baseline device

--- a/patches/0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
+++ b/patches/0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
@@ -24,10 +24,18 @@ matter how modern the real device is.
 The synthesised-description path (patch 0061) was meant to cover table
 misses, but it declines to run when the driver reports no video
 memory, and on the EGL x11 backend - the default - win32u fills video
-memory only from GL_NVX_gpu_memory_info, which Mesa does not expose.
-An Intel or AMD machine on the EGL backend reports zero and falls
+memory only from GL_NVX_gpu_memory_info (dlls/win32u/opengl.c). A
+driver that does not expose that extension reports zero and falls
 through to the fabricated 0x0162 anyway. A table entry is immune to
-that guard. Loosening the guard is a separate change.
+that guard, being consulted first. Loosening the guard is a separate
+change.
+
+How far that reaches is not established. Mesa implements the extension
+per driver: radeonsi on Mesa 26.1.6 does expose it, and an RX 7900 XT
+on the EGL backend was measured reporting 20 GB, so 0061 fires there.
+Whether iris exposes it on the reporting machine is unknown - no
+WINEDEBUG=+d3d trace from that machine has been captured. The table
+entry this patch adds does not depend on the answer.
 
 Verified by compiling the patched table: all 24 IDs resolve to their
 pci.ids names, the table holds no duplicate vendor+device pair, and no

--- a/patches/0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
+++ b/patches/0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
@@ -5,15 +5,21 @@ The synthesised description declines when the driver reports no video
 memory, on the reasoning that reporting zero bytes is worse than the
 feature-level fallback's table approximation. That trade only holds
 where a memory figure is available at all, and on the default EGL
-backend it never is for Mesa: win32u fills the figure solely from
-GL_NVX_gpu_memory_info (dlls/win32u/opengl.c), which NVIDIA's driver
-provides and Mesa does not.
+backend that depends entirely on the driver: win32u fills the figure
+solely from GL_NVX_gpu_memory_info (dlls/win32u/opengl.c), which Mesa
+implements per driver rather than universally. radeonsi on Mesa 26.1.6
+exposes it - an RX 7900 XT on EGL was measured reporting 20 GB - so the
+guard is no obstacle there. A driver that does not expose it reports
+zero.
 
-So every Intel and AMD machine on the EGL backend takes the fallback,
-which names a card from roughly 2010 - and for Intel that is device
-0x0162, "Intel(R) HD Graphics 4000". Ableton Live 12 refuses that PCI
-ID, so a correctly working modern GPU loses Live's GPU renderer purely
-because the video-memory attribute was unavailable.
+Such a machine takes the fallback, which names a card from roughly
+2010 - and for Intel that is device 0x0162, "Intel(R) HD Graphics
+4000". Ableton Live 12 refuses that PCI ID, so a correctly working
+modern GPU would lose Live's GPU renderer purely because the
+video-memory attribute was unavailable. Which drivers land there is not
+established, and no WINEDEBUG=+d3d trace from an affected machine has
+been captured; this removes the dependency rather than relying on the
+answer.
 
 Report the real device instead, and carry a neutral video-memory figure
 of the same order as the table's integrated-graphics entries when the

--- a/patches/0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
+++ b/patches/0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
@@ -29,15 +29,15 @@ this way, and it leaves a card that already reports the baseline alone.
 Off by default: applications other than Live read the device ID too, so
 this belongs to a user who has decided they want it.
 ---
- dlls/wined3d/adapter_gl.c | 64 +++++++++++++++++++++++++++++++++++++++
+ dlls/wined3d/adapter_gl.c | 73 +++++++++++++++++++++++++++++++++++++++
  dlls/wined3d/wined3d_gl.h |  5 +++
- 2 files changed, 69 insertions(+)
+ 2 files changed, 78 insertions(+)
 
 diff --git a/dlls/wined3d/adapter_gl.c b/dlls/wined3d/adapter_gl.c
-index 40b9753..a09264b 100644
+index 40b9753..9ce2732 100644
 --- a/dlls/wined3d/adapter_gl.c
 +++ b/dlls/wined3d/adapter_gl.c
-@@ -1053,6 +1053,65 @@ static const struct wined3d_gpu_description *synthesise_gpu_description(struct w
+@@ -1053,6 +1053,74 @@ static const struct wined3d_gpu_description *synthesise_gpu_description(struct w
      return &ctx->synthetic_gpu_description;
  }
  
@@ -69,6 +69,8 @@ index 40b9753..a09264b 100644
 +{
 +    const struct wined3d_gpu_description *baseline;
 +    const char *env;
++    size_t tail;
++    int room;
 +
 +    if (!(env = getenv("WINE_D3D_FORCE_GPU_RENDERING")) || strcmp(env, "1"))
 +        return gpu_description;
@@ -85,8 +87,15 @@ index 40b9753..a09264b 100644
 +            || gpu_description->device == CARD_INTEL_UHD630_1)
 +        return gpu_description;
 +
-+    snprintf(ctx->forced_description, sizeof(ctx->forced_description), "%s (reporting as %s)",
-+            gpu_description->description, baseline->description);
++    /* DXGI_ADAPTER_DESC1 truncates the description at 128 characters and the
++     * disclosure is its tail, so bound the card's own name to leave room:
++     * whatever else is lost, the substitution must still be readable. */
++    tail = strlen(" (reporting as )") + strlen(baseline->description);
++    room = sizeof(ctx->forced_description) > tail + 1
++            ? (int)(sizeof(ctx->forced_description) - 1 - tail) : 0;
++
++    snprintf(ctx->forced_description, sizeof(ctx->forced_description), "%.*s (reporting as %s)",
++            room, gpu_description->description, baseline->description);
 +
 +    ctx->forced_gpu_description = *gpu_description;
 +    ctx->forced_gpu_description.device = baseline->device;
@@ -103,7 +112,7 @@ index 40b9753..a09264b 100644
  static const struct wined3d_gpu_description *query_gpu_description(const struct wined3d_gl_info *gl_info,
          struct wined3d_caps_gl_ctx *ctx, const char *gl_renderer)
  {
-@@ -3882,6 +3941,11 @@ static BOOL wined3d_adapter_init_gl_caps(struct wined3d_adapter_gl *adapter_gl,
+@@ -3882,6 +3950,11 @@ static BOOL wined3d_adapter_init_gl_caps(struct wined3d_adapter_gl *adapter_gl,
              return FALSE;
          }
      }
@@ -116,7 +125,7 @@ index 40b9753..a09264b 100644
  
      adapter->vram_bytes_used = 0;
 diff --git a/dlls/wined3d/wined3d_gl.h b/dlls/wined3d/wined3d_gl.h
-index 8510773..f5fc241 100644
+index 8510773..7d3aa62 100644
 --- a/dlls/wined3d/wined3d_gl.h
 +++ b/dlls/wined3d/wined3d_gl.h
 @@ -819,6 +819,11 @@ struct wined3d_caps_gl_ctx
@@ -124,10 +133,10 @@ index 8510773..f5fc241 100644
      struct wined3d_gpu_description synthetic_gpu_description;
      char synthetic_description[128];
 +    /* Backing store for a description whose device ID was substituted under
-+     * WINE_D3D_FORCE_GPU_RENDERING. Holds two card names and the connecting
-+     * text, and DXGI_ADAPTER_DESC1 truncates at 128 characters anyway. */
++     * WINE_D3D_FORCE_GPU_RENDERING. Sized to DXGI_ADAPTER_DESC1's field so
++     * that what fits here is what the application reads. */
 +    struct wined3d_gpu_description forced_gpu_description;
-+    char forced_description[192];
++    char forced_description[128];
      UINT64 vram_bytes;
  };
  

--- a/patches/0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
+++ b/patches/0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
@@ -29,12 +29,12 @@ this way, and it leaves a card that already reports the baseline alone.
 Off by default: applications other than Live read the device ID too, so
 this belongs to a user who has decided they want it.
 ---
- dlls/wined3d/adapter_gl.c | 62 +++++++++++++++++++++++++++++++++++++++
- dlls/wined3d/wined3d_gl.h |  5 ++++
- 2 files changed, 67 insertions(+)
+ dlls/wined3d/adapter_gl.c | 64 +++++++++++++++++++++++++++++++++++++++
+ dlls/wined3d/wined3d_gl.h |  5 +++
+ 2 files changed, 69 insertions(+)
 
 diff --git a/dlls/wined3d/adapter_gl.c b/dlls/wined3d/adapter_gl.c
-index 40b9753..65b301d 100644
+index 40b9753..a09264b 100644
 --- a/dlls/wined3d/adapter_gl.c
 +++ b/dlls/wined3d/adapter_gl.c
 @@ -1053,6 +1053,65 @@ static const struct wined3d_gpu_description *synthesise_gpu_description(struct w
@@ -103,16 +103,18 @@ index 40b9753..65b301d 100644
  static const struct wined3d_gpu_description *query_gpu_description(const struct wined3d_gl_info *gl_info,
          struct wined3d_caps_gl_ctx *ctx, const char *gl_renderer)
  {
-@@ -1085,6 +1144,9 @@ static const struct wined3d_gpu_description *query_gpu_description(const struct
-     if ((gpu_description_override = wined3d_get_user_override_gpu_description(vendor, device)))
-         gpu_description = gpu_description_override;
- 
-+    if (gpu_description)
-+        gpu_description = substitute_gpu_device_id(ctx, gpu_description);
+@@ -3882,6 +3941,11 @@ static BOOL wined3d_adapter_init_gl_caps(struct wined3d_adapter_gl *adapter_gl,
+             return FALSE;
+         }
+     }
++    /* Both branches above settle a description, and the feature-level fallback
++     * settles the fabricated CARD_INTEL_IVBD that the substitution exists to
++     * replace, so substitute here rather than inside query_gpu_description. */
++    caps_gl_ctx->gpu_description = substitute_gpu_device_id(caps_gl_ctx, caps_gl_ctx->gpu_description);
 +
-     return gpu_description;
- }
+     fixup_extensions(gl_info, caps_gl_ctx, gl_renderer_str, gl_vendor);
  
+     adapter->vram_bytes_used = 0;
 diff --git a/dlls/wined3d/wined3d_gl.h b/dlls/wined3d/wined3d_gl.h
 index 8510773..f5fc241 100644
 --- a/dlls/wined3d/wined3d_gl.h

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -189,14 +189,13 @@ Apply them in sequence with the rest of the series.
   fabricated device `0x0162`, "Intel(R) HD Graphics 4000", a PCI ID
   Live 12 rejects for D3D11, exactly as 0035 describes for Battlemage.
   Device IDs come from the pci.ids database; devices still missing fall
-  through to 0061's synthesised
-  description instead. A table entry takes precedence over 0061, and on
-  the default EGL x11 backend it has to: a 0061-only build stayed
-  greyed out on the issue 84 machine (PR 105 comments, 2026-07-31)
-  because that backend reports zero video memory on Mesa and 0061's
-  synthesis declines to run. The "(MTL)" suffix was first blamed, but
-  Live's check reads only PCI device IDs, never names (established by
-  disassembly 2026-08-02; see 0066). See issue 84 and
+  through to 0061's synthesised description instead. A table entry
+  takes precedence over 0061, and on the issue 84 machine it had to: a
+  0061-only build stayed greyed out there (PR 105 comments,
+  2026-07-31), consistent with that machine's driver reporting no video
+  memory, which makes 0061's synthesis decline. The "(MTL)" suffix was
+  first blamed, but Live's check reads only PCI device IDs, never names
+  (established by disassembly 2026-08-02; see 0066). See issue 84 and
   `notes/ABLETON-WINE-GPU-RENDERER.md`.
 - `0058`: fall back to the GDI present path for any frame whose
   present-time client rect disagrees with the captured destination
@@ -224,9 +223,11 @@ Apply them in sequence with the rest of the series.
   fabricated device `0x0162`, a PCI ID on Live's GPU denylist, which is
   what 0035 worked around one device at a time. The Vulkan back end
   already behaves this way. Caveat found 2026-08-02: the synthesis
-  requires a non-zero video-memory report and the default EGL x11
-  backend has none on Mesa, so it does not fire there (see 0066). See
-  issue 84 and `notes/ABLETON-WINE-GPU-RENDERER.md`.
+  requires a non-zero video-memory report, and on the default EGL x11
+  backend that figure comes only from `GL_NVX_gpu_memory_info`, which
+  Mesa implements per driver — so on a driver without it the synthesis
+  does not fire (see 0066, 0067). See issue 84 and
+  `notes/ABLETON-WINE-GPU-RENDERER.md`.
 - `0062`: let the launcher keep one exact top-level Windows class on
   winex11's offscreen-composited path. The Live launcher selects
   `Ableton Live Window Class`, preventing M4L child visibility from
@@ -254,20 +255,21 @@ Apply them in sequence with the rest of the series.
   pre-2014 PCI device IDs and reads no names (established by
   disassembly 2026-08-02), and a table miss fabricates denylisted
   device `0x0162`, so each missing entry disabled the GPU renderer.
-  0061 does not rescue the default EGL backend, where Mesa reports zero
-  video memory and the synthesis declines; a table entry bypasses that
-  guard. Field report: HP EliteDesk 800 G4 (i5-8500, `0x3e92`) on
-  2026.08.01.1. See `notes/ABLETON-WINE-GPU-RENDERER.md`.
+  0061 does not rescue a driver that reports no video memory, since the
+  synthesis declines there; a table entry bypasses that guard, being
+  consulted first. Field report: HP EliteDesk 800 G4 (i5-8500,
+  `0x3e92`) on 2026.08.01.1. See `notes/ABLETON-WINE-GPU-RENDERER.md`.
 - `0067`: build the synthesised description (0061) even when the driver
   reports no video memory. The guard assumed a missing figure is worse
   than the feature-level fallback's approximation, but on the default
-  EGL backend Mesa never supplies one: win32u fills it solely from
-  `GL_NVX_gpu_memory_info`, an NVIDIA-only extension. Every Intel and
-  AMD machine on EGL therefore took the fallback, and for Intel that
-  means fabricated device `0x0162`, which Live refuses. A neutral
-  video-memory figure stands in when the driver supplies none; a
-  machine that does report one is unaffected. See
-  `notes/ABLETON-WINE-GPU-RENDERER.md`.
+  EGL backend win32u fills it solely from `GL_NVX_gpu_memory_info`,
+  which Mesa implements per driver. radeonsi on Mesa 26.1.6 does expose
+  it (an RX 7900 XT on EGL measured 20 GB), so the guard is no obstacle
+  there; a driver without it reports zero, takes the fallback, and for
+  Intel that means fabricated device `0x0162`, which Live refuses.
+  Which drivers land there is not established. A neutral video-memory
+  figure stands in when the driver supplies none; a machine that does
+  report one is unaffected. See `notes/ABLETON-WINE-GPU-RENDERER.md`.
 - `0068`: add `WINE_D3D_FORCE_GPU_RENDERING=1`, which reports a
   baseline Intel device ID in place of the card's own so Live's GPU
   gate passes on hardware its denylist covers. The card's real name is

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -62,6 +62,6 @@ a07f7ecb2c3a568d8eeae9a42df558cea4d8e279e5bdeb0af67a6649086973f7  0062-winex11-k
 81e02eeac88e6eda5da8044cd5bf74a197b2742f77c46da54e61dbf300031bd3  0064-shell32-route-explorer-folder-open-commands-to-the-h.patch
 6815d113dd11260058c74a5cba213625e732337d563aa0c6481476ced9eedb9c  0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
 8055ef9cb8ee075bde27da01da5e7f4c9ce63c84d1e44916885b6d0c40ec05f2  0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
-19837a23cd2757458a1ed1f6535d5007c4a9ed58ddceed4d259f795b6dc17b11  0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
+867a9fd70a61eff0eeeb51765eebb9b1bc39b63468360d8801fbc960ca97e343  0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -62,6 +62,6 @@ a07f7ecb2c3a568d8eeae9a42df558cea4d8e279e5bdeb0af67a6649086973f7  0062-winex11-k
 81e02eeac88e6eda5da8044cd5bf74a197b2742f77c46da54e61dbf300031bd3  0064-shell32-route-explorer-folder-open-commands-to-the-h.patch
 6815d113dd11260058c74a5cba213625e732337d563aa0c6481476ced9eedb9c  0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
 8055ef9cb8ee075bde27da01da5e7f4c9ce63c84d1e44916885b6d0c40ec05f2  0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
-867a9fd70a61eff0eeeb51765eebb9b1bc39b63468360d8801fbc960ca97e343  0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
+7374abf4910b3da7b6b8592efcd167bb2f8b8c6abdb9c84761147b54f3e4d5dd  0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -60,8 +60,8 @@ eb85bc3dc958314b299ebe45dc690ed3e9958d7beea82647513964ca0531a1b6  0059-wined3d-q
 a07f7ecb2c3a568d8eeae9a42df558cea4d8e279e5bdeb0af67a6649086973f7  0062-winex11-keep-a-selected-top-level-class-offscreen.patch
 0a7fb762e4bef288556f2118c318f6e99fe5532bb61058ccdb6d7732bf42ba27  0063-comdlg32-reveal-explorer-select-folder-targets-throu.patch
 81e02eeac88e6eda5da8044cd5bf74a197b2742f77c46da54e61dbf300031bd3  0064-shell32-route-explorer-folder-open-commands-to-the-h.patch
-6815d113dd11260058c74a5cba213625e732337d563aa0c6481476ced9eedb9c  0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
-8055ef9cb8ee075bde27da01da5e7f4c9ce63c84d1e44916885b6d0c40ec05f2  0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
+d7301fb19b7b6a509ea4648234053127ba40ea2c2b0425887c9e215cc6832fdc  0066-wined3d-add-the-missing-Intel-devices-from-Skylake-t.patch
+d93dd82d0e6bf6e3c370dd7f4b8e46473fe55beb50be36b852c83243beecb873  0067-wined3d-synthesise-a-GPU-description-without-a-video.patch
 7374abf4910b3da7b6b8592efcd167bb2f8b8c6abdb9c84761147b54f3e4d5dd  0068-wined3d-add-WINE_D3D_FORCE_GPU_RENDERING-disclosed-i.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch


### PR DESCRIPTION
Three follow-ups from reviewing #124, based on 466e5fa so they land in the branch. No rebase — #114's 0065 conflicts with `BASE.txt`, `SERIES.sha256` and `build-audit.sh`, easier for you to do it once. Each commit carries its own `SERIES.sha256` line and applies independently. Audit passes 91/91.

**`5aa607b`** — `substitute_gpu_device_id` ran at the tail of `query_gpu_description`, so it was skipped when that returned NULL. On that path `wined3d_adapter_init_gl_caps` settles the description from `wined3d_guess_card` — for Intel, the fabricated `0x0162` the substitution exists to replace. The flag was a silent no-op there. Moved to where the description is final. Forced the branch with `LIBGL_ALWAYS_SOFTWARE=1`: no trace at all before, `Not substituting a device ID for vendor 10de` after.

**`e393024`** — `forced_description` was 192 bytes but `DXGI_ADAPTER_DESC1` truncates at 128, so a card name over 86 chars would drop the disclosure while the substituted ID still went through. Buffer sized to DXGI's field, card name bounded. No change today (63 chars) — reasoned, not exercised, since I can't produce a long enough name here.

**`ec60941`** — "`GL_NVX_gpu_memory_info` … which Mesa does not" is wrong as a universal; Mesa implements it per driver. radeonsi on Mesa 26.1.6 reported 20 GB over EGL here, so 0061's guard is no obstacle there. Restated as conditional across both patch headers, `BASE.txt`, notes and changelog. AMD only — no Intel iGPU here, so iris is untested. Neither patch depends on the answer.

Testing:

Real Live 12.4.3 on this build, isolated prefix clone, Intel identity via `HKCU\Software\Wine\Direct3D`.

Flag off (`8086:0162`) — `Can't use GPU renderer: Intel(R) HD Graphics 4000: Unexplained slow UI at zoom-level 100% and/or crashes`, setting greyed out with that reason.

Flag on — `TD3dSurface: Adapter: 'Intel(R) HD Graphics 4000 (reporting as Intel(R) UHD Graphics 630)' (8086:3e9b rev0)`, setting available and on.

The name was byte-identical in both runs; only the device ID differed, and the outcome flipped. Your disassembly finding, confirmed black-box.