### PR TITLE
Stop new windows starting black (patch 0091)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- New windows and newly exposed areas no longer start black. Plugin
+  popups with transparency keep a clean first frame. If a window now
+  flashes white where it did not before, launch with
+  `env WINE_SURFACE_INIT=black ableton-live` and report it.
+
 - Window problems are now easier to report. Launching with
   `env ABLETON_WM_TRACE=1 ableton-live` logs every window change that
   Live and the desktop exchange, and `tools/wm-capture.sh` records how

--- a/patches/0091-win32u-init-window-surfaces-white-transparent-only-f.patch
+++ b/patches/0091-win32u-init-window-surfaces-white-transparent-only-f.patch
@@ -1,0 +1,71 @@
+Subject: win32u: init window surfaces white, transparent only for layered ARGB
+
+The base filled every fresh window surface with 0x00. A 32-bit layered
+popup reads that as ARGB(0,0,0,0), fully transparent, which is the
+correct first frame for dark-themed DComp/JUCE dropshadow popups
+(giang17/wine 53d78989 and 44278e2b document the trade-off). Every
+other window reads 0x00 as opaque black: the floating black squares
+and black newly-exposed regions.
+
+Fill 0xff as vanilla Wine does, and keep 0x00 only when the surface is
+32 bpp and the window is WS_EX_LAYERED. WINE_SURFACE_INIT=black
+restores the old unconditional fill, =white forces vanilla everywhere.
+The 0090 SURFACE-CREATE trace line reports the chosen fill for A/B
+evidence.
+
+diff --git a/dlls/win32u/dce.c b/dlls/win32u/dce.c
+index 8962d9a..8442967 100644
+--- a/dlls/win32u/dce.c
++++ b/dlls/win32u/dce.c
+@@ -555,10 +555,36 @@ static void *window_surface_get_color( struct window_surface *surface, BITMAPINF
+     return gdi_bits.ptr;
+ }
+ 
++/* Initial fill for a fresh window surface.  Vanilla Wine uses 0xff (opaque
++ * white).  A 32-bit layered window reads 0x00 as ARGB(0,0,0,0), fully
++ * transparent, so its first frame shows nothing instead of a stale white
++ * flash (dark-themed DComp/JUCE dropshadow popups); every other window
++ * keeps vanilla white instead of showing black.  WINE_SURFACE_INIT=black
++ * restores the old unconditional 0x00 for comparison, =white forces
++ * vanilla everywhere. */
++static BYTE window_surface_init_color( HWND hwnd, const BITMAPINFO *info )
++{
++    static int mode = -1;
++
++    if (mode == -1)
++    {
++        const char *env = getenv( "WINE_SURFACE_INIT" );
++        if (env && !strcmp( env, "black" )) mode = 0;
++        else if (env && !strcmp( env, "white" )) mode = 1;
++        else mode = 2;
++    }
++    if (mode == 0) return 0x00;
++    if (mode == 1) return 0xff;
++    if (info->bmiHeader.biBitCount == 32 && (get_window_long( hwnd, GWL_EXSTYLE ) & WS_EX_LAYERED))
++        return 0x00;
++    return 0xff;
++}
++
+ struct window_surface *window_surface_create( UINT size, const struct window_surface_funcs *funcs, HWND hwnd,
+                                               const RECT *rect, BITMAPINFO *info, HBITMAP bitmap )
+ {
+     struct window_surface *surface;
++    BYTE init_color;
+ 
+     if (!(surface = calloc( 1, size ))) return NULL;
+     surface->funcs = funcs;
+@@ -579,10 +605,12 @@ struct window_surface *window_surface_create( UINT size, const struct window_sur
+ 
+     pthread_mutex_init( &surface->mutex, NULL );
+ 
+-    memset( window_surface_get_color( surface, info ), 0x00, info->bmiHeader.biSizeImage );
++    init_color = window_surface_init_color( hwnd, info );
++    memset( window_surface_get_color( surface, info ), init_color, info->bmiHeader.biSizeImage );
+ 
+     TRACE( "created surface %p for hwnd %p rect %s\n", surface, hwnd, wine_dbgstr_rect( &surface->rect ) );
+-    TRACE_(wmtrace)( "SURFACE-CREATE hwnd=%p surface=%p rect=%s\n", hwnd, surface, wine_dbgstr_rect( &surface->rect ) );
++    TRACE_(wmtrace)( "SURFACE-CREATE hwnd=%p surface=%p rect=%s init=%02x\n", hwnd, surface,
++                     wine_dbgstr_rect( &surface->rect ), init_color );
+     return surface;
+ }
+ 

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -11,7 +11,7 @@ narrative — 5 merge conflicts, three build breaks the clean rebase didn't
 catch, a build.sh/pipefail tooling gotcha — is in
 `notes/ABLETON-WINE-11.11-TO-11.13-BASE-BUMP.md`.
 
-The current Wine series contains 82 files, numbered 0001 through 0090.
+The current Wine series contains 83 files, numbered 0001 through 0091.
 Patches 0027 and 0044 are intentionally absent. Numbers 0066 through 0068
 and 0072 through 0074 are reserved by open pull requests and will enter this
 branch as those merge.
@@ -381,3 +381,14 @@ Apply them in sequence with the rest of the series.
   `WINEDEBUG=-all,+wmtrace,+winediag`, or `ABLETON_WM_TRACE=1` through
   the launcher; `tools/wm-capture.sh` records the matching host-side
   view.
+- `0091`: initialise fresh window surfaces white, as vanilla Wine does,
+  and keep the transparent 0x00 fill only for 32-bit layered windows,
+  where it gives a fully transparent first frame instead of a stale
+  white flash (dark-themed DComp/JUCE dropshadow popups). The base
+  filled every surface with 0x00, which reads as black on ordinary
+  windows: the floating black squares and black newly-exposed regions.
+  `WINE_SURFACE_INIT=black` restores the old fill; `=white` forces
+  vanilla everywhere. The 0090 SURFACE-CREATE trace line reports the
+  chosen fill. Adapted from `giang17/wine` `53d78989` and `44278e2b`.
+  Their shipped diff is an unconditional 0x00; this patch limits their
+  per-pixel-alpha rationale to the windows it actually describes.

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -80,5 +80,6 @@ ee36bbf26e5ea22b8d6ecd5344cb72fc7883ac59ed733661dfb4e73f773fc18f  0087-win32u-re
 efec6729f1663efe78c7efa941b826b2a28d219bf6faa974294a3bfa854b84f5  0088-win32u-allow-a-semantic-desktop-UI-stock-font.patch
 10d34c085b2a1b554457524978e8a380d3c15aaafd290657e5ef8ca9874221c2  0089-d2d1-avoid-unsigned-ClearType-coverage-underflow.patch
 d15fbf9a1bb079e972135c252642b2e10029125a67ff52f3584ff063045f2807  0090-winex11-win32u-dxgi-add-a-compact-wmtrace-state-tran.patch
+b885814c8533d8eca4c714288a6516960fdc7543e7f13fae626f1e7b2b8ed4f8  0091-win32u-init-window-surfaces-white-transparent-only-f.patch
 b2d30d77078263b8141199195ea16b0e6df7eac04b939b9e56cd53552cfb9175  pipeasio/0001-asio-keep-graph-sample-rate-instead-of-ASE_NoClock.patch
 f25d5b4c3ee71b7e9491f91c462e2b7ddaca377b8b94c7bd95df7734f0a4b563  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/scripts/ableton-live
+++ b/scripts/ableton-live
@@ -13,6 +13,8 @@
 #            WINE_X11_FORCE_OFFSCREEN_CLASS=off (disable the M4L selection-flicker fix),
 #            WINE_WIN32_FULLSCREEN_CLASS=off (disable Live fullscreen normalization),
 #            WINE_WIN32_RESIZABLE_CLASS=off (disable the monitor-sized resizability fix),
+#            WINE_SURFACE_INIT=black (restore the old black window-surface fill;
+#              =white forces vanilla white everywhere),
 #            ABLETON_WM_TRACE=1 (log every window-state transition on the wmtrace
 #              channel for window-management reports; pair with tools/wm-capture.sh).
 set -u

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -156,6 +156,7 @@ FINGERPRINTS='
 0090|ascii|lib/wine/x86_64-unix/winex11.so|REQ-WMSTATE hwnd=
 0090|ascii|lib/wine/x86_64-unix/win32u.so|SURFACE-CREATE hwnd=
 0090|ascii|lib/wine/x86_64-windows/dxgi.dll|PRESENT-PATH hwnd=
+0091|ascii|lib/wine/x86_64-unix/win32u.so|WINE_SURFACE_INIT
 pipeasio/0001|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-clamp-sample-rate
 pipeasio/0002|ascii|lib/wine/x86_64-unix/pipeasio64.dll.so|pipeasio-midi-timebase
 '


### PR DESCRIPTION
The Wine base fills every fresh window surface with 0x00, which reads as black on ordinary windows: the floating black squares and the black newly-exposed regions from the graphics review. Patch 0091 fills vanilla white instead and keeps the transparent fill only for 32-bit layered windows, whose dropshadow popups need a transparent first frame. giang17/wine went 0x00 -> 0xff -> 0x00 on this line (53d78989, 44278e2b); their shipped diff is an unconditional 0x00, and this patch limits their per-pixel-alpha rationale to the windows it actually describes.

A/B: `env WINE_SURFACE_INIT=black ableton-live` restores the old fill, `=white` forces vanilla everywhere. The SURFACE-CREATE line of the wmtrace channel (patch 0090) reports the chosen fill per surface.

Verified so far: the patch applies through container-build's git am path with an identical tree, and win32u compiles clean in the build container with no warnings. Runtime verification on the matrix is open: Live dropdowns, WebView2 panes (Learn View, Splice) and plugin dropshadow popups need a look under each fill mode.

Stacked on gfx/trace (patch 0090, the wmtrace channel); this PR targets that branch and merges after it.