### PR TITLE
Patch 0099: Fix/jit alloc order

### DIFF
--- a/patches/0099-ntdll-grow-the-reserved-pool-instead-of-unordered-mmap.patch
+++ b/patches/0099-ntdll-grow-the-reserved-pool-instead-of-unordered-mmap.patch
@@ -1,0 +1,176 @@
+Subject: ntdll: grow the reserved pool instead of falling back to unordered mmap
+
+The preloader reserves a fixed set of areas and a large application exhausts
+them. After that anonymous views are placed by the host with no ordering, and
+the reserved-area path serves only what fits in holes freed since. How much it
+recovers depends on what the application releases: a failing set load fell
+through 5203 times against 414 later hits from the pool. Code that caches an
+image base from its first allocation and encodes later ones as unsigned 32-bit
+offsets from it fails once its allocations land either side of the boundary.
+LLVM's RuntimeDyld does this for IMAGE_REL_AMD64_ADDR32NB, so a Max for Live
+gen~ device aborts a set load when its slabs do.
+
+Reserve further arenas above the highest view served from the pool and retry,
+so views keep ascending and stay on the binary-searched reserved-area path.
+Adjacency matters as much as ordering: an ADDR32NB target must also lie within
+UINT32_MAX of the cached image base, so an arena opened several GB above the
+area a JIT began in fails the same way as one below it. A reserved-area end is
+the wrong anchor, because the reserved set includes the main image range and
+leaves exactly that gap.
+
+Growth respects both ends of the caller's address range. Without the limit_high
+test a request carrying zero_bits, or any 32-bit process under WoW64, reserves
+an arena above the range it may use; without the limit_low test a WoW64 thread
+stack, or an image based above 4 GB, reserves one below it. Either way once per
+failed request: a bare wineboot reserves 76 arenas it never uses, 17 GiB.
+
+The highest preloader area is documented as serving top-down allocations and
+ends at the address space limit, leaving no free space above it, so bottom-up
+requests no longer consume it.
+
+---
+--- a/dlls/ntdll/unix/virtual.c
++++ b/dlls/ntdll/unix/virtual.c
+@@ -2140,6 +2140,111 @@
+  * Try to map some space inside a reserved area.
+  * virtual_mutex must be held by caller.
+  */
++/* The preloader's highest reserved area is documented as serving top-down
++ * allocations, and it ends at the address space limit, so nothing can be
++ * reserved above it. Bottom-up allocations that consume it therefore have
++ * nowhere left to grow and fall through to unordered mmap for as long as the
++ * pool stays full. Keep it for the top-down requests it is meant for, and let
++ * grow_reserved_arena() extend the bottom-up pool instead. The threshold sits
++ * below that area's base at 0x7ffffe000000; nothing is reserved between it and
++ * the area below, which ends at 0x7fff0000, so it selects only that area. */
++#define ARENA_TOPDOWN_BASE  ((void *)0x7ffff0000000)
++#define ARENA_SIZE          (256 * 1024 * 1024)
++
++static void *arena_next;        /* next address to try for a new arena */
++static void *alloc_high_water;  /* end of the highest view served from the pool */
++
++/* Advance the mark a grown arena is anchored to. Both call sites are
++ * reserved-area paths, so a host-placed view never reaches this. The address
++ * test excludes the preloader's top-down area: a view there sits far above the
++ * pool, and anchoring the next arena to it would open exactly the gap this
++ * mark exists to prevent. */
++static inline void note_pool_high_water( void *ptr, size_t size )
++{
++    if (!is_win64) return;
++    if (ptr >= ARENA_TOPDOWN_BASE) return;
++    if ((char *)ptr + size > (char *)alloc_high_water)
++        alloc_high_water = (char *)ptr + size;
++}
++
++/***********************************************************************
++ *           grow_reserved_arena
++ *
++ * Reserve another chunk of address space for bottom-up allocation, above every
++ * chunk reserved so far, so successive views keep ascending once the preloader's
++ * areas are used up. virtual_mutex must be held by caller.
++ */
++static BOOL grow_reserved_arena( size_t size, void *limit_low, void *limit_high )
++{
++    size_t arena_size = max( (size_t)ARENA_SIZE, ROUND_SIZE( 0, size, granularity_mask ) );
++    int attempt;
++
++    if (!is_win64) return FALSE;
++    /* The caller may be restricted to part of the address space - a 32-bit
++     * process under WoW64, or any request carrying zero_bits. An arena outside
++     * that range can never satisfy the request, and reserving one per failed
++     * request consumes address space without effect. */
++    if ((char *)limit_high - (char *)limit_low < arena_size) return FALSE;
++
++    /* Anchor just above the highest view served from the pool. Ascending
++     * placement alone is not sufficient: a 32-bit image-base-relative
++     * relocation also requires its target within UINT32_MAX of the base, so an
++     * arena opened several GB above the area a JIT began in fails the same way
++     * as one below it. A reserved-area end is the wrong anchor, because the
++     * reserved set includes the main image's range, which sits above the pool
++     * and leaves exactly that gap. */
++    if (alloc_high_water > arena_next) arena_next = alloc_high_water;
++    if (!arena_next)
++    {
++        struct reserved_area *area;
++
++        LIST_FOR_EACH_ENTRY( area, &reserved_areas, struct reserved_area, entry )
++        {
++            void *area_end = (char *)area->base + area->size;
++
++            if (area->base >= ARENA_TOPDOWN_BASE) break;
++            /* skip the image's own reserve; it is not part of the pool */
++            if (preload_reserve_end > preload_reserve_start &&
++                area->base <= preload_reserve_start && area_end >= preload_reserve_end)
++                continue;
++            if (area_end > arena_next) arena_next = area_end;
++        }
++        if (!arena_next) return FALSE;
++    }
++
++    /* arena_next is not raised to limit_low. It is static and only increases,
++     * so a single caller with a high lower bound would move it there for every
++     * later allocation, each of which then probes back down the address space.
++     * Return FALSE instead, so such a caller takes the same path as on stock;
++     * the lower bound within an arena is applied by the search in
++     * map_reserved_area. */
++    for (attempt = 0; attempt < 64; attempt++)
++    {
++        void *ptr;
++
++        if (is_beyond_limit( arena_next, arena_size, ARENA_TOPDOWN_BASE )) return FALSE;
++        /* stop before reserving anything the caller could not be given: above
++         * limit_high, or wholly below limit_low. WoW64 thread stacks and
++         * images based above 4 GB pass limit_4g as limit_low, and an arena
++         * under it can never serve them. */
++        if (is_beyond_limit( arena_next, arena_size, limit_high )) return FALSE;
++        if (limit_low && (char *)arena_next + arena_size <= (char *)limit_low) return FALSE;
++        ptr = anon_mmap_tryfixed( arena_next, arena_size, PROT_NONE, MAP_NORESERVE );
++        if (ptr != MAP_FAILED)
++        {
++            TRACE( "reserved new arena %p-%p\n", ptr, (char *)ptr + arena_size );
++            mmap_add_reserved_area( ptr, arena_size );
++            arena_next = (char *)ptr + arena_size;
++            return TRUE;
++        }
++        if (errno != EEXIST) return FALSE;
++        /* something is already mapped there; step over it and try again */
++        arena_next = (char *)arena_next + arena_size;
++    }
++    return FALSE;
++}
++
++
+ static void *map_reserved_area( void *limit_low, void *limit_high, size_t size, int top_down,
+                                 int unix_prot, size_t align_mask )
+ {
+@@ -2170,6 +2275,9 @@
+ 
+             if (start >= limit_high) return NULL;
+             if (end <= limit_low) continue;
++            /* Reserve this area for top-down requests. Serving bottom-up ones
++             * from it leaves the pool with no free address space above it. */
++            if (is_win64 && start >= ARENA_TOPDOWN_BASE) return NULL;
+             if (start < limit_low) start = (void *)ROUND_SIZE( 0, limit_low, host_page_mask );
+             if (end > limit_high) end = ROUND_ADDR( limit_high, host_page_mask );
+             ptr = find_reserved_free_area_outside_preloader( start, end, size, top_down, align_mask );
+@@ -2305,6 +2413,20 @@
+         if ((ptr = map_reserved_area( start, end, host_size, top_down, unix_prot, align_mask )))
+         {
+             TRACE( "got mem in reserved area %p-%p\n", ptr, (char *)ptr + size );
++            note_pool_high_water( ptr, host_size );
++            goto done;
++        }
++
++        /* The preloader's areas are finite and a large application exhausts
++         * them; while they stay full every later view is placed by the host
++         * with no ordering. Extend the pool upward instead and retry,
++         * which keeps successive views ascending and keeps them on the
++         * binary-searched reserved-area path. */
++        if (!top_down && grow_reserved_arena( host_size, start, end ) &&
++            (ptr = map_reserved_area( start, end, host_size, top_down, unix_prot, align_mask )))
++        {
++            TRACE( "got mem in grown arena %p-%p\n", ptr, (char *)ptr + size );
++            note_pool_high_water( ptr, host_size );
+             goto done;
+         }
+ 

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -94,6 +94,7 @@ b644c922888e201e1ae525ab22993d89bee835410cd36a739b9f84387009d009  0095-winex11-s
 707a404f2c1d4e02abfa4eb4cbe35669f0caa46ce12dd685d5748f3a699d1186  0096-win32u-cache-the-enumerated-host-font-list-in-the-pr.patch
 80c69a6f555ecc8fcf36fb5d7f466ab9fe4cc1a09f48db7c1cbac442197faef7  0097-winex11-restore-pointer-inertia-and-ignore-held-scroll.patch
 5296ad3f9f91911cf13849e2edf33793d97c2c4d0c06fbee0f119cb06e1114fc  0098-winex11-suspend-XI-scroll-selection-during-core-drags.patch
+84e8c5bf8a7916361449d15abf675815c4a1fa7183f800a23632e00f1e6ae44b  0099-ntdll-grow-the-reserved-pool-instead-of-unordered-mmap.patch
 e2759a5aee2cc5820a3ed27d2d4f954a6a5262c1a95172ad11ffa5302c487387  pipeasio/0001-asio-clamp-unavailable-sample-rate-requests.patch
 b4d53b6ebb24e39c7d23efcbddd837149d4d08886167637a73bb085af851d2c1  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch
 65555e38187564f77ac4f2ba1dd76d812e452c5442e21474b9c8a31706beb7ba  pipeasio/0004-accept-any-buffer-size-in-range-log-every-adjustment.patch

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -15,10 +15,14 @@ readonly REQUIRED_PIPEASIO_TAIL='pipeasio/0011-controlpanel-dialog-off-the-host-
 
 check_required_series_tails()
 {
-    local manifest="${1:?series manifest required}" wine_tail pipeasio_tail
+    local manifest="${1:?series manifest required}" body wine_tail pipeasio_tail
     [ -r "$manifest" ] || fail "series manifest is missing or unreadable: $manifest"
-    wine_tail="$(awk '$2 !~ /^pipeasio\// { print $2 }' "$manifest" | sort | tail -1)"
-    pipeasio_tail="$(awk '$2 ~ /^pipeasio\// { print $2 }' "$manifest" | sort | tail -1)"
+    # Read once. Callers may pass a process substitution, and a second open of
+    # that FIFO returns EOF - which reported the PipeASIO tail as absent while
+    # every patch was present.
+    body="$(cat -- "$manifest")"
+    wine_tail="$(printf '%s\n' "$body" | awk '$2 !~ /^pipeasio\// { print $2 }' | sort | tail -1)"
+    pipeasio_tail="$(printf '%s\n' "$body" | awk '$2 ~ /^pipeasio\// { print $2 }' | sort | tail -1)"
     [ "$wine_tail" = "$REQUIRED_WINE_TAIL" ] ||
         fail "Wine series must end at $REQUIRED_WINE_TAIL (found ${wine_tail:-none})"
     [ "$pipeasio_tail" = "$REQUIRED_PIPEASIO_TAIL" ] ||

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -10,7 +10,7 @@ SERIES="$root/patches/SERIES.sha256"
 say()  { printf '%s\n' "$*"; }
 fail() { printf '!! %s\n' "$*" >&2; exit 1; }
 
-readonly REQUIRED_WINE_TAIL='0098-winex11-suspend-XI-scroll-selection-during-core-drags.patch'
+readonly REQUIRED_WINE_TAIL='0099-ntdll-grow-the-reserved-pool-instead-of-unordered-mmap.patch'
 readonly REQUIRED_PIPEASIO_TAIL='pipeasio/0011-controlpanel-dialog-off-the-host-gui-thread.patch'
 
 check_required_series_tails()
@@ -407,6 +407,7 @@ STAMP_ONLY='
 0077|logic-only (minimise/maximise Motif functions advertised unconditionally; extends 0037, no new string literal)
 0078|logic-only (initial monitor DPI seeded in the create_window request; MR 11573 backport, no new string literal)
 0079|logic-only (standalone-surface window search gated on a private-data marker; adds no string literal)
+0099|logic-only (reserved pool grown with further arenas once map_reserved_area declines, keeping anonymous views ascending; new TRACE only, adds no string literal)
 '
 wide_pattern() {  # ascii string -> PCRE matching its UTF-16LE bytes
     printf '%s' "$1" | od -An -v -tx1 | tr -d '\n' | tr -s ' ' ' ' \


### PR DESCRIPTION
- Max embeds LLVM 13.0.1. `RuntimeDyldCOFFX86_64::getImageBase()` **memoises** the image base from the first object linked through an instance, then rejects any `IMAGE_REL_AMD64_ADDR32NB` target below it or more than `UINT32_MAX` above.
- The preloader reserves a fixed set of areas. A large application exhausts them, after which anonymous views are placed by the host with no ordering, and the reserved-area path serves only what later frees make room for. A failing set load took **5,203** such fall-throughs against 414 later pool hits; how far a session recovers depends on what it releases.
- The JIT then encodes a relocation across that boundary and aborts: `IMAGE_REL_AMD64_ADDR32NB relocation requires an ordered section layout`.
- Explains the intermittency, and why the device works when added interactively but not when the set is reloaded.

## Observations

Disassembled at the branch reaching `report_fatal_error`, `rax` is `ImageBase` and `rsi` is `Value`. Captured at that branch during a failing load:

| register | value | |
| --- | --- | --- |
| `rax` | `0x24410000` | ImageBase — a slab served from the pool, 608 MB |
| `rsi` | `0x78818fd00050` | Value — a later view placed by unordered mmap, ~132 TB |
| `rcx` | `0x78816b8f0050` | the delta, matching `rsi - rax` exactly |

`rdx` reads `0xffffff01` — `0xffffffff` after `mov $0x1,%dl` — confirming the `> UINT32_MAX` clause, by 132 TB.

## Fix

- When the pool is exhausted, reserve another 256 MB arena and retry; raw mmap stays a last resort.
- Arenas anchor to the **high-water mark of views served from the pool**, so they stay adjacent. Anchoring to a reserved-area end opens a gap (the reserved set includes the main image range); letting host-placed views advance the mark drags it to the builtin region at `0x6ffff...`.
- Growth respects the caller's address range. A request carrying `zero_bits`, or any 32-bit process under WoW64, may only use part of the address space; without the guard each such request that cannot be satisfied still reserves a 256 MB arena outside that range, and 4,000 of them consumed ~1 TB while every one still failed. Stock fails these requests identically, so the guard preserves that behaviour rather than adding a leak on top of it.
- Bottom-up requests stop drawing from the preloader's top area: it serves top-down allocations and ends at `0x7fffffff0000`, Wine's own address-space limit, so nothing can be reserved above it and consuming it strands the pool with nowhere to grow.

## Results

| | before | after |
| --- | --- | --- |
| affected set | crash 4/4 | **opens 3/3** |
| raw-mmap fall-throughs / session | 5,203 | **0** |
| clang errors / session | 1 | **0** |
| alloc mean @ 16k views | 2-3 us | **1 us** |
| alloc p95 @ 16k views | 5-9 us | **2-3 us** |
| alloc worst case @ 16k views | 140-249 us | **6-12 us** |

- Arenas cost address space, not memory: `PROT_NONE | MAP_NORESERVE`, +262 MB VSZ and +36 kB RSS each. 14 per 16k allocations synthetic and 20-21 for a bare `wineboot -u`, every one of them used.

## Testing

- Affected set cold, no priming: 3/3 clean, zero clang errors.
- Set load on an unaffected set, both runtimes on the same NVMe device, zero audio-queue timeouts throughout: 
  - stock median 10.97 s (n=3, range 10.97-11.07)
  - patched median 10.37 s (n=5, range 9.55-12.49). 
  - Ranges overlap; **no difference is resolvable** 
- `jitorder` probe (attached in the thread) — `descents: 2 of 11` on stock, `PASS - monotonic and within a 4 GB window` after.
- `allocbench`, `zerobits` (same attachment) — latency vs view count; ceiling leak 4,053 arenas -> 1.
- Build audit passes, 169 checks.

## Scope

- Both new paths engage **only once `map_reserved_area` has declined outright** — the point at which stock surrenders placement for as long as the pool stays full. Behaviour before that is identical. Gated on `is_win64`.
- Keeps allocations ascending; does not make ordering unconditional. `find_reserved_free_area` still takes the lowest fitting hole, so once anything frees low a later view can be placed below an earlier one — existing behaviour, unchanged. The holes are opened by whatever else is running, not by the JIT, so RuntimeDyld never freeing its slabs does not rule this out. What makes it sufficient is narrower: RuntimeDyld links in a burst, and a burst is when the pool is most exhausted and low holes scarcest.
- Only Live has been exercised with the patch. The stock hazard is not confined to it: @giang17 reproduced `descents: 2 of 11` on Wine 11.0, with fall-throughs during project load in Live 12 Intro (1,026) and FL Studio 2026 (1,140), and none at all in Fender Studio Pro 8.


