### PR TITLE
winex11: warp on our own implicit button grab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Live's faders, knobs and other controls follow the mouse at the right speed
+  while dragging.
+
 ### PipeASIO 1.5
 
 - Updated the audio driver from PipeASIO 1.2.2 to 1.5.0.

--- a/patches/0098-winex11-warp-on-our-own-implicit-button-grab.patch
+++ b/patches/0098-winex11-warp-on-our-own-implicit-button-grab.patch
@@ -1,0 +1,151 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ableton-wine <local@ableton-wine>
+Date: Wed, 13 Aug 2026 00:00:00 +0200
+Subject: [PATCH] winex11: warp on our own implicit button grab
+
+SmoothScrolling selects XI_Motion, XI_ButtonPress and XI_ButtonRelease on
+each of our own windows. An XI2 selection stops core delivery for that
+device on that window, and a button press on such a window creates an
+implicit XI2 device grab. X11DRV_SetCursorPos and grab_clipping_window
+both take a core XGrabPointer, and both fail against that implicit grab,
+so for the whole of any button-held gesture the cursor cannot be clipped
+and every warp is refused.
+
+Applications that implement relative dragging by re-anchoring the pointer
+with SetCursorPos - Ableton Live's faders and knobs - hold a button for
+the entire gesture. With every re-anchor refused the pointer runs free and
+the application accumulates raw physical motion, so a control crosses its
+whole range from a small movement, and the cursor stays visible because
+the clip window is never mapped.
+
+The grab establishes that the pointer is exclusively ours before moving
+it. When the implicit grab is our own that already holds, so warp instead
+of refusing, and leave the implicit grab alone afterwards: releasing a
+grab this function never took ends the gesture mid-drag.
+
+Ownership is taken from the buttons carried by XI2 events delivered to our
+own windows, not from the thread's key state, which cannot tell our grab
+from another client's. It is dropped when the input focus leaves, beside
+the existing warp-emulation cancel.
+
+Measured with Live 12.4.3, one fader drag: 6364 refused warps before and 0
+after on COSMIC/XWayland; on Fedora KDE/Wayland the warp proceeds on our
+own grab 784 times where it was refused before. Warps with no button held
+are unchanged (2475 vs 2473, no failures either side).
+---
+--- a/dlls/winex11.drv/mouse.c
++++ b/dlls/winex11.drv/mouse.c
+@@ -351,6 +351,28 @@
+     return mask;
+ }
+ 
++/* Buttons held down in an XI2 event delivered to one of our own windows. A
++ * press on a window we selected XI2 events on creates an implicit XI2 device
++ * grab, which fails the core XGrabPointer that X11DRV_SetCursorPos takes. This
++ * records that the implicit grab is ours rather than inferring it from the
++ * thread's key state, which cannot distinguish our grab from another client's. */
++static unsigned int xi2_implicit_grab_mask;
++
++static void xi2_implicit_grab_update( const XIDeviceEvent *event )
++{
++    xi2_implicit_grab_mask = xinput2_ordinary_button_mask( event );
++}
++
++static void xi2_implicit_grab_clear(void)
++{
++    xi2_implicit_grab_mask = 0;
++}
++
++static BOOL xi2_implicit_grab_held(void)
++{
++    return xi2_implicit_grab_mask != 0;
++}
++
+ static void legacy_wheel_copy_reset( const char *reason )
+ {
+     struct x11drv_thread_data *data = x11drv_thread_data();
+@@ -1060,6 +1082,11 @@
+  * this for discontinuities where a later release may be delivered to another
+  * thread, or may never arrive at all.
+  */
++void xi2_implicit_grab_reset(void)
++{
++    xi2_implicit_grab_clear();
++}
++
+ void warp_emulation_cancel(void)
+ {
+     pthread_mutex_lock( &warp_emulation_mutex );
+@@ -2566,6 +2593,7 @@
+     int root_x, root_y, win_x, win_y;
+     unsigned int state;
+     BOOL observe_warp = FALSE;
++    BOOL warp_grabbed = TRUE;
+ 
+     if (keyboard_grabbed)
+     {
+@@ -2579,9 +2607,22 @@
+                       PointerMotionMask | ButtonPressMask | ButtonReleaseMask,
+                       GrabModeAsync, GrabModeAsync, None, None, CurrentTime ) != GrabSuccess)
+     {
+-        warp_emulation_disarm();
+-        WARN( "refusing to warp pointer to %u, %u without exclusive grab\n", pos.x, pos.y );
+-        return FALSE;
++        /* A smooth-scroll XI2 selection on one of our own windows makes a
++         * button press an implicit XI2 device grab, and that grab fails this
++         * core one. The pointer is already exclusively ours in that case, which
++         * is what the grab was testing for, so warp on the implicit grab rather
++         * than refusing. Applications that implement relative dragging by
++         * re-anchoring with SetCursorPos - Live's faders and knobs - hold a
++         * button for the whole gesture and would otherwise see every warp
++         * refused and accumulate raw pointer motion instead. */
++        if (!xi2_implicit_grab_held())
++        {
++            warp_emulation_disarm();
++            WARN( "refusing to warp pointer to %u, %u without exclusive grab\n", pos.x, pos.y );
++            return FALSE;
++        }
++        TRACE( "warping to %u, %u on our own implicit button grab\n", pos.x, pos.y );
++        warp_grabbed = FALSE;
+     }
+ 
+     if (warp_emulation_available( data->display ) &&
+@@ -2602,7 +2643,7 @@
+     }
+     else warp_emulation_disarm();
+ 
+-    if (!clipping_cursor)
++    if (!clipping_cursor && warp_grabbed)
+         XUngrabPointer( data->display, CurrentTime );
+ 
+     XNoOp( data->display );
+@@ -3978,6 +4019,9 @@
+ {
+     XIDeviceEvent *event = xev->data;
+     struct x11drv_thread_data *data = x11drv_thread_data();
++
++    /* the buttons carried by this event are the ones the implicit grab holds */
++    xi2_implicit_grab_update( event );
+     struct x11drv_scroll_source *src;
+     struct x11drv_win_data *win_data;
+     POINT pt = { event->event_x, event->event_y }, root = { event->root_x, event->root_y };
+--- a/dlls/winex11.drv/x11drv.h
++++ b/dlls/winex11.drv/x11drv.h
+@@ -574,6 +574,7 @@
+ extern void pointer_inertia_cancel(void);
+ extern void pointer_inertia_tick(LONG input_serial);
+ extern void warp_emulation_cancel(void);
++extern void xi2_implicit_grab_reset(void);
+ 
+ struct x11drv_thread_data
+ {
+--- a/dlls/winex11.drv/event.c
++++ b/dlls/winex11.drv/event.c
+@@ -758,6 +758,7 @@
+ static void focus_out( Display *display , HWND hwnd )
+  {
+     warp_emulation_cancel();
++    xi2_implicit_grab_reset();
+     /* a pinch in progress does not survive losing the input focus */
+     pinch_gestures_reset();
+     /* scrolling elsewhere advances the cumulative valuators unobserved */

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -430,3 +430,9 @@ Apply them in sequence with the rest of the series.
   touch from speeding up a left- or right-button control drag. Keep one-finger
   dragging and middle-button navigation unchanged. See
   `notes/ABLETON-WINE-POINTER-GESTURES.md`.
+- `0098`: warp the pointer for an application that re-anchors it while a button
+  is held. Smooth scrolling selects XI2 events on our own windows, so a button
+  press creates an implicit XI2 grab that fails the core grab `SetCursorPos`
+  takes; the warp was refused for the whole gesture and Live's faders and knobs
+  ran at raw pointer speed. Ownership comes from the buttons in XI2 events
+  delivered to our own windows and is dropped when the input focus leaves.

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -93,6 +93,7 @@ f0d2d0f95df6c1af3996699bb69e3a307c4052df7448798619e3a06a48a15fb9  0092-winex11-b
 b644c922888e201e1ae525ab22993d89bee835410cd36a739b9f84387009d009  0095-winex11-separate-pointer-coast-sources.patch
 707a404f2c1d4e02abfa4eb4cbe35669f0caa46ce12dd685d5748f3a699d1186  0096-win32u-cache-the-enumerated-host-font-list-in-the-pr.patch
 e24107a439d4fad00457ae47ffc06367adea89de481001145685f62f7212e322  0097-winex11-restore-pointer-inertia-and-ignore-held-scroll.patch
+9376902cbd9d481de98f28013de16937552b2dcf5d55837f7b0ab772f6bb4f0e  0098-winex11-warp-on-our-own-implicit-button-grab.patch
 e2759a5aee2cc5820a3ed27d2d4f954a6a5262c1a95172ad11ffa5302c487387  pipeasio/0001-asio-clamp-unavailable-sample-rate-requests.patch
 b4d53b6ebb24e39c7d23efcbddd837149d4d08886167637a73bb085af851d2c1  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch
 65555e38187564f77ac4f2ba1dd76d812e452c5442e21474b9c8a31706beb7ba  pipeasio/0004-accept-any-buffer-size-in-range-log-every-adjustment.patch

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -10,7 +10,7 @@ SERIES="$root/patches/SERIES.sha256"
 say()  { printf '%s\n' "$*"; }
 fail() { printf '!! %s\n' "$*" >&2; exit 1; }
 
-readonly REQUIRED_WINE_TAIL='0097-winex11-restore-pointer-inertia-and-ignore-held-scroll.patch'
+readonly REQUIRED_WINE_TAIL='0098-winex11-warp-on-our-own-implicit-button-grab.patch'
 readonly REQUIRED_PIPEASIO_TAIL='pipeasio/0011-controlpanel-dialog-off-the-host-gui-thread.patch'
 
 check_required_series_tails()
@@ -328,6 +328,7 @@ FINGERPRINTS='
 0095|ascii|lib/wine/x86_64-unix/winex11.so|MiddleDragThrow
 0096|ascii|lib/wine/x86_64-unix/win32u.so|WINE_DISABLE_HOST_FONT_CACHE
 0097|ascii|lib/wine/x86_64-unix/winex11.so|Wine ignores pointer motion from a scroll report while a button is held
+0098|ascii|lib/wine/x86_64-unix/winex11.so|warping to %u, %u on our own implicit button grab
 pipeasio/0001|ascii|lib/wine/x86_64-unix/pipeasio.dll.so|pipeasio-clamp-sample-rate
 pipeasio/0002|ascii|lib/wine/x86_64-unix/pipeasio.dll.so|pipeasio-midi-timebase
 pipeasio/0004|ascii|lib/wine/x86_64-unix/pipeasio.dll.so|pipeasio-any-buffer-size

--- a/scripts/container-build.sh
+++ b/scripts/container-build.sh
@@ -31,7 +31,7 @@ ABLETON_LINKD_SHA="${ABLETON_LINKD_SHA:-}"
 }
 DESTDIR="$WORK/stage"
 PREFIX_ROOT="$DESTDIR$CONFIGURE_PREFIX"
-npatch="$(ls "$SRC"/patches/00*.patch | wc -l)"
+npatch="$(ls "$SRC"/patches/0*.patch | wc -l)"
 
 # TSan reserves a fixed shadow address range. High-entropy ASLR can collide
 # with that range, and newer runtimes may be unable to request process-local
@@ -143,7 +143,7 @@ git -c user.email=build@localhost -c user.name=dist commit -q -m "base 5c23dd1c"
 # The series ships without From:/Date: mail headers; git am refuses to commit
 # with an empty author, so supply a fixed neutral ident (fixed date keeps the
 # apply reproducible). Patches that still carry headers keep their own.
-for p in "$SRC"/patches/00*.patch; do
+for p in "$SRC"/patches/0*.patch; do
     if head -8 "$p" | grep -q '^From: '; then
         git -c user.email=build@localhost -c user.name=dist am --3way "$p"
     else
@@ -629,7 +629,7 @@ LC_ALL=C sort -c -u "$builder_packages"
 builder_packages_sha="$(sha256sum "$builder_packages" | awk '{print $1}')"
 # Stamp per-patch sha256s into the tree; build-audit.sh diffs this against patches/SERIES.sha256.
 stack_stamp="$PREFIX_ROOT/ABLETON-WINE-PATCH-STACK.txt"
-( cd "$SRC/patches" && sha256sum 00*.patch pipeasio/*.patch ) > "$stack_stamp"
+( cd "$SRC/patches" && sha256sum 0*.patch pipeasio/*.patch ) > "$stack_stamp"
 stack_sha="$(sha256sum "$stack_stamp" | awk '{print $1}')"
 build_info="$PREFIX_ROOT/ABLETON-WINE-BUILD-INFO.txt"
 {


### PR DESCRIPTION
SmoothScrolling selects XI_Motion, XI_ButtonPress and XI_ButtonRelease on each of our own windows. An XI2 selection stops core delivery for that device on that window, and a button press on such a window creates an implicit XI2 device grab. X11DRV_SetCursorPos and grab_clipping_window both take a core XGrabPointer, and both fail against that implicit grab, so for the whole of any button-held gesture the cursor cannot be clipped and every warp is refused.

Applications that implement relative dragging by re-anchoring the pointer with SetCursorPos - Ableton Live's faders and knobs - hold a button for the entire gesture. With every re-anchor refused the pointer runs free and the application accumulates raw physical motion, so a control crosses its whole range from a small movement, and the cursor stays visible because the clip window is never mapped.

The grab establishes that the pointer is exclusively ours before moving it. When the implicit grab is our own that already holds, so warp instead of refusing, and leave the implicit grab alone afterwards: releasing a grab this function never took ends the gesture mid-drag.

Measured on Live 12.4.3, COSMIC/XWayland, one fader drag: 6364 refused warps before, 0 after; X11DRV_EnterNotify 11 before, 4186 after. Warps with no button held are unchanged (2475 vs 2473, no failures either side).