### PR TITLE
PR119: setup: stop wineboot prompting for Wine Mono on a fresh prefix

### DIFF
--- a/scripts/setup-prefix.sh
+++ b/scripts/setup-prefix.sh
@@ -270,7 +270,12 @@ case "$dpi_mode" in
 esac
 
 echo "== [1/5] initialise prefix at $WINEPREFIX =="
-wineboot -u
+# While updating the prefix, wineboot offers Wine's Mono and Gecko installers. This runtime
+# vendors neither, so on a machine with no cached package it opens a modal "Wine Mono
+# Installer" prompt; nothing answers it in an unattended run and the wineserver -w below then
+# never returns. Live needs neither - ableton-live and max9 already disable both on every
+# launch - so disable them here and wineboot stops asking.
+WINEDLLOVERRIDES="mscoree,mshtml=" wineboot -u
 "$WINESERVER" -w
 
 if [ "$refresh" -eq 1 ]; then


### PR DESCRIPTION
While updating the prefix, wineboot offers Wine's Mono and Gecko installers. This runtime vendors neither, so on a machine with no cached package the modal "Wine Mono Installer" dialog opens and waits for a click. An unattended run has nothing to answer it, and the wineserver -w on the next line then never returns - the prefix setup hangs after "[1/5] initialise prefix" with no error and no output.

Live needs neither: ableton-live and max9 already disable mscoree and mshtml on every launch, so the prefix was never going to use what wineboot offers to install.

Reproduced by moving ~/.cache/wine aside to simulate a machine that has never installed wine-mono. Without the override wineboot blocks on "Wine Mono Installer" within 3s; with it, no prompt appears, no mono lands in the prefix, and setup-prefix.sh completes in 91s, exit 0.