### PR TITLE
Resolve the runtime tarball and the install root the same way everywhere

### DIFF
--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -4,7 +4,15 @@
 set -euo pipefail
 here="$(cd "$(dirname "$0")" && pwd)"
 root="$(cd "$here/.." && pwd)"
-NAME="wine-d2d1-nspa-11.13"
+# Runtime naming and tarball selection resolve in one place; see
+# scripts/runtime-env.sh.
+for _l in "$(dirname "$0")/runtime-env.sh" "$root/scripts/runtime-env.sh"; do
+    # shellcheck source=scripts/runtime-env.sh
+    [ -r "$_l" ] && . "$_l" && break
+done
+command -v ableton_pick_tarball >/dev/null 2>&1 || {
+    echo "!! runtime-env.sh not found next to $0" >&2; exit 1; }
+NAME="$(ableton_runtime_name)"
 SERIES="$root/patches/SERIES.sha256"
 
 say()  { printf '%s\n' "$*"; }
@@ -30,7 +38,10 @@ grep -qP 'x' <<<'x' 2>/dev/null || fail "grep -P not supported on this system (n
 # --- resolve the artifact: tarball (unpack to tmp) or tree --------------------
 target="${1:-}"
 if [ -z "$target" ]; then
-    target="$(ls "$root"/dist/${NAME}-*.tar.zst 2>/dev/null | sort -V | tail -1 || true)"
+    # Never a bare glob: this gate would otherwise certify the debug tree
+    # instead of the runtime it is vouching for, and CI calls it with no
+    # argument so the fallback is the path that actually runs.
+    target="$(ableton_pick_tarball "$root/dist")"
     [ -n "$target" ] || fail "no ${NAME}-*.tar.zst in dist/ and no argument given"
 fi
 cleanup_dir=""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,6 +13,15 @@ OPT="$HOME/.local/opt"
 BIN="$HOME/.local/bin"
 APPS="$HOME/.local/share/applications"
 NAME="wine-d2d1-nspa-11.13"
+# Where this install lands. scripts/ableton-live and scripts/setup-prefix.sh
+# already honour ABLETON_WINE_ROOT; install.sh and uninstall.sh hardcoded it,
+# which is the only reason two runtimes could not sit side by side. Staging,
+# the dated rollbacks, and — since PR #120 — the runtime_pids scan and the
+# wineserver stop all follow the target, so an overridden root is guarded by
+# the same gate as the default one rather than silently unprotected.
+WINE_ROOT="${ABLETON_WINE_ROOT:-$OPT/$NAME}"
+WINE_ROOT_DIR="$(dirname "$WINE_ROOT")"
+WINE_ROOT_BASE="$(basename "$WINE_ROOT")"
 stamp="$(date -u +%Y%m%dT%H%M%SZ)"
 stage=""
 backup=""
@@ -24,37 +33,40 @@ cleanup()
     rc=$?
     trap - EXIT
     if [ "$rc" -ne 0 ]; then
-        failed="$OPT/${NAME}.failed-$stamp"
-        if [ "$promoted" -eq 1 ] && [ -e "$OPT/$NAME" ]; then
-            mv "$OPT/$NAME" "$failed" || true
+        failed="$WINE_ROOT.failed-$stamp"
+        if [ "$promoted" -eq 1 ] && [ -e "$WINE_ROOT" ]; then
+            mv "$WINE_ROOT" "$failed" || true
         fi
-        if [ -n "$backup" ] && [ -e "$backup" ] && [ ! -e "$OPT/$NAME" ]; then
-            mv "$backup" "$OPT/$NAME" || true
+        if [ -n "$backup" ] && [ -e "$backup" ] && [ ! -e "$WINE_ROOT" ]; then
+            mv "$backup" "$WINE_ROOT" || true
         elif [ -n "$backup" ] && [ -e "$backup" ]; then
-            echo "!! $OPT/$NAME still present; backup left at $backup" >&2
+            echo "!! $WINE_ROOT still present; backup left at $backup" >&2
         fi
         if [ -n "$launcher_backup" ] && [ -e "$launcher_backup" ]; then
             cp -a "$launcher_backup" "$BIN/ableton-live" || true
         fi
-        echo "!! install failed; previous runtime restored" >&2
+        if [ "$promoted" -eq 1 ] || [ -n "$backup" ] || [ -n "$launcher_backup" ]; then
+            echo "!! install failed; previous runtime restored" >&2
+        else
+            echo "!! install aborted; nothing was changed" >&2
+        fi
     fi
     [ -z "$stage" ] || rm -rf "$stage"
     exit "$rc"
 }
 trap cleanup EXIT
