### PR TITLE
PR119: installer family

### DIFF
--- a/scripts/setup-prefix.sh
+++ b/scripts/setup-prefix.sh
@@ -648,12 +648,14 @@ cat <<EOF
 Remaining steps (you supply Ableton + your own license):
 
   1. Install Live (any edition) through THIS wine (plain wine reads
-     WINEPREFIX, not the ABLETON_* launcher variables). The flags let the
-     installer run by itself and skip Ableton's Windows USB audio driver,
-     which does nothing on Linux:
+     WINEPREFIX, not the ABLETON_* launcher variables). For Live 12 the flags
+     let the installer run by itself and skip Ableton's Windows USB audio
+     driver, which does nothing on Linux:
        WINEPREFIX=$WINEPREFIX \\
-       $WINE_ROOT/bin/wine "/path/to/Ableton Live NN Edition Installer.exe" \\
+       $WINE_ROOT/bin/wine "/path/to/Ableton Live 12 Edition Installer.exe" \\
        /SILENT /SUPPRESSMSGBOXES /NORESTART '/MERGETASKS=!audiodriver'
+     Live 11's installer is a different kind and ignores those flags; run it
+     without them and click through its window.
 
   2. Launch:            ableton-live
   3. Authorize Live with your own account (binds to this prefix's MachineGuid).

--- a/scripts/setup-run-header.sh
+++ b/scripts/setup-run-header.sh
@@ -336,18 +336,27 @@ if [ "$manual_install" -eq 0 ]; then
         fi
     fi
     if [ -n "$live_exe" ]; then
-        say "-- installing Ableton Live; a progress window opens, no clicks needed"
-        say "   (Live is large, so this can take several minutes)"
-        # run from the installer's own directory so its relative payload lookups resolve.
-        # Ableton's installer is Inno Setup: /SILENT keeps the progress bar but asks
-        # nothing, /SUPPRESSMSGBOXES /NORESTART cover the rest. The audiodriver task
-        # installs Ableton's Windows USB kernel driver, which cannot load under Wine
-        # (audio goes through PipeASIO), so deselect it with /MERGETASKS.
+        # Live 12 ships Inno Setup, Live 11 a WiX Burn bundle. Burn ignores /MERGETASKS and
+        # /SUPPRESSMSGBOXES, and reads /SILENT as /quiet - no window at all - so the Inno set
+        # on Live 11 installs the USB audio driver anyway and loses the wizard. /MERGETASKS
+        # drops that task: a Windows USB kernel driver Wine cannot load (audio is PipeASIO).
+        # Burn first - `.wixburn` is a PE section ~630 bytes in, so 4k settles it however big
+        # the installer is; the Inno marker is ~680 KB in. Process substitution, not a pipe:
+        # grep -q exits early, head takes SIGPIPE, and pipefail would report 141.
+        live_flags=()
+        if ! grep -qaF '.wixburn' <(head -c 4k -- "$live_exe") \
+             && grep -qa 'Inno Setup' <(head -c 4M -- "$live_exe"); then
+            live_flags=(/SILENT /SUPPRESSMSGBOXES /NORESTART '/MERGETASKS=!audiodriver')
+            say "-- installing Ableton Live; a progress window opens, no clicks needed"
+            say "   (Live is large, so this can take several minutes)"
+        else
+            say "-- starting the Ableton installer; from here just click through its window"
+        fi
+        # run from the installer's own directory so its relative payload lookups resolve
         if ( cd "$(dirname -- "$live_exe")" && \
                  WINEPREFIX="$HOME/.wine-ableton" \
                  "$HOME/.local/opt/$RUNTIME_NAME/bin/wine" \
-                 "./$(basename -- "$live_exe")" \
-                 /SILENT /SUPPRESSMSGBOXES /NORESTART '/MERGETASKS=!audiodriver' ); then
+                 "./$(basename -- "$live_exe")" "${live_flags[@]}" ); then
             live_installed=1
         else
             say "!! the Ableton installer exited with an error; instructions below"
@@ -372,7 +381,8 @@ else
     say "       cd ~/live-installer && WINEPREFIX=~/.wine-ableton \\"
     say "           ~/.local/opt/$RUNTIME_NAME/bin/wine ./*.exe \\"
     say "           /SILENT /SUPPRESSMSGBOXES /NORESTART '/MERGETASKS=!audiodriver'"
-    say "     (the flags let it install by itself and skip a Windows-only driver)"
+    say "     (Live 12: the flags let it install by itself and skip a Windows-only driver;"
+    say "      Live 11: drop them and click through its installer window instead)"
 fi
 say "Launch Live:   ~/.local/bin/ableton-live"
 say "Then, inside Live:"


### PR DESCRIPTION
Live 12 ships an Inno Setup installer; Live 11 ships a WiX Burn bundle.

Burn does take `/SILENT` (its own synonym for `/quiet`) and `/NORESTART`, but it has no `/SUPPRESSMSGBOXES` and no `/MERGETASKS`. So on Live 11 the current flags mean the USB audio driver installs and fails regardless — #111 is untouched there — and `/SILENT` selects Burn's quiet mode, which shows no window at all rather than the progress bar the message promises.

Identify the family and send the flags only where they mean something. Live 12 keeps your invocation exactly; Live 11 falls back to no flags, byte-identical to main, so the behaviour change stays scoped to Live 12.

Detection is ordered so the expensive case can't happen. `.wixburn` is a PE section ~630 bytes in, so 4k rules Burn out however large the installer is — and Burn is the case with no Inno marker to stop at. The Inno marker is ~680 KB in, so 4M covers it. Both reads use process substitution rather than a pipe: `grep -q` exits at the first match, `head` then takes SIGPIPE, and under `pipefail` the pipeline would report 141 and pick the wrong branch.

Verified end to end through a built kit with an isolated `HOME`:

| | result |
| --- | --- |
| Live 12.4.2 | progress window, no clicks, driver skipped — no `tlsetupfx.log`, no `AbletonPush` registry entries — exit 0 |
| Live 11.3.25 | wizard as before, `Applied non-vital package: Ableton_Push_Audio_Driver.msi, error: 0x80070643. Continuing...`, exit 0 |
| unrelated binary | falls through to no flags |
