### PR TITLE
Pr120 runtime process stop

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -105,25 +105,28 @@ for p in $(runtime_pids); do
     esac
 done
 if ableton_up; then
-    echo "== stopping running Ableton processes ($(runtime_pids | wc -l)) =="
+    echo "== stop processes using the installed runtime =="
+    echo "   $(runtime_pids | wc -l) found"
     # Closing Live discards unsaved work, so require an explicit yes.
     # -r and -w cannot ask that: they stat a 0666 device node and pass
     # even with no controlling terminal, and the printf would then fail
     # ENXIO and abort the install under set -e. Opening it is the only
-    # honest test. A timeout, an EOF or a missing terminal all mean
-    # nobody consented, so refuse. Leftover wineserver and winedevice.exe
-    # without Live have nothing to save and never reach this.
+    # honest test. Anything but y - a timeout, an EOF, a bare Enter, a
+    # missing terminal - means nobody consented, so refuse. Leftover
+    # wineserver and winedevice.exe without Live have nothing to save and
+    # never reach this.
     if [ "$live_up" -eq 1 ]; then
         if { : >/dev/tty; } 2>/dev/null; then
-            printf "Live is still open and updating will close it. Save your work, then press Enter to continue (Ctrl-C to abort): " > /dev/tty
-            if ! read -r -t 60 _ < /dev/tty; then
-                printf '\n' > /dev/tty 2>/dev/null || true
-                echo "!! no confirmation after 60s: close Live and rerun" >&2
-                exit 1
-            fi
+            echo "!! Live is running. Updating will force-close it. Save your work before continuing." >&2
+            printf "Force-close Live? [y/N] " > /dev/tty
+            ans=""
+            read -r -t 60 ans < /dev/tty || printf '\n' > /dev/tty 2>/dev/null || true
+            case "$ans" in
+                y|Y|yes|Yes|YES) ;;
+                *) exit 1 ;;
+            esac
         else
-            echo "!! Live is running and there is no terminal to confirm on:" >&2
-            echo "   close Live, or rerun this installer from a terminal" >&2
+            echo "!! Live is running; no terminal to confirm on. Close Live, or rerun from a terminal." >&2
             exit 1
         fi
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -95,10 +95,7 @@ for p in $(runtime_pids); do
     esac
 done
 if ableton_up; then
-    echo "== stopping running Ableton processes =="
-    runtime_pids | while read -r p; do
-        printf '%s %s\n' "$p" "$(tr -s '\0' ' ' < "/proc/$p/cmdline" 2>/dev/null)"
-    done
+    echo "== stopping running Ableton processes ($(runtime_pids | wc -l)) =="
     # Closing Live discards unsaved work, so require an explicit yes.
     # -r and -w cannot ask that: they stat a 0666 device node and pass
     # even with no controlling terminal, and the printf would then fail

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -58,36 +58,67 @@ fi
 # Anything still running from the installed runtime holds the old files
 # open. Stop it all instead of refusing: ask the prefix's wineserver to
 # take the whole session down (Live and its helpers are its clients), and