+# Without these, a signal reaches the EXIT trap with $? still 0 and the
+# rollback above is skipped: an interrupt between the two promotion mv's
+# would leave no runtime installed and say nothing. The confirmation
+# prompt is a 60 second window inviting exactly that Ctrl-C.
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
-# Newest runtime tarball in $1, or empty. The glob is deliberately not the
-# selector: the build also emits ${NAME}-<version>-debug.tar.zst beside the
-# runtime, and `sort -V` orders that suffix *after* the plain version, so a
-# glob piped straight to `tail -1` picks the debug tree whenever both are
-# present. That tree carries bin/ and lib/ but no share/ and no wineboot, so
-# `wine --version` still answers while any real launch dies with "could not
-# exec the wine loader" - a failure that looks nothing like its cause. Match
-# the dated release form only and let every suffixed variant fall out.
+# tarball: prefer dist/ (freshly built), else a release tarball dropped in root
 pick_runtime_tarball() {
     local dir="$1" f base
     # NAME carries dots (11.13); escape them so they match literally.
-    local re="^${NAME//./\\.}-[0-9]{4}\.[0-9]{2}\.[0-9]{2}\.[0-9]+\.tar\.zst\$"
+    local re="^${NAME//./\\.}-[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}\\.[0-9]+\\.tar\\.zst\$"
     local -a found=()
     for f in "$dir"/"$NAME"-*.tar.zst; do
         [ -e "$f" ] || continue          # no match: the glob came back literal
@@ -66,9 +78,6 @@ pick_runtime_tarball() {
     printf '%s\n' "${found[@]}" | sort -V | tail -1
 }
 
-# tarball: prefer dist/ (freshly built), else a release tarball dropped in root.
-# ABLETON_RUNTIME_TARBALL pins one outright, for testing a second channel or a
-# bisect build without moving files out of the way first.
 if [ -n "${ABLETON_RUNTIME_TARBALL:-}" ]; then
     tarball="$ABLETON_RUNTIME_TARBALL"
     [ -f "$tarball" ] || { echo "!! ABLETON_RUNTIME_TARBALL is not a file: $tarball" >&2; exit 1; }
@@ -76,8 +85,7 @@ else
     tarball="$(pick_runtime_tarball "$root/dist")"
     [ -n "$tarball" ] || tarball="$(pick_runtime_tarball "$root")"
 fi
-[ -n "$tarball" ] || { echo "!! no ${NAME}-<version>.tar.zst found: run ./build.sh first, or drop a release tarball in $root/dist/" >&2; exit 1; }
-echo "   runtime: $(basename "$tarball")"
+[ -n "$tarball" ] || { echo "!! no ${NAME}-*.tar.zst found: run ./build.sh first, or drop a release tarball in $root/dist/"; exit 1; }
 
 echo "== verify checksum =="
 if [ -f "$tarball.sha256" ]; then
@@ -86,15 +94,94 @@ else
     echo "   (no .sha256 next to tarball: skipping)"
 fi
 
-if pgrep -af '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' >/dev/null 2>&1 || \
-   pgrep -af "$OPT/$NAME" >/dev/null 2>&1; then
-    echo "!! the installed Ableton Wine is still running: close Live, wait a few seconds, and rerun" >&2
-    exit 1
+# Anything still running from the installed runtime holds the old files
+# open. Stop it all instead of refusing: ask the prefix's wineserver to
+# take the whole session down (Live and its helpers are its clients), and
+# signal the processes directly only when that is unavailable or leaves
+# something behind. ableton-linkd is not part of the runtime and is
+# handled at its own install step below.
+
+# Every process running from the installed runtime. Wine's in-prefix
+# helpers show a Windows path in argv (C:\windows\system32\...), so no
+# command-line pattern reaches them, and a pattern also catches unrelated
+# processes that merely mention the path. /proc/PID/exe is the binary
+# itself: bin/wineserver, or the wine-preloader every in-prefix process
+# runs from.
+runtime_pids()
+{
+    local d
+    for d in /proc/[0-9]*; do
+        case "$(readlink "$d/exe" 2>/dev/null)" in
+            "$WINE_ROOT"/*) printf '%s\n' "${d#/proc/}" ;;
+        esac
+    done
+}
+# Live's exe resolves to the same wine-preloader, so runtime_pids covers
+# it; the name match stays as a second opinion, since detection failing
+# open here means installing over a running runtime.
+ableton_up()
+{
+    [ -n "$(runtime_pids)" ] || \
+        pgrep -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' >/dev/null 2>&1
+}
+# Live itself, as opposed to the support processes: the prompt below is
+# about unsaved work and only Live has any. Scoped to this runtime, so a
+# Live under an unrelated Wine install is neither prompted for nor killed.
+live_up=0
+for p in $(runtime_pids); do
+    case "$(tr -s '\0' ' ' < "/proc/$p/cmdline" 2>/dev/null)" in
+        *"Ableton Live"*.exe*) live_up=1; break ;;
+    esac
+done
+if ableton_up; then
+    echo "== stop processes using the installed runtime =="
+    echo "   $(runtime_pids | wc -l) found"
+    # Closing Live discards unsaved work, so require an explicit yes.
+    # -r and -w cannot ask that: they stat a 0666 device node and pass
+    # even with no controlling terminal, and the printf would then fail
+    # ENXIO and abort the install under set -e. Opening it is the only
+    # honest test. Anything but y - a timeout, an EOF, a bare Enter, a
+    # missing terminal - means nobody consented, so refuse. Leftover
+    # wineserver and winedevice.exe without Live have nothing to save and
+    # never reach this.
+    if [ "$live_up" -eq 1 ]; then
+        if { : >/dev/tty; } 2>/dev/null; then
+            echo "!! Live is running. Updating will force-close it. Save your work before continuing." >&2
+            printf "Force-close Live? [y/N] " > /dev/tty
+            ans=""
+            read -r -t 60 ans < /dev/tty || printf '\n' > /dev/tty 2>/dev/null || true
+            case "$ans" in
+                y|Y|yes|Yes|YES) ;;
+                *) exit 1 ;;
+            esac
+        else
+            echo "!! Live is running; no terminal to confirm on. Close Live, or rerun from a terminal." >&2
+            exit 1
+        fi
+    fi
+    if [ -x "$WINE_ROOT/bin/wineserver" ]; then
+        WINEPREFIX="${ABLETON_WINEPREFIX:-$HOME/.wine-ableton}" \
+            "$WINE_ROOT/bin/wineserver" -k 2>/dev/null || true
+        for _ in $(seq 1 20); do
+            ableton_up || break
+            sleep 0.5
+        done
+    fi
+    if ableton_up; then
+        runtime_pids | xargs -r kill 2>/dev/null || true
+        pkill -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' 2>/dev/null || true
+        for _ in $(seq 1 10); do
+            ableton_up || break
+            sleep 0.5
+        done
+        runtime_pids | xargs -r kill -9 2>/dev/null || true
+        pkill -9 -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' 2>/dev/null || true
+    fi
 fi
 
 echo "== stage and validate patched Wine =="
-mkdir -p "$OPT"
-stage="$(mktemp -d "$OPT/.${NAME}.install.XXXXXX")"
+mkdir -p "$WINE_ROOT_DIR"
+stage="$(mktemp -d "$WINE_ROOT_DIR/.${WINE_ROOT_BASE}.install.XXXXXX")"
 tar -C "$stage" -I zstd -xf "$tarball"
 candidate="$stage/$NAME"
 for required in \
@@ -171,14 +258,14 @@ else
 fi
 
 echo "== promote runtime with dated rollback =="
-if [ -e "$OPT/$NAME" ]; then
-    backup="$OPT/${NAME}-rollback-$stamp"
+if [ -e "$WINE_ROOT" ]; then
+    backup="$WINE_ROOT-rollback-$stamp"
     [ ! -e "$backup" ] || { echo "!! rollback path already exists: $backup" >&2; exit 1; }
-    mv "$OPT/$NAME" "$backup"
+    mv "$WINE_ROOT" "$backup"
 fi
-mv "$candidate" "$OPT/$NAME"
+mv "$candidate" "$WINE_ROOT"
 promoted=1
-"$OPT/$NAME/bin/wine" --version
+"$WINE_ROOT/bin/wine" --version
 
 echo "== install launcher -> $BIN/ableton-live =="
 mkdir -p "$BIN"
@@ -215,8 +302,21 @@ done
 # timeline survive a Live restart (notes/ABLETON-WINE-LINK-FIRSTCLASS.md).
 # The launcher auto-starts it. The .run wrapper calls setup-link.sh once after
 # this install; repository installs may call the staged script directly.
+# Stop a running daemon before replacing the binary, else the old process
+# keeps running from the deleted inode and the update takes effect only
+# after a reboot. SIGTERM is a clean exit for it, so Restart=on-failure
+# does not undo the stop.
+linkd_active=0
+if systemctl --user is-active --quiet ableton-linkd.service 2>/dev/null; then
+    linkd_active=1
+    systemctl --user stop ableton-linkd.service 2>/dev/null || true
+fi
+pkill -x ableton-linkd 2>/dev/null || true   # launcher-started instance, no unit
 install -m755 "$linkd" "$HOME/.local/share/ableton-wine/ableton-linkd"
 install -m644 "$linkd_unit" "$HOME/.local/share/ableton-wine/ableton-linkd.service"
+if [ "$linkd_active" -eq 1 ]; then
+    systemctl --user start ableton-linkd.service 2>/dev/null || true
+fi
 # Keep the setup command installed for retries after a firewall or
 # hook-removal failure.
 install -m755 "$here/setup-link.sh" "$HOME/.local/share/ableton-wine/setup-link.sh"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,7 +12,15 @@ root="$(cd "$here/.." && pwd)"
 OPT="$HOME/.local/opt"
 BIN="$HOME/.local/bin"
 APPS="$HOME/.local/share/applications"
-NAME="wine-d2d1-nspa-11.13"
+# Runtime naming and tarball selection resolve in one place; see
+# scripts/runtime-env.sh.
+for _l in "$(dirname "$0")/runtime-env.sh" "$root/scripts/runtime-env.sh"; do
+    # shellcheck source=scripts/runtime-env.sh
+    [ -r "$_l" ] && . "$_l" && break
+done
+command -v ableton_pick_tarball >/dev/null 2>&1 || {
+    echo "!! runtime-env.sh not found next to $0" >&2; exit 1; }
+NAME="$(ableton_runtime_name)"
 # Where this install lands. scripts/ableton-live and scripts/setup-prefix.sh
 # already honour ABLETON_WINE_ROOT; install.sh and uninstall.sh hardcoded it,
 # which is the only reason two runtimes could not sit side by side. Staging,
@@ -63,27 +71,12 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 # tarball: prefer dist/ (freshly built), else a release tarball dropped in root
-pick_runtime_tarball() {
-    local dir="$1" f base
-    # NAME carries dots (11.13); escape them so they match literally.
-    local re="^${NAME//./\\.}-[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}\\.[0-9]+\\.tar\\.zst\$"
-    local -a found=()
-    for f in "$dir"/"$NAME"-*.tar.zst; do
-        [ -e "$f" ] || continue          # no match: the glob came back literal
-        base="${f##*/}"
-        [[ "$base" =~ $re ]] || continue
-        found+=("$f")
-    done
-    [ "${#found[@]}" -gt 0 ] || return 0
-    printf '%s\n' "${found[@]}" | sort -V | tail -1
-}
-
 if [ -n "${ABLETON_RUNTIME_TARBALL:-}" ]; then
     tarball="$ABLETON_RUNTIME_TARBALL"
     [ -f "$tarball" ] || { echo "!! ABLETON_RUNTIME_TARBALL is not a file: $tarball" >&2; exit 1; }
 else
