### PR TITLE
Default SmoothScrolling to disabled

### DIFF
--- a/notes/ABLETON-WINE-POINTER-GESTURES.md
+++ b/notes/ABLETON-WINE-POINTER-GESTURES.md
@@ -6,7 +6,7 @@ Wine uses 120 units for one wheel step.
 
 By default, Live provides:
 
-- smooth vertical and horizontal scrolling;
+- whole-notch vertical and horizontal scrolling;
 - pinch zoom;
 - middle-button drag navigation;
 - scrolling inertia after a quick release;
@@ -18,6 +18,18 @@ By default, Live provides:
 middle-button movement after release. Turning either one off leaves direct
 scrolling and direct middle-button navigation unchanged.
 
+`SmoothScrolling` defaults to `disabled` because any other value selects
+XI2 motion and button events on our own windows. That selection stops core
+event delivery for the device on those windows, and a button press then
+creates an implicit XI2 device grab. `X11DRV_SetCursorPos` and
+`grab_clipping_window` both take a core `XGrabPointer`, which fails against
+that grab, so while a button is held every warp is refused and cursor
+clipping is never established. Live drags a fader by re-anchoring the
+pointer with `SetCursorPos`, so each refused re-anchor leaves it
+accumulating raw physical motion and the control crosses its whole range
+from a small movement. Setting `precise` or `notched` restores fractional
+scrolling and reintroduces this.
+
 The XWayland correction for faders and knobs defaults to `disabled`.
 KDE/XWayland, GNOME/XWayland and Xorg checks remain open.
 
@@ -25,7 +37,7 @@ KDE/XWayland, GNOME/XWayland and Xorg checks remain open.
 
 | Setting | Launch variable | Default | Choices |
 | --- | --- | --- | --- |
-| `SmoothScrolling` | `WINE_X11_SMOOTH_SCROLLING` | `precise` | `disabled`, `precise`, `notched` |
+| `SmoothScrolling` | `WINE_X11_SMOOTH_SCROLLING` | `disabled` | `disabled`, `precise`, `notched` |
 | `TouchpadInertia` | `WINE_X11_TOUCHPAD_INERTIA` | `enabled` | `disabled`, `auto`, `enabled` |
 | `PinchZoom` | `WINE_X11_PINCH_ZOOM` | `legacy-wheel` | `disabled`, `legacy-wheel` |
 | `MiddleDrag` | `WINE_X11_MIDDLE_DRAG` | `navigate` | `disabled`, `navigate`, `navigate-notched` |

