### PR TITLE
Strip the CR from reg output before matching the PipeASIO CLSID

### DIFF
--- a/scripts/lib/pipeasio.sh
+++ b/scripts/lib/pipeasio.sh
@@ -501,6 +501,7 @@ ableton_pipeasio_register()
         return 1
     }
     printf '%s\n' "$result" | awk -v wanted="$ABLETON_PIPEASIO_CLSID" '
+        { gsub(/\r/, "") }   # reg output is CRLF
         toupper($1)=="CLSID" && toupper($2)=="REG_SZ" \
             && toupper($3)==toupper(wanted) && NF==3 { found=1 }
         END { exit !found }


### PR DESCRIPTION
reg query emits CRLF, and awk does not treat CR as a field separator, so the CLSID field kept a trailing carriage return and never compared equal. Every prefix setup failed at PipeASIO registration with "points to an unexpected driver". Matches the CRLF handling in setup-prefix.sh.