-    tarball="$(pick_runtime_tarball "$root/dist")"
-    [ -n "$tarball" ] || tarball="$(pick_runtime_tarball "$root")"
+    tarball="$(ableton_pick_tarball "$root/dist")"
+    [ -n "$tarball" ] || tarball="$(ableton_pick_tarball "$root")"
 fi
 [ -n "$tarball" ] || { echo "!! no ${NAME}-*.tar.zst found: run ./build.sh first, or drop a release tarball in $root/dist/"; exit 1; }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -36,27 +36,48 @@ cleanup()
         if [ -n "$launcher_backup" ] && [ -e "$launcher_backup" ]; then
             cp -a "$launcher_backup" "$BIN/ableton-live" || true
         fi
-        if [ "$promoted" -eq 1 ] || [ -n "$backup" ] || [ -n "$launcher_backup" ]; then
-            echo "!! install failed; previous runtime restored" >&2
-        else
-            echo "!! install aborted; nothing was changed" >&2
-        fi
+        echo "!! install failed; previous runtime restored" >&2
     fi
     [ -z "$stage" ] || rm -rf "$stage"
     exit "$rc"
 }
 trap cleanup EXIT
-# Without these, a signal reaches the EXIT trap with $? still 0 and the
-# rollback above is skipped: an interrupt between the two promotion mv's
-# would leave no runtime installed and say nothing. The confirmation
-# prompt is a 60 second window inviting exactly that Ctrl-C.
-trap 'exit 130' INT
-trap 'exit 143' TERM
 