-# pkill only what survives that or runs when no wineserver binary is
-# there to call. ableton-linkd is not part of the runtime and is handled
-# at its own install step below.
+# signal the processes directly only when that is unavailable or leaves
+# something behind. ableton-linkd is not part of the runtime and is
+# handled at its own install step below.
+
+# Every process running from the installed runtime. Wine's in-prefix
+# helpers show a Windows path in argv (C:\windows\system32\...), so no
+# command-line pattern reaches them, and a pattern also catches unrelated
+# processes that merely mention the path. /proc/PID/exe is the binary
+# itself: bin/wineserver, or the wine-preloader every in-prefix process
+# runs from.
+runtime_pids()
+{
+    local d
+    for d in /proc/[0-9]*; do
+        case "$(readlink "$d/exe" 2>/dev/null)" in
+            "$OPT/$NAME"/*) printf '%s\n' "${d#/proc/}" ;;
+        esac
+    done
+}
+# Live's exe resolves to the same wine-preloader, so runtime_pids covers
+# it; the name match stays as a second opinion, since detection failing
+# open here means installing over a running runtime.
 ableton_up()
 {
-    # Two patterns: Live's exe processes do not carry the runtime path on
-    # their command line, the support processes do.
-    pgrep -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' >/dev/null 2>&1 || \
-        pgrep -f "$OPT/$NAME" >/dev/null 2>&1
+    [ -n "$(runtime_pids)" ] || \
+        pgrep -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' >/dev/null 2>&1
 }
+# Live itself, as opposed to the support processes: the prompt below is
+# about unsaved work and only Live has any. Scoped to this runtime, so a
+# Live under an unrelated Wine install is neither prompted for nor killed.
 live_up=0
-if pgrep -af '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' >/dev/null 2>&1; then
-    live_up=1
-fi
-if [ "$live_up" -eq 1 ] || pgrep -af "$OPT/$NAME" >/dev/null 2>&1; then
+for p in $(runtime_pids); do
+    case "$(tr -s '\0' ' ' < "/proc/$p/cmdline" 2>/dev/null)" in
+        *"Ableton Live"*.exe*) live_up=1; break ;;
+    esac
+done
+if ableton_up; then
     echo "== stopping running Ableton processes =="
-    pgrep -af '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' || true
-    pgrep -af "$OPT/$NAME" || true
-    # Closing Live discards unsaved work, so ask first. Leftover wineserver
-    # and winedevice.exe without Live have nothing to save: no prompt.
-    # /dev/tty rather than stdin: the .run wrapper feeds the script through
-    # a pipe. Without a terminal there is nobody to ask; proceed. The -r/-w
-    # tests pass even with no controlling terminal (they check the device
-    # mode, not an open), so the open itself is the real gate: when it
-    # fails, the group falls through to || true instead of tripping set -e.
-    if [ "$live_up" -eq 1 ] && [ -r /dev/tty ] && [ -w /dev/tty ]; then
-        {
-            printf "You're updating and Live is still open. Make sure you've saved everything and press Enter to continue."
-            read -r _
-        } 2>/dev/null < /dev/tty > /dev/tty || true
+    runtime_pids | while read -r p; do
+        printf '%s %s\n' "$p" "$(tr -s '\0' ' ' < "/proc/$p/cmdline" 2>/dev/null)"
+    done
+    # Closing Live discards unsaved work, so require an explicit yes.
+    # -r and -w cannot ask that: they stat a 0666 device node and pass
+    # even with no controlling terminal, and the printf would then fail
+    # ENXIO and abort the install under set -e. Opening it is the only
+    # honest test. A timeout, an EOF or a missing terminal all mean
+    # nobody consented, so refuse. Leftover wineserver and winedevice.exe
+    # without Live have nothing to save and never reach this.
+    if [ "$live_up" -eq 1 ]; then
+        if { : >/dev/tty; } 2>/dev/null; then
+            printf "Live is still open and updating will close it. Save your work, then press Enter to continue (Ctrl-C to abort): " > /dev/tty
+            if ! read -r -t 60 _ < /dev/tty; then
+                printf '\n' > /dev/tty 2>/dev/null || true
+                echo "!! no confirmation after 60s: close Live and rerun" >&2
+                exit 1
+            fi
+        else
+            echo "!! Live is running and there is no terminal to confirm on:" >&2
+            echo "   close Live, or rerun this installer from a terminal" >&2
+            exit 1
+        fi
     fi
     if [ -x "$OPT/$NAME/bin/wineserver" ]; then
         WINEPREFIX="${ABLETON_WINEPREFIX:-$HOME/.wine-ableton}" \
@@ -98,14 +129,14 @@ if [ "$live_up" -eq 1 ] || pgrep -af "$OPT/$NAME" >/dev/null 2>&1; then
         done
     fi
     if ableton_up; then
+        runtime_pids | xargs -r kill 2>/dev/null || true
         pkill -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' 2>/dev/null || true
-        pkill -f "$OPT/$NAME" 2>/dev/null || true
         for _ in $(seq 1 10); do
             ableton_up || break
             sleep 0.5
         done
+        runtime_pids | xargs -r kill -9 2>/dev/null || true
         pkill -9 -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' 2>/dev/null || true
-        pkill -9 -f "$OPT/$NAME" 2>/dev/null || true
     fi
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -36,12 +36,22 @@ cleanup()
         if [ -n "$launcher_backup" ] && [ -e "$launcher_backup" ]; then
             cp -a "$launcher_backup" "$BIN/ableton-live" || true
         fi
-        echo "!! install failed; previous runtime restored" >&2
+        if [ "$promoted" -eq 1 ] || [ -n "$backup" ] || [ -n "$launcher_backup" ]; then
+            echo "!! install failed; previous runtime restored" >&2
+        else
+            echo "!! install aborted; nothing was changed" >&2
+        fi
     fi
     [ -z "$stage" ] || rm -rf "$stage"
     exit "$rc"
 }
 trap cleanup EXIT
+# Without these, a signal reaches the EXIT trap with $? still 0 and the
+# rollback above is skipped: an interrupt between the two promotion mv's
+# would leave no runtime installed and say nothing. The confirmation
+# prompt is a 60 second window inviting exactly that Ctrl-C.
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # tarball: prefer dist/ (freshly built), else a release tarball dropped in root
 tarball="$(ls "$root"/dist/${NAME}-*.tar.zst 2>/dev/null | sort -V | tail -1 || true)"


### PR DESCRIPTION
Four commits on top of 144a45c, all tested against a real Live session in a throwaway HOME.

**Discovery.** Wine rewrites argv for in-prefix processes, so `pgrep -f "$OPT/$NAME"` only ever matches `wineserver`. With Live open the current patterns find **2 of 14** processes; `/proc/PID/exe` finds **14 of 14**, including `Ableton AddOns.exe` and `Ableton Index.exe`, which the `Ableton Live` name pattern doesn't match either. It matches through the `(deleted)` suffix so it also catches orphans from an already-swapped runtime, and it removes the `pkill -f` false positives — the unanchored pattern matched a `less .../README`. This is what makes the fallback work: SIGKILL on `wineserver` does not cascade to its clients, so the old predicate reported success while orphans still held the tree open.

**Confirmation.** 144a45c already stopped the ENXIO abort, but two paths through that prompt were still open. The `read` had no timeout, so an update with a prompt nobody is watching — `sh install-ableton-latest.run --update < /dev/null`, or a terminal left alone — hung indefinitely; it is bounded to 60 s now. And with no controlling terminal it proceeded to force-close Live with nobody having confirmed; it refuses now. The prompt is `force-close Live? [y/N]`, so only `y`/`Y`/`yes` continue and a bare Enter work. `n`, an EOF, the timeout and a missing terminal all refuse. `-r`/`-w` are replaced by an open probe, since those stat a 0666 device node and pass even with no terminal.

**Signals.** `trap 'exit 130' INT` / `'exit 143' TERM`. Without them the EXIT trap saw `$? = 0` and the promotion rollback never ran — and SIGINT during an external command was swallowed outright, so Ctrl-C could not cancel an install at all.
