### PR TITLE
fix(launcher): terminate lingering wineserver process when main window closes

### DIFF
--- a/scripts/ableton-live
+++ b/scripts/ableton-live
@@ -736,9 +736,16 @@ if [ -n "$EXE" ] && [ -f "$learnheal" ]; then
     disown
 fi
 
+cleanup_wineserver() {
+    local rc=$1
+    "$WINESERVER" -k 2>/dev/null || true
+    exit "$rc"
+}
+
 if [ -n "${ABLETON_VDESK:-}" ]; then
     require_live
-    exec "${run[@]}" explorer "/desktop=AbletonLive,${ABLETON_VDESK}" "$EXE"
+    "${run[@]}" explorer "/desktop=AbletonLive,${ABLETON_VDESK}" "$EXE"
+    cleanup_wineserver $?
 elif [ "$#" -gt 0 ]; then
     # ableton:// URLs, .auz license files, Live documents from the file
     # manager or command line. A single existing file arrives as a unix path
@@ -752,14 +759,22 @@ elif [ "$#" -gt 0 ]; then
                 require_live
                 doc="$(winepath -w "$1" 2>/dev/null || true)"
                 if [ -n "$doc" ]; then
-                    exec "${run[@]}" "$EXE" "$doc"
+                    "${run[@]}" "$EXE" "$doc"
+                    cleanup_wineserver $?
                 fi
                 ;;
         esac
-        case "$1" in /*) exec "${run[@]}" start /unix "$1" ;; esac
+        case "$1" in /*)
+            "${run[@]}" start /unix "$1"
+            cleanup_wineserver $?
+            ;;
+        esac
     fi
-    exec "${run[@]}" start "$@"
+    "${run[@]}" start "$@"
+    cleanup_wineserver $?
 else
     require_live
-    exec "${run[@]}" "$EXE"
+    "${run[@]}" "$EXE"
+    cleanup_wineserver $?
 fi
+

--- a/scripts/max9
+++ b/scripts/max9
@@ -47,4 +47,8 @@ if [ -x "$LINKD" ] && ! pgrep -x ableton-linkd >/dev/null 2>&1; then
     "$LINKD" --daemon || echo "max9: ableton-linkd failed to start" >&2
 fi
 
-exec "${run[@]}" "$MAX_EXE" ${args[@]+"${args[@]}"}
+"${run[@]}" "$MAX_EXE" ${args[@]+"${args[@]}"}
+rc=$?
+"$WINESERVER" -k 2>/dev/null || true
+exit $rc
+


### PR DESCRIPTION
### Problem
When closing the main Ableton Live window (or standalone Max 9), the Wine process terminates, but a residual `wineserver` daemon process frequently remains active in the background for the `$WINEPREFIX`.

### Proposed Fix
While modifying the desktop entry (`Exec=bash -c "~/.local/bin/ableton-live; WINEPREFIX=~/.wine-ableton wineserver -k"`) works as a workaround for desktop menu shortcuts, implementing the cleanup directly within `scripts/ableton-live` and `scripts/max9` provides a complete, robust fix:

1. **Launcher-level Cleanup**: Instead of `exec` replacing the shell process, the launchers now run `wine`, wait for process exit, and invoke `"$WINESERVER" -k 2>/dev/null || true` before exiting with wine's return code.
2. **Universal Coverage**: Works seamlessly whether Ableton Live is launched from the desktop menu (`.desktop`), terminal, custom DAW scripts, or external launchers.
3. **Environment Aware**: Automatically uses the launcher's `$WINEPREFIX` and `$WINESERVER` (`$WINE_ROOT/bin/wineserver`), avoiding hardcoded prefix paths or global binary assumptions.

### Verification
- Tested syntax with `bash -n scripts/ableton-live` and `bash -n scripts/max9`.
- Verified exit code forwarding and cleanup execution flow upon process exit.


AI disclosure: Used ai for translation and debugging but the proposal is mine and already tested on Live. 