-# tarball: prefer dist/ (freshly built), else a release tarball dropped in root
-tarball="$(ls "$root"/dist/${NAME}-*.tar.zst 2>/dev/null | sort -V | tail -1 || true)"
-[ -z "$tarball" ] && tarball="$(ls "$root"/${NAME}-*.tar.zst 2>/dev/null | sort -V | tail -1 || true)"
-[ -n "$tarball" ] || { echo "!! no ${NAME}-*.tar.zst found: run ./build.sh first, or drop a release tarball in $root/dist/"; exit 1; }
+# Newest runtime tarball in $1, or empty. The glob is deliberately not the
+# selector: the build also emits ${NAME}-<version>-debug.tar.zst beside the
+# runtime, and `sort -V` orders that suffix *after* the plain version, so a
+# glob piped straight to `tail -1` picks the debug tree whenever both are
+# present. That tree carries bin/ and lib/ but no share/ and no wineboot, so
+# `wine --version` still answers while any real launch dies with "could not
+# exec the wine loader" - a failure that looks nothing like its cause. Match
+# the dated release form only and let every suffixed variant fall out.
+pick_runtime_tarball() {
+    local dir="$1" f base
+    # NAME carries dots (11.13); escape them so they match literally.
+    local re="^${NAME//./\\.}-[0-9]{4}\.[0-9]{2}\.[0-9]{2}\.[0-9]+\.tar\.zst\$"
+    local -a found=()
+    for f in "$dir"/"$NAME"-*.tar.zst; do
+        [ -e "$f" ] || continue          # no match: the glob came back literal
+        base="${f##*/}"
+        [[ "$base" =~ $re ]] || continue
+        found+=("$f")
+    done
+    [ "${#found[@]}" -gt 0 ] || return 0
+    printf '%s\n' "${found[@]}" | sort -V | tail -1
+}
+
+# tarball: prefer dist/ (freshly built), else a release tarball dropped in root.
+# ABLETON_RUNTIME_TARBALL pins one outright, for testing a second channel or a
+# bisect build without moving files out of the way first.
+if [ -n "${ABLETON_RUNTIME_TARBALL:-}" ]; then
+    tarball="$ABLETON_RUNTIME_TARBALL"
+    [ -f "$tarball" ] || { echo "!! ABLETON_RUNTIME_TARBALL is not a file: $tarball" >&2; exit 1; }
+else
+    tarball="$(pick_runtime_tarball "$root/dist")"
+    [ -n "$tarball" ] || tarball="$(pick_runtime_tarball "$root")"
+fi
+[ -n "$tarball" ] || { echo "!! no ${NAME}-<version>.tar.zst found: run ./build.sh first, or drop a release tarball in $root/dist/" >&2; exit 1; }
+echo "   runtime: $(basename "$tarball")"
 
 echo "== verify checksum =="
 if [ -f "$tarball.sha256" ]; then
@@ -65,89 +86,10 @@ else
     echo "   (no .sha256 next to tarball: skipping)"
 fi
 
