### PR TITLE
Lift the four-digit series ceiling at 0099

### DIFF
--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -43,7 +43,7 @@ fi
 
 # --- --freeze: (re)generate the frozen series manifest ------------------------
 if [ "${1:-}" = --freeze ]; then
-    new="$(cd "$root/patches" && sha256sum 00*.patch pipeasio/*.patch)"
+    new="$(cd "$root/patches" && sha256sum [0-9][0-9][0-9][0-9]-*.patch pipeasio/*.patch)"
     check_required_series_tails <(printf '%s\n' "$new")
     if [ -f "$SERIES" ]; then
         say "== freeze diff (old -> new) =="
@@ -97,7 +97,10 @@ while read -r sum file; do
         sha_ok["$file"]=0
     fi
 done < "$SERIES"
-extras="$(cd "$root/patches" && printf '%s\n' 00*.patch pipeasio/*.patch \
+# Every .patch on disk, not just the numbered ones the series globs match: a file
+# the series glob skips is applied by nothing and audited by nothing, so it has
+# to surface here rather than pass as absent.
+extras="$(cd "$root/patches" && printf '%s\n' *.patch pipeasio/*.patch \
     | grep -vxF -f <(awk '{print $2}' "$SERIES") || true)"
 [ -z "$extras" ] && ok "no unlisted patches" "" || bad "unlisted patches present" "$extras"
 # Retired numbers stay retired (renumbering would break cross-references in patch

--- a/scripts/container-build.sh
+++ b/scripts/container-build.sh
@@ -31,7 +31,7 @@ ABLETON_LINKD_SHA="${ABLETON_LINKD_SHA:-}"
 }
 DESTDIR="$WORK/stage"
 PREFIX_ROOT="$DESTDIR$CONFIGURE_PREFIX"
-npatch="$(ls "$SRC"/patches/00*.patch | wc -l)"
+npatch="$(ls "$SRC"/patches/[0-9][0-9][0-9][0-9]-*.patch | wc -l)"
 
 # TSan reserves a fixed shadow address range. High-entropy ASLR can collide
 # with that range, and newer runtimes may be unable to request process-local
@@ -143,7 +143,7 @@ git -c user.email=build@localhost -c user.name=dist commit -q -m "base 5c23dd1c"
 # The series ships without From:/Date: mail headers; git am refuses to commit
 # with an empty author, so supply a fixed neutral ident (fixed date keeps the
 # apply reproducible). Patches that still carry headers keep their own.
-for p in "$SRC"/patches/00*.patch; do
+for p in "$SRC"/patches/[0-9][0-9][0-9][0-9]-*.patch; do
     if head -8 "$p" | grep -q '^From: '; then
         git -c user.email=build@localhost -c user.name=dist am --3way "$p"
     else
@@ -629,7 +629,7 @@ LC_ALL=C sort -c -u "$builder_packages"
 builder_packages_sha="$(sha256sum "$builder_packages" | awk '{print $1}')"
 # Stamp per-patch sha256s into the tree; build-audit.sh diffs this against patches/SERIES.sha256.
 stack_stamp="$PREFIX_ROOT/ABLETON-WINE-PATCH-STACK.txt"
-( cd "$SRC/patches" && sha256sum 00*.patch pipeasio/*.patch ) > "$stack_stamp"
+( cd "$SRC/patches" && sha256sum [0-9][0-9][0-9][0-9]-*.patch pipeasio/*.patch ) > "$stack_stamp"
 stack_sha="$(sha256sum "$stack_stamp" | awk '{print $1}')"
 build_info="$PREFIX_ROOT/ABLETON-WINE-BUILD-INFO.txt"
 {


### PR DESCRIPTION
The series globs matched `00*.patch`, so a patch numbered 0100 or above was applied by nothing and audited by nothing — no error, just a runtime missing the fix. The Wine series is at 0097, leaving 0098 and 0099.

Match `[0-9][0-9][0-9][0-9]-*.patch` instead, in the apply loop, the stack stamp and the freeze. Zero-padded four-digit names sort the same lexically as numerically, so apply order is unchanged — verified across the 0097→0100 boundary.

The unlisted-patch check now lists every `.patch` on disk rather than the ones the series glob matches, so a file outside the numbering scheme is reported instead of passing as absent.

Verified with a synthetic `0100-` patch present: the old glob saw 95 Wine patches, the new one 96, and the audit reports it as `unlisted patches present`.