--- a/patches/0072-winex11-registry-pointer-settings-and-middle-button-dra.patch
+++ b/patches/0072-winex11-registry-pointer-settings-and-middle-button-dra.patch
@@ -388,7 +388,7 @@ index 500a013..f0cc453 100644
 + * the registry nor the environment names a value */
 +struct x11drv_pointer_config pointer_config =
 +{
-+    .smooth_scrolling = POINTER_SCROLL_PRECISE,
++    .smooth_scrolling = POINTER_SCROLL_DISABLED,
 +    .touchpad_inertia = POINTER_INERTIA_ENABLED,
 +    .pinch_zoom       = POINTER_PINCH_LEGACY_WHEEL,
 +    .middle_drag      = POINTER_MIDDLE_DRAG_NAVIGATE,

--- a/patches/BASE.txt
+++ b/patches/BASE.txt
@@ -268,7 +268,11 @@ Apply them in sequence with the rest of the series.
   swapchain is destroyed. The launchers now run `WINEDEBUG=-all,+winediag`
   so the warning reaches the log. See `notes/ABLETON-WINE-GPU-RENDERER.md`.
 - `0072`: add six pointer settings and middle-button drag navigation. Keep
-  normal middle clicks and correct the pointer position after a drag. See
+  normal middle clicks and correct the pointer position after a drag.
+  `SmoothScrolling` defaults to `disabled`: any other value selects XI2 events
+  on our own windows, which makes a button press an implicit XI2 grab and
+  fails the core `XGrabPointer` that `SetCursorPos` needs, so fader and knob
+  drags accumulate raw motion instead of re-anchoring. See
   `notes/ABLETON-WINE-POINTER-GESTURES.md`.
 - `0073`: report vertical and horizontal wheel movement at the pointer's screen
   position. See

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -67,7 +67,7 @@ b65877e816921195b1b0f45b901dc512b0c1111b9ea3e034e73aaa57362596b2  0067-wined3d-s
 4b4ca42a11539df9482e7160141be08c10e8f4b1d1c46e1ce3fa60caa0fb993a  0069-win32u-keep-selected-captioned-monitor-sized-window-resizable.patch
 e97acef9969ada9041f66c80d58dcb9b94fa3bcbba62b7fa99beba33ae9bbedd  0070-win32u-break-alt-f10-menu-arming-on-consumed-keys.patch
 f45f017f21733461ddcc11ab443526ad999d43d3a220e191ce05e973a790148c  0071-wined3d-count-and-report-sustained-present-size-fall.patch
-f94996e6fa27bba4ad0db107438a9f45176ac77ac41b2f773f117a3e027e03b0  0072-winex11-registry-pointer-settings-and-middle-button-dra.patch
+2987dcaf498f8e7258dfc2e068b4e87b5bdea6ff752286d95730f8f7f5086495  0072-winex11-registry-pointer-settings-and-middle-button-dra.patch
 73bd659652f4e9a493ed0eb70807107905101da12c61ac32f771ce6e9948b141  0073-win32u-server-keep-horizontal-wheel-coordinates-in-screen.patch
 55fcbef84ff3ec6c03907626af252f1bbbe40c851642cac3dbfd1729d4231350  0074-winex11-server-report-a-touchpad-pinch-as-Ctrl-tagged-whe.patch
 8520b205e8b38440ed942c1b88ee4f48c6dd6e38f93c758104d85b4dcca931ec  0075-kernel32-add-UnregisterApplicationRecoveryCallback.patch


### PR DESCRIPTION
Fader and knob drags run away on every XWayland desktop with a stock install. This changes one default.

## Mechanism

`SmoothScrolling` defaults to `precise`. Any value other than `disabled` sets `xinput2_smooth_scroll`, which makes `x11drv_xinput2_select` select `XI_Motion`, `XI_ButtonPress` and `XI_ButtonRelease` on our own windows. An XI2 selection on a window stops core event delivery for that device to that client on that window, and a button press on such a window creates an implicit XI2 device grab.

`X11DRV_SetCursorPos` and `grab_clipping_window` both take a core `XGrabPointer`, which fails against that implicit grab. While any button is held, every warp is therefore refused and cursor clipping is never established.

Live implements relative fader and knob dragging by re-anchoring the pointer with `SetCursorPos`. Each refused re-anchor leaves it accumulating raw physical motion, so a control crosses its entire range from a small movement. The cursor stays visible throughout because the clip window is never mapped.

`notched` does not avoid this. The selection is gated on `!= POINTER_SCROLL_DISABLED`, so only `disabled` clears it. There is no setting that keeps fractional scrolling and working drags at the same time.

## What this costs

Scrolling falls back to whole notches by default. Fractional scrolling stays available per user through the `SmoothScrolling` registry value and `WINE_X11_SMOOTH_SCROLLING`, which is the right trade while the default install is unusable for mouse-driven editing.

## Relationship to #195

PR #195 fixes the routing so that precise scrolling and drags can coexist, by suspending `XI_Motion` selection during core drags. That is the better end state and this does not block it. When #195 lands and has been confirmed against a real drag, this default can be reverted in one line.

This is offered as the interim: one line, no new code paths, and it makes a stock install work on every Wayland desktop today.

## Testing

COSMIC/Wayland, Live 12.

The fault reproduces at `main`. Setting `WINE_X11_SMOOTH_SCROLLING=disabled` on a `main` runtime resolves it, which is the same condition this patch makes the default.

A runtime built from this branch was then installed and launched with no registry value and no launch variable set, so the built-in default is what applies. Fader drags track the pointer correctly.

Two other runtimes were built while isolating this, both of which still showed the fault: one with patch 0097 dropped and 0095 reverted to its form before `9a58a50`, and one with 0095 and 0097 both dropped. The pointer inertia and throw work is not involved.

Earlier instrumentation of the mechanism on `6ed47e4`, for reference rather than as a measurement of this branch: core `MotionNotify` 29952 to 0, `X11DRV_EnterNotify` 8203 to 11, and 6364 refused warps in a single fader drag.

`make check` passes. Build audit passes, 167 checks.
