### PR TITLE
PR119: setup: suppress the winedbg crash dialog in the prefix

### DIFF
--- a/scripts/setup-prefix.sh
+++ b/scripts/setup-prefix.sh
@@ -613,7 +613,11 @@ wine reg add "$push2_key" /v libusb-1.0 /t REG_SZ /d builtin /f
 wine reg query "$push2_key" /v libusb-1.0
 
 # Ableton's tlsetupfx.exe (kernel USB driver installer) faults under Wine and pops a winedbg
-# dialog mid-install; this runtime has no IFEO Debugger hook to neuter it, so nothing is set here.
+# dialog mid-install - twice, on every Live 11 install. The fault is harmless: the installer
+# records it (0x80070643), carries on, and Live installs fine (issue 111), but two unexplained
+# "Program Error" boxes make a working install look broken. Suppress the dialog only: winedbg
+# still runs and still writes the backtrace to stderr.
+wine reg add 'HKCU\Software\Wine\WineDbg' /v ShowCrashDialog /t REG_DWORD /d 0 /f
 
 # winemenubuilder's entries assume `wine` on PATH (never true here) and are dead buttons: disable
 # it and delete entries it already wrote for this prefix (matched by WINEPREFIX=; install.sh's entries can't match).


### PR DESCRIPTION
Ableton's tlsetupfx.exe, the Push USB audio driver installer, faults under Wine on every Live 11 install and raises two "Program Error" boxes. The fault is harmless - the installer records 0x80070643, carries on, and Live installs fine (issue 111) - but two unexplained boxes make a working install look broken, and an unattended install stops on them entirely.

ShowCrashDialog=0 suppresses the dialog only: winedbg still runs and still writes the backtrace to stderr, and the installer still logs the driver failure. Verified against Live 11.3.25 - the fault still occurs, no dialog appears, Apply completes 0x0 and Live installs.

The ivar is prefix-wide, so this also silences the crash dialog for Live itself; a crash still reaches stderr but is no longer shown on screen. IMO - not a dealbreaker. In my experience, live _never_ properly crashes with our Wine instance. It just hangs. So this would likely never be exercised anyway. 