-# Anything still running from the installed runtime holds the old files
-# open. Stop it all instead of refusing: ask the prefix's wineserver to
-# take the whole session down (Live and its helpers are its clients), and
-# signal the processes directly only when that is unavailable or leaves
-# something behind. ableton-linkd is not part of the runtime and is
-# handled at its own install step below.
-
-# Every process running from the installed runtime. Wine's in-prefix
-# helpers show a Windows path in argv (C:\windows\system32\...), so no
-# command-line pattern reaches them, and a pattern also catches unrelated
-# processes that merely mention the path. /proc/PID/exe is the binary
-# itself: bin/wineserver, or the wine-preloader every in-prefix process
-# runs from.
-runtime_pids()
-{
-    local d
-    for d in /proc/[0-9]*; do
-        case "$(readlink "$d/exe" 2>/dev/null)" in
-            "$OPT/$NAME"/*) printf '%s\n' "${d#/proc/}" ;;
-        esac
-    done
-}
-# Live's exe resolves to the same wine-preloader, so runtime_pids covers
-# it; the name match stays as a second opinion, since detection failing
-# open here means installing over a running runtime.
-ableton_up()
-{
-    [ -n "$(runtime_pids)" ] || \
-        pgrep -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' >/dev/null 2>&1
-}
-# Live itself, as opposed to the support processes: the prompt below is
-# about unsaved work and only Live has any. Scoped to this runtime, so a
-# Live under an unrelated Wine install is neither prompted for nor killed.
-live_up=0
-for p in $(runtime_pids); do
-    case "$(tr -s '\0' ' ' < "/proc/$p/cmdline" 2>/dev/null)" in
-        *"Ableton Live"*.exe*) live_up=1; break ;;
-    esac
-done
-if ableton_up; then
-    echo "== stop processes using the installed runtime =="
-    echo "   $(runtime_pids | wc -l) found"
-    # Closing Live discards unsaved work, so require an explicit yes.
-    # -r and -w cannot ask that: they stat a 0666 device node and pass
-    # even with no controlling terminal, and the printf would then fail
-    # ENXIO and abort the install under set -e. Opening it is the only
-    # honest test. Anything but y - a timeout, an EOF, a bare Enter, a
-    # missing terminal - means nobody consented, so refuse. Leftover
-    # wineserver and winedevice.exe without Live have nothing to save and
-    # never reach this.
-    if [ "$live_up" -eq 1 ]; then
-        if { : >/dev/tty; } 2>/dev/null; then
-            echo "!! Live is running. Updating will force-close it. Save your work before continuing." >&2
-            printf "Force-close Live? [y/N] " > /dev/tty
-            ans=""
-            read -r -t 60 ans < /dev/tty || printf '\n' > /dev/tty 2>/dev/null || true
-            case "$ans" in
-                y|Y|yes|Yes|YES) ;;
-                *) exit 1 ;;
-            esac
-        else
-            echo "!! Live is running; no terminal to confirm on. Close Live, or rerun from a terminal." >&2
-            exit 1
-        fi
-    fi
-    if [ -x "$OPT/$NAME/bin/wineserver" ]; then
-        WINEPREFIX="${ABLETON_WINEPREFIX:-$HOME/.wine-ableton}" \
-            "$OPT/$NAME/bin/wineserver" -k 2>/dev/null || true
-        for _ in $(seq 1 20); do
-            ableton_up || break
-            sleep 0.5
-        done
-    fi
-    if ableton_up; then
-        runtime_pids | xargs -r kill 2>/dev/null || true
-        pkill -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' 2>/dev/null || true
-        for _ in $(seq 1 10); do
-            ableton_up || break
-            sleep 0.5
-        done
-        runtime_pids | xargs -r kill -9 2>/dev/null || true
-        pkill -9 -f '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' 2>/dev/null || true
-    fi
+if pgrep -af '[A]bleton Live.*\.exe|[P]ush2DisplayProcess.exe' >/dev/null 2>&1 || \
+   pgrep -af "$OPT/$NAME" >/dev/null 2>&1; then
+    echo "!! the installed Ableton Wine is still running: close Live, wait a few seconds, and rerun" >&2
+    exit 1
 fi
 
 echo "== stage and validate patched Wine =="
@@ -273,21 +215,8 @@ done
 # timeline survive a Live restart (notes/ABLETON-WINE-LINK-FIRSTCLASS.md).
 # The launcher auto-starts it. The .run wrapper calls setup-link.sh once after
 # this install; repository installs may call the staged script directly.
-# Stop a running daemon before replacing the binary, else the old process
-# keeps running from the deleted inode and the update takes effect only
-# after a reboot. SIGTERM is a clean exit for it, so Restart=on-failure
-# does not undo the stop.
-linkd_active=0
-if systemctl --user is-active --quiet ableton-linkd.service 2>/dev/null; then
-    linkd_active=1
-    systemctl --user stop ableton-linkd.service 2>/dev/null || true
-fi
-pkill -x ableton-linkd 2>/dev/null || true   # launcher-started instance, no unit
 install -m755 "$linkd" "$HOME/.local/share/ableton-wine/ableton-linkd"
 install -m644 "$linkd_unit" "$HOME/.local/share/ableton-wine/ableton-linkd.service"
-if [ "$linkd_active" -eq 1 ]; then
-    systemctl --user start ableton-linkd.service 2>/dev/null || true
-fi
 # Keep the setup command installed for retries after a firewall or
 # hook-removal failure.
 install -m755 "$here/setup-link.sh" "$HOME/.local/share/ableton-wine/setup-link.sh"

--- a/scripts/make-installer.sh
+++ b/scripts/make-installer.sh
@@ -13,11 +13,25 @@ cd "$root"
 
 ENGINE="${ENGINE:-podman}"
 IMAGE="${IMAGE:-ableton-wine-build:22.04}"
-NAME="wine-d2d1-nspa-11.13"
+# Runtime naming and tarball selection resolve in one place; see
+# scripts/runtime-env.sh.
+for _l in "$(dirname "$0")/runtime-env.sh" "$here/runtime-env.sh"; do
+    # shellcheck source=scripts/runtime-env.sh
+    [ -r "$_l" ] && . "$_l" && break
+done
+command -v ableton_pick_tarball >/dev/null 2>&1 || {
+    echo "!! runtime-env.sh not found next to $0" >&2; exit 1; }
+NAME="$(ableton_runtime_name)"
 VERSION="$(cat VERSION)"
-# exact-version runtime if present, else the newest built one
-tarball="dist/${NAME}-${VERSION}.tar.zst"
-[ -f "$tarball" ] || tarball="$(ls dist/${NAME}-*.tar.zst 2>/dev/null | sort -V | tail -1 || true)"
+# ABLETON_RUNTIME_TARBALL pins one outright; otherwise the exact-version
+# runtime if present, else the newest properly-named one. Never a bare glob.
+if [ -n "${ABLETON_RUNTIME_TARBALL:-}" ]; then
+    tarball="$ABLETON_RUNTIME_TARBALL"
+    [ -f "$tarball" ] || { echo "!! ABLETON_RUNTIME_TARBALL is not a file: $tarball" >&2; exit 1; }
+else
+    tarball="dist/${NAME}-${VERSION}.tar.zst"
+    [ -f "$tarball" ] || tarball="$(ableton_pick_tarball dist)"
+fi
 
 [ -n "$tarball" ] && [ -f "$tarball" ] || { echo "!! no ${NAME}-*.tar.zst in dist/: run ./build.sh first" >&2; exit 1; }
 [ -f "$tarball.sha256" ] || { echo "!! $tarball.sha256 missing" >&2; exit 1; }
@@ -66,7 +80,7 @@ mkdir -p "$kit/bin" "$kit/dist" "$kit/vendor"
 cp -a "$tarball" "$tarball.sha256" "$kit/dist/"
 cp -a "dist/BUILD-INFO-${VERSION}.txt" "$kit/" 2>/dev/null || true
 mkdir -p "$kit/scripts"
-cp -a scripts/install.sh scripts/setup-prefix.sh scripts/uninstall.sh \
+cp -a scripts/runtime-env.sh scripts/install.sh scripts/setup-prefix.sh scripts/uninstall.sh \
       scripts/ableton-live scripts/max9 scripts/detect-scale.sh \
       scripts/detect-theme.sh scripts/check-live-audio.sh scripts/setup-link.sh \
       "$kit/scripts/"

--- a/scripts/make-installer.sh
+++ b/scripts/make-installer.sh
@@ -34,6 +34,20 @@ else
 fi
 
 [ -n "$tarball" ] && [ -f "$tarball" ] || { echo "!! no ${NAME}-*.tar.zst in dist/: run ./build.sh first" >&2; exit 1; }
+# The kit carries this tarball and the kit's own install.sh selects it by name,
+# so a name the selector rejects builds a kit that packs cleanly and then dies
+# on the user's machine with "no tarball found". Only the pin reaches here with
+# an unchecked name — the branch above already filters — but the pin is exactly
+# how a published nightly gets packed, and those are named
+# <name>-<version>+nightly.<sha>.tar.zst.
+#
+# install.sh honours its own pin whatever the name, deliberately: there the
+# consequence lands on whoever set the variable. Here it lands on whoever is
+# handed the .run, so this refuses instead.
+ableton_is_runtime_tarball "$tarball" || {
+    echo "!! not a name the kit's install.sh will select: $(basename "$tarball")" >&2
+    echo "   expected ${NAME}-<YYYY.MM.DD.N>.tar.zst — rename it, or drop it in dist/ under that name" >&2
+    exit 1; }
 [ -f "$tarball.sha256" ] || { echo "!! $tarball.sha256 missing" >&2; exit 1; }
 echo "   runtime: $(basename "$tarball")"
 

--- a/scripts/runtime-env.sh
+++ b/scripts/runtime-env.sh
@@ -11,7 +11,7 @@ ableton_runtime_name() {
     printf '%s\n' "wine-d2d1-nspa-11.13"
 }
 
-# The newest runtime tarball in <dir>, or nothing.
+# Is this a runtime tarball an install will select? The name is the whole test.
 #
 # The glob cannot be the selector. The build also emits
 # <name>-<version>-debug.tar.zst, and `sort -V` orders that suffix *after* the
@@ -20,17 +20,29 @@ ableton_runtime_name() {
 # with "could not exec the wine loader". Match the dated release form only and
 # let every suffixed variant fall out.
 #
+# A predicate rather than the regex inlined at one call site, because there are
+# two: the selector below, and make-installer.sh checking the tarball it was
+# told to pack. Those disagreeing is not hypothetical — a name this rejects
+# packs into a kit perfectly well, and the failure surfaces on the user's
+# machine, where the kit's own install.sh finds nothing to install.
+ableton_is_runtime_tarball() {
+    local _b="${1##*/}" _nm _re
+    _nm="$(ableton_runtime_name)"
+    _re="^${_nm//./\\.}-[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}\\.[0-9]+\\.tar\\.zst\$"
+    [[ "$_b" =~ $_re ]]
+}
+
+# The newest runtime tarball in <dir>, or nothing.
+#
 # Locals are underscore-prefixed: this is sourced into scripts with their own
 # $found and $target.
 ableton_pick_tarball() {
-    local _dir="$1" _nm _f _b
+    local _dir="$1" _nm _f
     _nm="$(ableton_runtime_name)"
-    local _re="^${_nm//./\\.}-[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}\\.[0-9]+\\.tar\\.zst\$"
     local -a _found=()
     for _f in "$_dir"/"$_nm"-*.tar.zst; do
         [ -e "$_f" ] || continue          # no match: the glob came back literal
-        _b="${_f##*/}"
-        [[ "$_b" =~ $_re ]] || continue
+        ableton_is_runtime_tarball "$_f" || continue
         _found+=("$_f")
     done
     [ "${#_found[@]}" -gt 0 ] || return 0

--- a/scripts/runtime-env.sh
+++ b/scripts/runtime-env.sh
@@ -1,0 +1,38 @@
+# shellcheck shell=bash
+# Which runtime tarball a script should act on.
+#
+# Sourced, never executed. This exists because the answer was written three
+# times — install.sh, make-installer.sh and build-audit.sh each had a copy, and
+# the same defect was in all three.
+
+# The runtime's build name. It carries the Wine version because the artifact
+# does: a tarball identifies which build it is.
+ableton_runtime_name() {
+    printf '%s\n' "wine-d2d1-nspa-11.13"
+}
+
+# The newest runtime tarball in <dir>, or nothing.
+#
+# The glob cannot be the selector. The build also emits
+# <name>-<version>-debug.tar.zst, and `sort -V` orders that suffix *after* the
+# runtime, so a glob piped to `tail -1` picks the debug tree — which carries
+# bin/ and lib/ but no share/, passes `wine --version`, and then fails at launch
+# with "could not exec the wine loader". Match the dated release form only and
+# let every suffixed variant fall out.
+#
+# Locals are underscore-prefixed: this is sourced into scripts with their own
+# $found and $target.
+ableton_pick_tarball() {
+    local _dir="$1" _nm _f _b
+    _nm="$(ableton_runtime_name)"
+    local _re="^${_nm//./\\.}-[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}\\.[0-9]+\\.tar\\.zst\$"
+    local -a _found=()
+    for _f in "$_dir"/"$_nm"-*.tar.zst; do
+        [ -e "$_f" ] || continue          # no match: the glob came back literal
+        _b="${_f##*/}"
+        [[ "$_b" =~ $_re ]] || continue
+        _found+=("$_f")
+    done
+    [ "${#_found[@]}" -gt 0 ] || return 0
+    printf '%s\n' "${_found[@]}" | sort -V | tail -1
+}

--- a/scripts/setup-run-header.sh
+++ b/scripts/setup-run-header.sh
@@ -28,6 +28,13 @@ export LC_ALL=C.UTF-8
 VERSION="@VERSION@"
 PAYLOAD_SHA="@PAYLOAD_SHA@"
 RUNTIME_NAME="wine-d2d1-nspa-11.13"
+# Resolve the same two paths install.sh does, and for the same reason: this
+# wrapper checks for an existing install and then runs Live's installer through
+# the runtime, so if it looks somewhere other than where install.sh puts things
+# it will offer a fresh install over an existing one, or run the Ableton
+# installer against a runtime that is not the one it just installed.
+WINE_ROOT="${ABLETON_WINE_ROOT:-$HOME/.local/opt/$RUNTIME_NAME}"
+PREFIX_DIR="${ABLETON_WINEPREFIX:-$HOME/.wine-ableton}"
 
 self="$(readlink -f -- "$0")"
 stick_dir="$(dirname -- "$self")"
@@ -69,8 +76,8 @@ say "== Ableton-on-Wine installer $VERSION =="
 # runtime, launcher, and prefix policy to this kit's version. It preserves the
 # Live installation, authorization, and projects; compatibility settings may
 # change.
-if [ "$mode" = install ] && [ -x "$HOME/.local/opt/$RUNTIME_NAME/bin/wine" ] \
-   && [ -f "${ABLETON_WINEPREFIX:-$HOME/.wine-ableton}/system.reg" ]; then
+if [ "$mode" = install ] && [ -x "$WINE_ROOT/bin/wine" ] \
+   && [ -f "$PREFIX_DIR/system.reg" ]; then
     installed_ver="$(cat "$HOME/.local/share/ableton-wine/VERSION" 2>/dev/null || true)"
     say ""
     say "An existing installation was found${installed_ver:+ (version $installed_ver)}."
@@ -305,7 +312,7 @@ if [ -z "${ABLETON_DPI_MODE:-}" ]; then
     if block="$(ableton_dpi_block_for_scale "$scale" "$family")"; then
         export ABLETON_DPI_MODE="$block"
         say "-- display scale: $(awk -v s="$scale" 'BEGIN { printf "%d", s*100 + 0.5 }')% (auto-detected)"
-    elif [ -d "$HOME/.wine-ableton" ]; then
+    elif [ -d "$PREFIX_DIR" ]; then
         export ABLETON_DPI_MODE=preserve
         say "-- display scale: ${scale:-could not be detected}${scale:+ (outside the calibrated 100-250% range)}; keeping your existing display settings"
     else
@@ -354,16 +361,16 @@ if [ "$manual_install" -eq 0 ]; then
         fi
         # run from the installer's own directory so its relative payload lookups resolve
         if ( cd "$(dirname -- "$live_exe")" && \
-                 WINEPREFIX="$HOME/.wine-ableton" \
-                 "$HOME/.local/opt/$RUNTIME_NAME/bin/wine" \
+                 WINEPREFIX="$PREFIX_DIR" \
+                 "$WINE_ROOT/bin/wine" \
                  "./$(basename -- "$live_exe")" "${live_flags[@]}" ); then
             live_installed=1
         else
             say "!! the Ableton installer exited with an error; instructions below"
             manual_install=1
         fi
-        WINEPREFIX="$HOME/.wine-ableton" \
-            "$HOME/.local/opt/$RUNTIME_NAME/bin/wineserver" -w 2>/dev/null || true
+        WINEPREFIX="$PREFIX_DIR" \
+            "$WINE_ROOT/bin/wineserver" -w 2>/dev/null || true
         rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/ableton-wine-setup" 2>/dev/null || true
     fi
 fi
@@ -378,8 +385,8 @@ else
     say "       unzip /path/to/ableton_live*.zip -d ~/live-installer"
     say "       (no unzip? try: bsdtar -xf FILE.zip -C ~/live-installer)"
     say "  2) run the installer through this Wine, from inside that directory:"
-    say "       cd ~/live-installer && WINEPREFIX=~/.wine-ableton \\"
-    say "           ~/.local/opt/$RUNTIME_NAME/bin/wine ./*.exe \\"
+    say "       cd ~/live-installer && WINEPREFIX=$PREFIX_DIR \\"
+    say "           $WINE_ROOT/bin/wine ./*.exe \\"
     say "           /SILENT /SUPPRESSMSGBOXES /NORESTART '/MERGETASKS=!audiodriver'"
     say "     (Live 12: the flags let it install by itself and skip a Windows-only driver;"
     say "      Live 11: drop them and click through its installer window instead)"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Remove what install.sh added. The Wine prefix (~/.wine-ableton) is kept unless you pass --prefix.
 set -euo pipefail
-OPT="$HOME/.local/opt/wine-d2d1-nspa-11.13"
+# Matches install.sh: ABLETON_WINE_ROOT picks a non-default runtime to remove.
+OPT="${ABLETON_WINE_ROOT:-$HOME/.local/opt/wine-d2d1-nspa-11.13}"
 BIN="$HOME/.local/bin/ableton-live"
 APPS="$HOME/.local/share/applications"
 


### PR DESCRIPTION
## Resolve the runtime tarball and the install root the same way everywhere

**Stage 2 of 5** — runtime layout migration. Each stage is its own branch and its own pull request.

| | Stage | Depends on |
| --- | --- | --- |
| 1 | `source-commit` in BUILD-INFO | nothing |
| **2** | **Shared path resolver (#136)** ← this one | nothing |
| 3 | Test suite and `ci-checks` | 2 |
| 4 | Nightly builds, published | 2 |
| 5 | Runtime moves to a version store | **1 and 2** |

Every other stage needs this one, and it stands alone as a bug fix regardless of the rest.

## Two defects, both in path resolution

**The installer could install a runtime that cannot start.** `install.sh` picked its tarball with `ls | sort -V | tail -1`. `sort -V` orders `wine-d2d1-nspa-11.13-<ver>-debug.tar.zst` *after* the release it belongs to, so whenever a debug build was present the installer chose it. That tree has `bin/` and `lib/` but no `share/`: it passes `wine --version`, then fails at launch with "could not exec the wine loader". The same resolution had been copied into `make-installer.sh` and `build-audit.sh`, and CI calls the latter with no argument — so a release could be assembled, and audited, from whatever `sort -V` left last.

Reachable two ways: a `KEEP_DEBUG=1` build emits that artifact beside the runtime tarball, and an interrupted download leaves a `.tar.zst.part` that sorts the same way.

**The `.run` wrapper and `install.sh` disagreed about where things go.** `install.sh` had started honouring `ABLETON_WINE_ROOT` while the wrapper hardcoded `$HOME/.local/opt/$RUNTIME_NAME` in five places and `$HOME/.wine-ableton` in three more. With either variable set, the wrapper installed the runtime to one root and then ran Live's own installer against another.

## What changed

New `scripts/runtime-env.sh` holds the two functions everything now shares:

- `ableton_runtime_name` — the runtime directory and tarball basename
- `ableton_pick_tarball` — matches `<name>-<dated-version>.tar.zst` exactly, so `-debug`, `.part` and any other suffixed variant are ignored rather than sorted, then takes the newest by `sort -V`

The glob deliberately cannot be the selector: matching the dated release form is what makes a suffixed variant unselectable rather than merely unlucky in sort order.

`install.sh`, `make-installer.sh` and `build-audit.sh` call it instead of carrying their own copy, and `make-installer.sh` stages it into the kit so the extracted installer has it too — without that the first `.run` built was dead on arrival.

Every runtime reference in `install.sh`, `uninstall.sh` and `setup-run-header.sh` resolves through a single `WINE_ROOT`, defaulting to `$HOME/.local/opt/$RUNTIME_NAME` exactly as before. `ABLETON_RUNTIME_TARBALL` pins a tarball outright when you need to name one.

## Behaviour

Unchanged for anyone not setting the new variables — same default install root, same tarball chosen whenever the exact-version file is present.

Two things become possible that were not: the installer can be pointed at a specific runtime, and the install root can be relocated. Both matter as soon as two runtimes have to coexist on one machine.

## Testing

Selector, against real artifacts with a higher-versioned decoy present:

```text
wine-d2d1-nspa-11.13-2026.07.29.1.tar.zst
wine-d2d1-nspa-11.13-2026.08.04.1.tar.zst
wine-d2d1-nspa-11.13-2026.08.04.1-debug.tar.zst
wine-d2d1-nspa-11.13-2026.12.01.1.tar.zst.part
  -> picked: wine-d2d1-nspa-11.13-2026.08.04.1.tar.zst
```

`make-installer.sh`'s fallback branch tested separately by hiding the exact-version match with a higher-versioned `-debug` decoy in `dist/`; it selected the correct older release.

On clean Fedora 42 and Ubuntu 24.04 VMs, against a `.run` built from this branch:

| | Fedora | Ubuntu |
| --- | --- | --- |
| `scripts/install.sh` | pass | pass |
| `.run` fresh install, incl. Live's own installer | rc 0 | rc 0 |
| `--update`, Live and authorization preserved | rc 0 | — |
| `--uninstall`, prefix and Live kept | rc 0 | — |

Live 12 Suite installs and launches. The runtime binaries were the published v2026.08.04.1 build, so the results isolate to the shell changes here.

PR #120's process guard was exercised incidentally and behaved correctly, including against `ABLE~OCJ.EXE` — a mangled 8.3 name no `pgrep -f` pattern reaches, which is the case `/proc/PID/exe` detection exists for.

## Not covered

`--uninstall --prefix`, interactive mode with a controlling terminal, and `--update`/`--uninstall` on Ubuntu. No automated test executes `install.sh`; everything above was driven by hand. A bats suite covering the selector and the resolvers is prepared as stage 3.
