### PR TITLE
tests: stop the release-policy gate breaking on every new patch

### DIFF
--- a/.github/workflows/ci-pr-build.yml
+++ b/.github/workflows/ci-pr-build.yml
@@ -120,10 +120,13 @@ jobs:
             [ ! -e "$path" ] || sudo chown -R "$owner" "$path"
           done
 
+      # xdg-utils, desktop-file-utils and shared-mime-info carry xdg-mime,
+      # update-desktop-database and update-mime-database, which install.sh
+      # requires before it will plan or apply the integration component.
       - name: Install installer test requirements
         run: |
           sudo apt-get update
-          sudo apt-get install --yes cabextract
+          sudo apt-get install --yes cabextract xdg-utils desktop-file-utils shared-mime-info
 
       - name: Test installer and launcher lifecycle
         run: make test

--- a/scripts/test-installer-lifecycle.sh
+++ b/scripts/test-installer-lifecycle.sh
@@ -3,8 +3,23 @@ set -euo pipefail
 here="$(cd "$(dirname "$0")" && pwd)"
 root="$(cd "$here/.." && pwd)"
 work="$(mktemp -d "${TMPDIR:-/tmp}/ableton-installer-test.XXXXXX")"
+# Checks that expect an installer run to succeed redirect its diagnostics into
+# the per-case log, so set -e ends the suite on an unexpected non-zero exit
+# with no failure line, leaving make's exit code as the only evidence.  Report
+# the case and replay what the run wrote.  The shell can exit while the failing
+# command's redirections are still applied, so this reports on a saved copy of
+# the suite's own stderr rather than into the log it is replaying.
+exec {suite_stderr}>&2
+reported=0
 cleanup()
 {
+    local code=$?
+    if [ "$code" -ne 0 ] && [ "$reported" -eq 0 ]; then
+        [ -z "${base:-}" ] || [ ! -s "$base/err" ] \
+            || sed -n '1,40p' "$base/err" >&"$suite_stderr"
+        printf 'not ok - a command exited %d unexpectedly in %s\n' \
+            "$code" "$(basename "${base:-unknown-case}")" >&"$suite_stderr"
+    fi
     [ "${ABLETON_KEEP_TEST_WORK:-0}" -eq 0 ] || { printf 'kept test work: %s\n' "$work" >&2; return; }
     rm -rf -- "$work"
 }
@@ -19,6 +34,7 @@ ok()
 
 fail()
 {
+    reported=1
     printf 'not ok - %s\n' "$1" >&2
     exit 1
 }

--- a/scripts/test-release-policy.sh
+++ b/scripts/test-release-policy.sh
@@ -223,7 +223,7 @@ grep -qF -- '--runtime "wine-d2d1-nspa-11.13-$ver.tar.zst" \' \
 grep -qF -- '--installer "ableton-wine-setup-$ver.run"' \
     "$root/.github/workflows/release.yml" \
     || fail 'published-asset verification omits the installer wrapper'
-if rg -q 'sh .*ableton-wine-setup.*\.run.*extract' "$root/.github/workflows/release.yml"; then
+if grep -qE 'sh .*ableton-wine-setup.*\.run.*extract' "$root/.github/workflows/release.yml"; then
     fail 'published-asset verification executes the untrusted installer candidate'
 fi
 grep -qF './scripts/make-installer.sh' "$root/scripts/release.sh" \

--- a/scripts/test-release-policy.sh
+++ b/scripts/test-release-policy.sh
@@ -264,13 +264,19 @@ series="$root/patches/SERIES.sha256"
 bash "$series_checker" --check-series-policy "$series" >/dev/null \
     || fail 'complete patch series failed its terminal-member policy'
 
-grep -v '  0096-win32u-cache-the-enumerated-host-font-list-in-the-pr.patch$' \
+# Read the terminal members off the manifest rather than naming them: the
+# policy pins whichever patch currently ends each series, so a hardcoded name
+# turns into a failing negative test the next time either series grows.
+wine_tail="$(awk '$2 !~ /^pipeasio\// { print $2 }' "$series" | sort | tail -1)"
+pipeasio_tail="$(awk '$2 ~ /^pipeasio\// { print $2 }' "$series" | sort | tail -1)"
+
+grep -v "  $wine_tail\$" \
     "$series" > "$tmp/no-wine-tail"
 if bash "$series_checker" --check-series-policy "$tmp/no-wine-tail" >/dev/null 2>&1; then
     fail 'series policy accepted a missing final Wine patch'
 fi
 
-grep -v '  pipeasio/0011-controlpanel-dialog-off-the-host-gui-thread.patch$' \
+grep -v "  $pipeasio_tail\$" \
     "$series" > "$tmp/no-pipeasio-tail"
 if bash "$series_checker" --check-series-policy "$tmp/no-pipeasio-tail" >/dev/null 2>&1; then
     fail 'series policy accepted a missing final PipeASIO patch'


### PR DESCRIPTION
`make test` has not completed on `main` since #187. Three independent breakages are stacked, each hiding the next; this fixes all three, plus the reporting gap that made the third one invisible.

**1. The negative series tests named their patches.** `test-release-policy.sh` strips each series' terminal patch and requires `build-audit.sh --check-series-policy` to reject the result. Both names were spelled out, and the Wine one still named `0096-win32u-cache-…` after #188 moved `REQUIRED_WINE_TAIL` to `0097-winex11-restore-pointer-inertia-…`. Stripping 0096 leaves 0097 as the tail, the policy passes, and the test's own `fail` fires. It would break again on the next patch past either tail. Both names now come off `SERIES.sha256` using the same `awk` split `build-audit.sh` uses.

**2. One guard ran under a tool the runner doesn't have.** The check that rejects a release workflow which executes the untrusted installer candidate was `if rg -q …`. `rg` isn't installed on the GitHub runner, and the enclosing `if` swallowed the 127, so the check has never fired there — the log shows `rg: command not found` immediately before a green tick. `grep -E` reads the same pattern.

**3. The runner has no desktop or MIME tooling.** `install.sh` refuses to plan or apply the integration component without `xdg-mime`, `update-desktop-database` and `update-mime-database`; the test-requirements step installed only `cabextract`. Every full-install dry run in `test-installer-lifecycle.sh` failed from the moment that requirement landed in `12af77f` (#170) — only the runtime-only cases, which skip integration, kept passing. #170's own CI died on `.ccache` before reaching `make test`, so it merged red-masked.

**4. That third failure was silent.** Cases expecting a run to succeed send diagnostics to the per-case log and don't check the exit status, so `set -e` ended the suite with no failure line — the CI log jumped from `ok - runtime-only rejects unrelated Link options before mutation` straight to `make: *** Error 1`. The EXIT trap now names the case and replays its log. It reports on a saved copy of the suite's stderr, because the shell can exit while the failing command's redirections are still applied — writing to `&2` there lands inside the very log being replayed.

Verified locally on this branch:

- full `make test`: exit 0, 174 checks, no `not ok`
- `test-installer-lifecycle.sh` with `xdg-mime`, `update-desktop-database` and `update-mime-database` hidden from `PATH`, reproducing the runner: fails with `not ok - a command exited 1 unexpectedly in compat-plan` and the installer's own `!! xdg-mime is required for desktop and MIME integration` above it
- the existing `fail` paths still report once, not twice

Running `make test` needs a built `dist/`; I staged one from another worktree. Two things left alone: the committed `dist/BUILD-INFO*.txt` on `main` records `patches: 104 / wine-patches: 95` against an actual 105/96, and a source-only checkout still can't run `make test` at all.