### PR TITLE
Fix instances where Max4Live devices interfere with Live's UI

### DIFF
--- a/notes/ABLETON-WINE-M4L-INPUT-INJECTION.md
+++ b/notes/ABLETON-WINE-M4L-INPUT-INJECTION.md
@@ -1,0 +1,170 @@
+# M4L devices make Live's sliders erratic (issue 122)
+
+This note explains why loading a Max for Live device can corrupt mouse
+dragging in Live's own interface, what patch 0066 changes, and how to
+verify the fix. Written 2026-08-03 from the diagnosis in issue 122.
+
+## Status
+
+Patch 0066 (`winex11: release stale cursor clipping state when X focus
+leaves the process`) is committed on this branch. The series applies,
+the build passes the full audit, and `winex11.so` compiles without
+warnings. Runtime verification is still open: the bug does not
+reproduce on the development machine, so the patch is validated against
+the traced mechanism, not against the live symptom.
+
+## How to verify the fix
+
+Verification needs a machine that shows the bug (the Fedora report, or
+trendwhore's setup).
+
+1. Install a build that contains patch 0066.
+2. Start Live with `WINEDEBUG=-all,+event` and a fresh session.
+3. Load any Max for Live device onto a track. Do not click the device
+   panel at any point.
+4. Drag the track volume fader in session view.
+
+Expected results: the fader follows the pointer normally, and when the
+fix has actually fired the log contains the line
+
+    lost X focus to another client while clipping
+
+That string is also the patch's build-audit fingerprint. A report that
+shows normal dragging plus that line confirms both the bug and the fix
+on that machine.
+
+## Symptom
+
+After an M4L device is added to a track, dragging Live's sliders makes
+the value jump wildly while the mouse pointer itself moves smoothly.
+Frame analysis of trendwhore's recording shows the track volume moving
+from -23 dB to 0.0 dB to -inf dB to -50 dB to -33 dB within about
+270 ms of one smooth downward drag. Hovering over the device changes
+nothing. Giving the embedded device window focus once restores normal
+behaviour for the rest of the session. trendwhore proved the focus part
+in isolation: a programmatic focus transfer with no mouse or capture
+events heals the session permanently.
+
+The affected device UI is a JUCE window owned by a separate process
+and embedded into Live's window. In the traced session the bundled DS
+devices run in `Ableton AddOns.exe`; `.amxd` devices load the Max
+runtime. The mechanism below only needs "a second process embedded
+into Live's window tree", so it applies to both.
+
+## Background: the three pieces of Wine state involved
+
+Three Wine mechanisms interact here. Each is healthy on its own.
+
+- **Cursor clipping.** When a Windows program calls `ClipCursor`, Wine
+  confines the pointer to a rectangle. In winex11 the process that owns
+  the foreground window takes an X11 pointer grab (an exclusive claim
+  on all pointer input) on a hidden helper window, the clip window.
+  Live calls `ClipCursor` routinely during normal interaction: in a
+  short healthy session the clip-release helper
+  `ungrab_clipping_window` ran 49 times in the desktop process and 14
+  times in Live.
+- **Raw motion.** While a process clips the cursor, it stops using
+  ordinary X11 motion events for positions. It selects XInput2 raw
+  motion events (unscaled hardware deltas delivered for every physical
+  mouse movement, screen-wide) and turns those deltas into pointer
+  positions itself, in `map_raw_event_coords`. The per-thread flag
+  `data->clipping_cursor` switches this conversion on. The conversion
+  is only correct while the process actually holds the pointer grab.
+- **Shared input state.** Live and the device host are separate
+  processes, but embedding the device window calls `SetParent` across
+  processes, and the wineserver then attaches both threads to one
+  input state (`set_parent_window` in `server/window.c`). Focus,
+  active window, and capture become shared between Live and the host.
+
+## The fault
+
+The clip-release notification is targeted, not broadcast. When the
+clip rectangle changes, the wineserver sends `WM_WINE_CLIPCURSOR` to
+the current foreground thread and, on reset, to the desktop thread
+(`set_clip_rectangle` in `server/queue.c`). No other process is told.
+
+That targeting creates a trap during device embedding:
+
+1. Live loads the M4L device. The host process creates its window and
+   the cross-process reparent begins.
+2. The window manager briefly treats the host's not-yet-embedded
+   window as the active one. The wineserver's foreground input flips
+   to the host.
+3. A clip change arrives in that window. The wineserver addresses
+   `WM_WINE_CLIPCURSOR` at the host, and the host's thread takes the
+   pointer grab and sets `data->clipping_cursor`.
+4. Focus returns to Live. The release notification now goes to Live
+   and the desktop thread. The host is never told.
+5. The host's own X11 FocusOut events could still clean this up, but
+   winex11 dismisses FocusOut during reparenting and during WM_STATE
+   changes, which is exactly the state the embed dance is in. The
+   grab itself dies soon after (for example when the clip window is
+   unmapped), but the flags survive.
+
+The host process now believes it is clipping. It has no grab, yet
+`data->clipping_cursor` is set and raw motion stays selected from the
+transient focus. From this point on, every physical mouse movement
+anywhere on screen delivers a raw delta to the host, and the host
+converts it into an absolute pointer position accumulated from a
+zeroed origin and feeds it into the wineserver's cursor stream through
+`send_mouse_input`.
+
+Live and the host now write the cursor position in turns: Live reports
+correct positions from its own motion events, the host injects
+positions computed from garbage. Live's controls read the merged
+stream, so a fader drag jumps between the real position and nonsense.
+The on-screen pointer is driven by the hardware and the X server, not
+by this stream, so it keeps moving smoothly. That split, corrupt
+values under a smooth pointer, is the recorded symptom.
+
+Wine offered the stranded host three repair opportunities and each one
+declined it before the patch:
+
+| Repair opportunity | Why it did not fire |
+|---|---|
+| Later clip attempt in the host (`grab_clipping_window`) | The unfocused early-out reports success and touches nothing |
+| Clip-window FocusOut handler | Unmapped the clip window but kept the flags set |
+| Regular FocusOut on the host's windows | Dismissed by the reparenting and WM_STATE guards; the processed path only releases the grab for virtual desktops and keyboard grabs |
+
+## Why focusing the device heals a session
+
+A focus pass through the embedded JUCE child makes the host thread the
+target of the clip bookkeeping once. Processing that traffic releases
+the stale state. The leftover raw-motion selection is harmless on its
+own, because raw frames carry no pointer movement while the clipping
+flag is clear. This matches trendwhore's observation exactly: one
+focus transfer, no mouse events, permanent recovery.
+
+## Why many machines never see the bug
+
+Arming requires the window manager to hand the host's window focus
+during the embed. On the development machine (GNOME on Wayland) that
+never happens: a `WINEDEBUG=+event,+cursor` trace of a full load-and-
+drag session shows the device host processes receiving zero FocusIn,
+FocusOut, raw motion, or clipping events. Environments whose window
+managers focus new windows during the embed, and X11 sessions in
+general, are exposed. High CPU load widens the timing window, which
+matches the 25% DSP note in the original report.
+
+## What patch 0066 changes
+
+The patch enforces one invariant in winex11: local clipping state must
+not outlive the X focus that justified it. It releases the grab and
+clears the flags at each point where the process can observe the loss:
+
+- `grab_clipping_window`: the "focus is in another process" early-out
+  now releases local clipping state before reporting success.
+- The clip-window FocusOut handler calls `ungrab_clipping_window`
+  instead of only unmapping the window, so the flags follow the grab.
+- Every FocusOut whose display shows another client's window holding
+  the X input focus releases local clipping state, checked before the
+  reparenting and WM_STATE guards can dismiss the event. When this
+  actually releases a grab it logs the warning quoted above.
+
+The XInput2 selection reference counts stay untouched on purpose. Once
+the clipping flag is correct, a stale raw-motion selection only costs
+wakeups.
+
+The changed code is byte-identical between the vendor base and
+upstream wine-11.13, so the patch is an upstream candidate once an
+affected environment confirms it.

--- a/patches/0066-winex11-release-stale-cursor-clipping-state-when-X-f.patch
+++ b/patches/0066-winex11-release-stale-cursor-clipping-state-when-X-f.patch
@@ -1,0 +1,108 @@
+From ac71a777b0049e096953a2905c81c4c2a13d2091 Mon Sep 17 00:00:00 2001
+From: ableton-wine <local@ableton-wine>
+Date: Mon, 3 Aug 2026 15:50:00 +0200
+Subject: [PATCH] winex11: release stale cursor clipping state when X focus
+ leaves the process
+
+A Max for Live device UI is a JUCE child window owned by a separate
+process and reparented into Live's window tree; the cross-process
+SetParent attaches the host's thread input to Live's. If the embed
+dance transiently makes the host process the foreground, the host's
+thread retrieves WM_WINE_CLIPCURSOR and acquires the pointer grab for
+the current clip rectangle. The release never reaches it:
+set_clip_rectangle notifies only the new foreground thread and the
+desktop thread, the host's FocusOut events are dismissed by the
+reparenting and WM_STATE guards during exactly that dance, and
+grab_clipping_window's unfocused early-out reports success without
+touching existing state. The clip-window FocusOut handler also only
+unmapped the clip window, ending the grab but keeping the flags.
+
+A process stranded like this keeps data->clipping_cursor set with no
+grab behind it, and XI_RawMotion stays selected on the root window
+from the transient FocusIn. map_raw_event_coords then turns every raw
+motion delta into an absolute pointer position accumulated from a
+zeroed origin and send_mouse_input feeds those into the shared cursor
+stream. In Live the faders jump across their whole range while the
+hardware pointer moves smoothly (issue 122). This is consistent with
+the report that focusing the embedded device UI once restores a
+session: a focus round-trip through the child re-targets the clip
+traffic at the host thread once, whose processing releases the state.
+
+Release the local clipping state at each point where the process can
+observe that it lost the focus that justified the grab: the unfocused
+early-out in grab_clipping_window, the clip-window FocusOut handler,
+and any FocusOut whose display shows another client's window holding
+the X input focus, checked before the reparenting and WM_STATE guards
+can dismiss the event. The last case logs a warning when it actually
+releases a grab so affected sessions are identifiable in a +event
+log. The XInput2 raw-motion selection refcount is deliberately left
+alone: once the clipping flag is clear, unclipped raw frames carry no
+pointer movement and a stale selection only costs wakeups.
+---
+ dlls/winex11.drv/event.c | 22 +++++++++++++++++++---
+ dlls/winex11.drv/mouse.c | 11 +++++++++--
+ 2 files changed, 28 insertions(+), 5 deletions(-)
+
+diff --git a/dlls/winex11.drv/event.c b/dlls/winex11.drv/event.c
+index a524761..a79ecfc 100644
+--- a/dlls/winex11.drv/event.c
++++ b/dlls/winex11.drv/event.c
+@@ -809,14 +809,30 @@ static BOOL X11DRV_FocusOut( HWND hwnd, XEvent *xev )
+         if (!hwnd && event->window == x11drv_thread_data()->clip_window)
+         {
+             NtUserClipCursor( NULL );
+-            /* NtUserClipCursor will ask the foreground window to ungrab the cursor, but
+-             * it might not be responsive, so unmap the clipping window ourselves too */
+-            XUnmapWindow( event->display, event->window );
++            /* NtUserClipCursor asks the foreground thread to ungrab the cursor, but
++             * that thread may be unresponsive or live in another process with a
++             * clip window of its own, so release our own grab and clipping state
++             * here too (issue 122) */
++            ungrab_clipping_window();
+         }
+         return TRUE;
+     }
+     if (!hwnd) return FALSE;
+ 
++    /* Once another client's window provably holds the X input focus, this
++       process must not keep a pointer grab or local clipping state: the clip
++       release notification only reaches the new foreground thread, never this
++       one, and stale state here turns every raw motion delta into synthesized
++       pointer input over the focused process's cursor stream (issue 122).
++       This must run even when the FocusOut is otherwise ignored below. */
++    if (focus_held_by_other_client( event->display ))
++    {
++        if (x11drv_thread_data()->clipping_cursor)
++            WARN( "window %p/%lx lost X focus to another client while clipping, releasing the pointer grab\n",
++                  hwnd, event->window );
++        ungrab_clipping_window();
++    }
++
+     if (window_has_pending_wm_state( hwnd, NormalState )) /* ignore FocusOut only if the window is being shown */
+     {
+         WARN( "Ignoring window %p/%lx FocusOut serial %lu, detail %s, mode %s, foreground %p during WM_STATE change\n",
+diff --git a/dlls/winex11.drv/mouse.c b/dlls/winex11.drv/mouse.c
+index 2c394b6..300177e 100644
+--- a/dlls/winex11.drv/mouse.c
++++ b/dlls/winex11.drv/mouse.c
+@@ -401,8 +401,15 @@ static BOOL grab_clipping_window( const RECT *clip )
+ 
+     /* don't clip in the desktop process */
+     if (NtUserGetWindowThread( NtUserGetDesktopWindow(), NULL ) == GetCurrentThreadId()) return TRUE;
+-    /* don't clip the cursor if the X input focus is on another process window */
+-    if (!is_current_process_focused()) return TRUE;
++    /* don't clip the cursor if the X input focus is on another process window;
++       release any clipping state a previous grab left in this process, or
++       map_raw_event_coords keeps turning raw deltas into pointer positions
++       and scribbles over the focused process's cursor stream (issue 122) */
++    if (!is_current_process_focused())
++    {
++        ungrab_clipping_window();
++        return TRUE;
++    }
+ 
+     if (!data) return FALSE;
+     if (!(clip_window = init_clip_window())) return TRUE;
+-- 
+2.55.0
+

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -244,3 +244,11 @@ Apply them in sequence with the rest of the series.
   removing `_NET_WM_STATE_FULLSCREEN` on exit. The Live launcher selects
   `Ableton Live Window Class`; other classes and ordinary windowed geometry
   retain Wine's existing behavior. See `notes/ABLETON-WINE-FULLSCREEN.md`.
+- `0066`: release winex11's local cursor-clipping state (pointer grab,
+  clipping flags) whenever the process can observe that the X input focus
+  left it: the unfocused clip early-out, the clip-window FocusOut, and
+  FocusOut events showing another client holding the focus, ahead of the
+  reparenting/WM_STATE guards. Stops a cross-process embedded device host
+  (M4L) stranded mid-embed from synthesizing pointer input out of raw
+  XInput2 deltas over Live's cursor stream (issue 122).
+  See `notes/ABLETON-WINE-M4L-INPUT-INJECTION.md`.

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -61,5 +61,6 @@ a07f7ecb2c3a568d8eeae9a42df558cea4d8e279e5bdeb0af67a6649086973f7  0062-winex11-k
 0a7fb762e4bef288556f2118c318f6e99fe5532bb61058ccdb6d7732bf42ba27  0063-comdlg32-reveal-explorer-select-folder-targets-throu.patch
 81e02eeac88e6eda5da8044cd5bf74a197b2742f77c46da54e61dbf300031bd3  0064-shell32-route-explorer-folder-open-commands-to-the-h.patch
 7931be1771a070325eb0b87f970e51f7089c216f1bad128fb5ecf504e100e005  0065-win32u-normalize-selected-fullscreen-window.patch
+36d37cd849b5ebce90c293bc667af3bb9115b7343d559eae7d6a7acfd2373f38  0066-winex11-release-stale-cursor-clipping-state-when-X-f.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -141,6 +141,7 @@ FINGERPRINTS='
 0064|ascii|lib/wine/x86_64-windows/shell32.dll|__wine_portal_open_folder
 0065|ascii|lib/wine/x86_64-unix/win32u.so|WINE_WIN32_FULLSCREEN_CLASS
 0065|ascii|lib/wine/x86_64-unix/winex11.so|WINE_WIN32_FULLSCREEN_CLASS
+0066|ascii|lib/wine/x86_64-unix/winex11.so|lost X focus to another client while clipping
 pipeasio/0001|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-clamp-sample-rate
 pipeasio/0002|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-midi-timebase
 '


### PR DESCRIPTION
This one turned out to be kinda easy.

Loading a Max for Live device embeds a device UI window owned by a second process into Live's window tree. 

If the window manager briefly focuses that window during the embed, the host process is handed Wine's cursor-clip pointer grab, and the release for that pointer grab never reaches it. Instead, the notification goes only to the new foreground thread and the desktop thread, while the host's own `FocusOut` is dismissed by the re-parenting and `WM_STATE` guards. 

As a result, the Host window thinks that it still clips the cursor, and from then on it converts every physical mouse delta into synthesized pointer input over Live's cursor stream.

This PR forces `winex11` to release its local clipping state at every point where a process can observe that the `X` input focus left it, and logs "lost X focus to another client while clipping" when that actually releases.