### PR TITLE
Fix: Stop the WebView2 updater wedging installs and sessions

### DIFF
--- a/scripts/ableton-live
+++ b/scripts/ableton-live
@@ -40,6 +40,19 @@ for lifecycle_lib in "$launcher_here/lib/lifecycle.sh" "$ABLETON_DATA_HOME/lib/l
 done
 declare -F ableton_live_running >/dev/null 2>&1 || { echo "ableton-live: lifecycle helper is missing" >&2; exit 1; }
 
+# Live exits cleanly - its extensions, its WebView2 processes and explorer all
+# go with it - but WebView2's updater does not, and one wedged agent keeps the
+# wineserver alive for the whole login session. Ending the agents by name lets
+# the server exit on its own, while a Max or a second Live in the same prefix
+# keeps it as it should.
+session_teardown()
+{
+    local rc=$?
+    ableton_session_teardown || true
+    return "$rc"
+}
+trap session_teardown EXIT
+
 WINE_ROOT="$ABLETON_WINE_ROOT"
 export WINEPREFIX="$ABLETON_WINEPREFIX"
 [ -x "$WINE_ROOT/bin/wine" ] || { echo "ableton-live: Wine runtime is missing at $WINE_ROOT" >&2; exit 1; }

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -11,6 +11,7 @@ if [ -d "$here/../bin" ]; then
     export PATH="$kit_bin:$PATH"
 fi
 . "$here/lib/config.sh"
+. "$here/lib/lifecycle.sh"
 . "$here/lib/pipeasio.sh"
 . "$here/lib/manifest.sh"
 
@@ -745,7 +746,7 @@ esac
 install_live_payload()
 {
     [ -n "$live_payload" ] || return 0
-    local installer="$live_payload" unpack="" lower flags=() timeout_secs extract_timeout status=0 tray seed_reg=""
+    local installer="$live_payload" unpack="" lower flags=() timeout_secs extract_timeout status=0 tray seed_reg="" holder holder_name
     lower="$(basename "$installer" | tr '[:upper:]' '[:lower:]')"
     if [[ "$lower" = *.zip ]]; then
         unpack="$(mktemp -d "${TMPDIR:-/tmp}/ableton-live-installer.XXXXXX")"
@@ -818,13 +819,35 @@ EOF
         done
         rm -f -- "$seed_reg"
     fi
-    for tray in AbletonPushCpl.exe tusbaudiocplapp.exe; do
+    # Images the payload starts and never stops. Live 12's WebView2 bootstrapper
+    # leaves MicrosoftEdgeUpdate.exe in core mode (/c), which has no window and, in a
+    # prefix, does not reach the exit it takes on Windows; the Push images are the
+    # driver's tray agents. All three are windowless background agents named exactly,
+    # so no application is ended here.
+    for tray in AbletonPushCpl.exe tusbaudiocplapp.exe MicrosoftEdgeUpdate.exe; do
         ableton_run_bounded 15 env WINEPREFIX="$ABLETON_WINEPREFIX" \
             "$ABLETON_WINE_ROOT/bin/wine" taskkill /f /im "$tray" >/dev/null 2>&1 || true
     done
-    ableton_run_bounded 60 env WINEPREFIX="$ABLETON_WINEPREFIX" \
-        "$ABLETON_WINE_ROOT/bin/wineserver" -w >/dev/null 2>&1 || {
-            echo "!! post-installer prefix wait timed out" >&2; return 1; }
+    # This prefix is the promoted one, so anything the names above did not cover is
+    # reported and left running rather than stopped: it is the user's, and the
+    # install is complete either way. The prefix was promoted before the payload ran
+    # and nothing after this point touches it, so the wait is hygiene, not a gate.
+    if ! ableton_prefix_wait; then
+        echo "-- the install is complete. A program in the prefix is still running and"
+        echo "   was left alone:"
+        for holder in $(ableton_prefix_pids); do
+            # comm truncates at 15 characters, which is short of most Windows image
+            # names, so the command line is the one that can be acted on.
+            holder_name="$(tr '\0' '\n' < "/proc/$holder/cmdline" 2>/dev/null | head -n 1)"
+            holder_name="${holder_name##*\\}"
+            holder_name="${holder_name##*/}"
+            [ -n "$holder_name" ] || holder_name="$(cat "/proc/$holder/comm" 2>/dev/null || true)"
+            printf '   %s (pid %s)\n' "${holder_name:-unknown}" "$holder"
+        done
+        echo "-- nothing needs to be done. To end it anyway, close it or run:"
+        printf '   WINEPREFIX=%s %s/bin/wineserver -k\n' \
+            "$ABLETON_WINEPREFIX" "$ABLETON_WINE_ROOT"
+    fi
     [ -z "$unpack" ] || cleanup_live_unpack
 }
 

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -746,7 +746,7 @@ esac
 install_live_payload()
 {
     [ -n "$live_payload" ] || return 0
-    local installer="$live_payload" unpack="" lower flags=() timeout_secs extract_timeout status=0 tray seed_reg="" holder holder_name
+    local installer="$live_payload" unpack="" lower flags=() timeout_secs extract_timeout status=0 seed_reg="" holder
     lower="$(basename "$installer" | tr '[:upper:]' '[:lower:]')"
     if [[ "$lower" = *.zip ]]; then
         unpack="$(mktemp -d "${TMPDIR:-/tmp}/ableton-live-installer.XXXXXX")"
@@ -819,16 +819,8 @@ EOF
         done
         rm -f -- "$seed_reg"
     fi
-    # Images the payload starts and never stops. Live 12's WebView2 bootstrapper
-    # leaves MicrosoftEdgeUpdate.exe in core mode (/c), which has no window and, in a
-    # prefix, does not reach the exit it takes on Windows; the Push images are the
-    # driver's tray agents. All three are windowless background agents named exactly,
-    # so no application is ended here.
-    for tray in AbletonPushCpl.exe tusbaudiocplapp.exe MicrosoftEdgeUpdate.exe; do
-        ableton_run_bounded 15 env WINEPREFIX="$ABLETON_WINEPREFIX" \
-            "$ABLETON_WINE_ROOT/bin/wine" taskkill /f /im "$tray" >/dev/null 2>&1 || true
-    done
-    # This prefix is the promoted one, so anything the names above did not cover is
+    ableton_stop_leftover_agents
+    # This prefix is the promoted one, so a process no agent name covered is
     # reported and left running rather than stopped: it is the user's, and the
     # install is complete either way. The prefix was promoted before the payload ran
     # and nothing after this point touches it, so the wait is hygiene, not a gate.
@@ -836,13 +828,7 @@ EOF
         echo "-- the install is complete. A program in the prefix is still running and"
         echo "   was left alone:"
         for holder in $(ableton_prefix_pids); do
-            # comm truncates at 15 characters, which is short of most Windows image
-            # names, so the command line is the one that can be acted on.
-            holder_name="$(tr '\0' '\n' < "/proc/$holder/cmdline" 2>/dev/null | head -n 1)"
-            holder_name="${holder_name##*\\}"
-            holder_name="${holder_name##*/}"
-            [ -n "$holder_name" ] || holder_name="$(cat "/proc/$holder/comm" 2>/dev/null || true)"
-            printf '   %s (pid %s)\n' "${holder_name:-unknown}" "$holder"
+            printf '   %s (pid %s)\n' "$(ableton_pid_image "$holder")" "$holder"
         done
         echo "-- nothing needs to be done. To end it anyway, close it or run:"
         printf '   WINEPREFIX=%s %s/bin/wineserver -k\n' \

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -136,6 +136,76 @@ ableton_wait_for_pid_exit()
     return 1
 }
 
+# Windowless agents an install or a session starts and never stops, ended by
+# exact name so no application is touched.  MicrosoftEdgeUpdate.exe is Live 12's
+# WebView2 updater: under Wine its COM registration fails to validate, so it
+# cannot start an update worker and parks in Core::DoRun indefinitely, holding
+# the prefix open after everything else has gone.  A Max session leaves the same
+# process behind.  The Push images are the USB driver's tray applets.  An image
+# that is not running is a no-op, so callers need not know which apply.
+ableton_stop_leftover_agents()
+{
+    local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}"
+    # wine builds a prefix at any path it is handed, so a caller that gave up
+    # because the runtime or prefix was missing must not create one on its way
+    # out.  Nothing is running in a prefix that does not exist either.
+    [ -x "$runtime/bin/wine" ] || return 0
+    [ -f "$prefix/system.reg" ] || return 0
+    # One invocation, not one per image: taskkill takes a list, and each wine
+    # start costs a second of a user's exit - or fifteen against a prefix that
+    # has stopped answering, three times over.
+    ableton_run_bounded 15 env WINEPREFIX="$prefix" "$runtime/bin/wine" taskkill /f \
+        /im AbletonPushCpl.exe /im tusbaudiocplapp.exe /im MicrosoftEdgeUpdate.exe \
+        >/dev/null 2>&1 || true
+    return 0
+}
+
+# Windows image name from the command line, which carries the full path where
+# /proc/PID/comm is truncated at 15 characters - short of most of them.  argv[0]
+# is read on its own NUL boundary: every Windows path has a space in it, so
+# splitting the joined command line on whitespace yields "Program".
+ableton_pid_image()
+{
+    local image
+    image="$(tr '\0' '\n' < "/proc/$1/cmdline" 2>/dev/null | head -n 1)"
+    image="${image##*\\}"
+    image="${image##*/}"
+    # A process that exits while it is being reported leaves nothing to read.
+    [ -n "$image" ] || image="$(cat "/proc/$1/comm" 2>/dev/null || true)"
+    printf '%s\n' "${image:-unknown}"
+}
+
+# End a session: stop the agents it leaves behind, then confirm the prefix
+# actually came down rather than assume it.  Wine's own processes exit once the
+# last client goes, so a prefix still busy after that grace period is being held
+# by something real - a Max, a second Live, or a program the user started in this
+# prefix themselves.  That is reported and left alone: at this point we cannot
+# tell a user's program from a leftover, and ending the session would take it
+# with us.  Returns non-zero when the prefix is still held.
+ableton_session_teardown()
+{
+    local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}"
+    local seconds="${3:-5}" i pid
+    seconds="$(ableton_timeout_value "$seconds" teardown-grace 1 60)" || return 2
+    # Nothing to end, and nothing to wait for.  Checked first because taskkill is
+    # itself a wine process: on an empty prefix it starts a server and a pair of
+    # services that outlive the grace period below, and the teardown would then
+    # report the session it started as the thing holding the prefix.
+    ableton_prefix_busy || return 0
+    ableton_stop_leftover_agents "$runtime" "$prefix" || true
+    for ((i=0; i<seconds*10; i++)); do
+        ableton_prefix_busy || return 0
+        sleep 0.1
+    done
+    ableton_prefix_busy || return 0
+    printf -- '-- the prefix is still in use, so its wineserver stays up for:\n' >&2
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        printf '   %s (pid %s)\n' "$(ableton_pid_image "$pid")" "$pid" >&2
+    done < <(ableton_prefix_pids)
+    return 1
+}
+
 # Wait for every process in the prefix to exit.  Bounded: a resident that outlives
 # the command that started it holds the server open indefinitely.
 ableton_prefix_wait()

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -2,11 +2,12 @@
 # Prefix- and runtime-scoped Wine lifecycle inspection.  No process is selected
 # by a global image-name match: both /proc/PID/exe and WINEPREFIX must match.
 
+# Definitions only: callers resolve the configuration themselves, because the
+# command line reaches some of them after this file is sourced.
 _ableton_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if ! declare -F ableton_config_init >/dev/null 2>&1; then
     . "$_ableton_lib_dir/config.sh"
 fi
-ableton_config_init
 
 ableton_pid_has_env()
 {
@@ -133,6 +134,38 @@ ableton_wait_for_pid_exit()
         sleep 0.1
     done
     return 1
+}
+
+# Wait for every process in the prefix to exit.  Bounded: a resident that outlives
+# the command that started it holds the server open indefinitely.
+ableton_prefix_wait()
+{
+    local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}"
+    ableton_run_bounded 60 env WINEPREFIX="$prefix" \
+        "$runtime/bin/wineserver" -w >/dev/null 2>&1
+}
+
+# Wait, and on timeout end every process in the prefix and wait again.  The stop is
+# indiscriminate, so this is only for a prefix the caller owns outright - a staging
+# prefix it just built, or one it is about to remove.  On a prefix the user can
+# reach, name the images to end instead and take ableton_prefix_wait's verdict as
+# advisory.  wineserver -k shuts down through SIGINT, so the registry is saved.
+# Returns 1 when a straggler survived the stop, and the wait's own exit code when
+# the wait could not run at all.
+ableton_prefix_quiesce()
+{
+    local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}" rc=0
+    ableton_prefix_wait "$runtime" "$prefix" || rc=$?
+    if [ "$rc" -eq 0 ]; then
+        return 0
+    fi
+    if [ "$rc" -ne 124 ] && [ "$rc" -ne 137 ]; then
+        return "$rc"
+    fi
+    echo "-- a leftover background program is holding the prefix open; stopping it"
+    ableton_run_bounded 20 env WINEPREFIX="$prefix" \
+        "$runtime/bin/wineserver" -k >/dev/null 2>&1 || true
+    ableton_prefix_wait "$runtime" "$prefix" || return 1
 }
 
 ableton_stop_prefix()

--- a/scripts/max9
+++ b/scripts/max9
@@ -13,6 +13,17 @@ for lib in "$here/lib/lifecycle.sh" "$ABLETON_DATA_HOME/lib/lifecycle.sh"; do
 done
 declare -F ableton_max_pids >/dev/null 2>&1 || { echo "max9: lifecycle helper is missing" >&2; exit 1; }
 
+# Max exits cleanly - its node.exe helpers and console host go with it - but a
+# Max session leaves WebView2's updater behind exactly as a Live session does,
+# and that one agent holds the wineserver for the rest of the login session.
+session_teardown()
+{
+    local rc=$?
+    ableton_session_teardown || true
+    return "$rc"
+}
+trap session_teardown EXIT
+
 WINE_ROOT="$ABLETON_WINE_ROOT"
 export WINEPREFIX="$ABLETON_WINEPREFIX"
 MAX_EXE="C:\\Program Files\\Cycling '74\\Max 9\\Max.exe"

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -155,6 +155,12 @@ refuse_runtime_users()
         else
             echo "!! another Wine prefix is using this runtime; close it before rollback" >&2
         fi
+        # Naming them matters here: a windowless agent left in the prefix reads
+        # as "close Live" with no Live to close, and rollback is what someone
+        # reaches for when something is already wrong.
+        for pid in $runtime_users; do
+            printf '   %s (pid %s)\n' "$(ableton_pid_image "$pid")" "$pid" >&2
+        done
         return 1
     }
 }

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -201,7 +201,7 @@ rollback_wine()
 }
 rollback_wineserver_wait()
 {
-    ableton_run_bounded 60 "$runtime/bin/wineserver" -w
+    ableton_prefix_wait "$runtime"
 }
 
 move_runtime_to_empty()

--- a/scripts/setup-prefix.sh
+++ b/scripts/setup-prefix.sh
@@ -445,13 +445,15 @@ wineboot()
 {
     ableton_run_bounded "$wine_command_timeout" "$WINE_ROOT/bin/wineboot" "$@"
 }
+# WINEPREFIX moves from the staging path to the final one partway through, so
+# both helpers name the prefix in force rather than the configured one.
 ableton_wineserver_wait()
 {
-    ableton_run_bounded 60 "$WINESERVER" -w
+    ableton_prefix_wait "$WINE_ROOT" "$WINEPREFIX"
 }
-ableton_wineserver_kill()
+ableton_wineserver_quiesce()
 {
-    ableton_run_bounded 20 "$WINESERVER" -k
+    ableton_prefix_quiesce "$WINE_ROOT" "$WINEPREFIX"
 }
 
 # DPI blocks: a detected scale maps to a calibrated set by compositor family (see
@@ -660,21 +662,14 @@ for startup_root in "$WINEPREFIX/drive_c/users" "$WINEPREFIX/drive_c/ProgramData
     find "$startup_root" -ipath '*Start Menu/Programs/Startup/*' \
         \( -iname '*ableton*' -o -iname '*push*' -o -iname '*tusbaudio*' \) -delete 2>/dev/null || true
 done
-# Bounded, because any resident wineboot started parks this barrier forever: the agent
-# under a name the taskkill missed, or WebView2's MicrosoftEdgeUpdate.exe, whose scheduled
-# task fires about two minutes after a boot and has no window (the --update half of issue
-# #111 is exactly this wait). On timeout, end every process in the prefix and continue -
-# the boot's registry writes are persisted when the server exits. The second wait stays
-# bounded too, in case a straggler survives even SIGKILL.
+# Any resident wineboot started parks this barrier forever: the agent under a name the
+# taskkill missed, or WebView2's MicrosoftEdgeUpdate.exe, whose scheduled task fires about
+# two minutes after a boot and has no window (the --update half of issue #111 is exactly
+# this wait). The boot's registry writes are persisted when the server exits, so a
+# straggler that survives the stop does not block the setup that follows.
 boot_wait_rc=0
-ableton_wineserver_wait || boot_wait_rc=$?
-if [ "$boot_wait_rc" -eq 124 ] || [ "$boot_wait_rc" -eq 137 ]; then
-    echo "-- a leftover background program is holding the prefix open; stopping it"
-    ableton_wineserver_kill 2>/dev/null || true
-    ableton_wineserver_wait 2>/dev/null || true
-elif [ "$boot_wait_rc" -ne 0 ]; then
-    exit "$boot_wait_rc"
-fi
+ableton_wineserver_quiesce || boot_wait_rc=$?
+[ "$boot_wait_rc" -le 1 ] || exit "$boot_wait_rc"
 
 if [ "$refresh" -eq 1 ]; then
     echo "== [2/5] winetricks: skipped (--refresh keeps the installed fonts/runtimes) =="

--- a/scripts/test-installer-lifecycle.sh
+++ b/scripts/test-installer-lifecycle.sh
@@ -527,6 +527,159 @@ grep -q 'appears to be Live 11' "$base/err" || fail "payload mismatch is explici
 [ ! -e "$base/runtime" ] && [ ! -e "$base/prefix" ] && [ ! -e "$base/config" ] || fail "payload mismatch mutates no installation state"
 ok "Live payload major is validated before installation"
 
+base="$(new_env prefix-quiesce)"
+mkdir -p "$base/runtime/bin" "$base/prefix"
+# 124 is timeout's TERM verdict, so the stub reports an expired wait without the
+# suite spending the wait's wall clock on it.
+cat > "$base/runtime/bin/wineserver" <<'EOF'
+#!/usr/bin/env bash
+printf '%s prefix=%s\n' "$1" "${WINEPREFIX-unset}" >> "${ABLETON_TEST_LOG:?}"
+case "$1" in
+    -w)
+        [ "${ABLETON_TEST_WAIT_EXIT:-0}" -eq 0 ] || exit "${ABLETON_TEST_WAIT_EXIT}"
+        [ ! -e "${ABLETON_TEST_BUSY:?}" ] || exit 124
+        exit 0 ;;
+    -k)
+        [ "${ABLETON_TEST_UNKILLABLE:-0}" -eq 1 ] || rm -f -- "${ABLETON_TEST_BUSY:?}"
+        exit 0 ;;
+esac
+exit 2
+EOF
+cat > "$base/run-quiesce" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+. "$here/lib/lifecycle.sh"
+ableton_config_init
+status=0
+ableton_prefix_quiesce "\$@" || status=\$?
+printf 'rc=%s\n' "\$status"
+EOF
+chmod +x "$base/runtime/bin/wineserver" "$base/run-quiesce"
+quiesce_calls()
+{
+    awk '{print $1}' "$base/log" | tr '\n' ' '
+}
+run_quiesce()
+{
+    local assignments=()
+    while [ "$#" -gt 0 ] && [[ "$1" = *=* ]]; do assignments+=("$1"); shift; done
+    : > "$base/log"
+    run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
+        ABLETON_TEST_LOG="$base/log" ABLETON_TEST_BUSY="$base/busy" "${assignments[@]}" \
+        bash "$base/run-quiesce" "$@" >"$base/out" 2>"$base/err"
+}
+
+rm -f "$base/busy"
+run_quiesce
+grep -qx 'rc=0' "$base/out" || fail "a quiet prefix reports success"
+[ "$(quiesce_calls)" = "-w " ] || fail "a quiet prefix is waited for exactly once"
+grep -qx -- "-w prefix=$base/prefix" "$base/log" || fail "the wait names the configured prefix"
+ok "a quiet prefix is waited for once and never stopped"
+
+: > "$base/busy"
+run_quiesce
+grep -qx 'rc=0' "$base/out" || fail "a stopped straggler reports success"
+[ "$(quiesce_calls)" = "-w -k -w " ] || fail "a held prefix is stopped and waited for again"
+grep -q 'holding the prefix open' "$base/out" || fail "stopping the prefix is reported"
+ok "a straggler holding the prefix open is stopped, not made fatal"
+
+: > "$base/busy"
+run_quiesce ABLETON_TEST_UNKILLABLE=1
+grep -qx 'rc=1' "$base/out" || fail "a surviving straggler is reported as still busy"
+[ "$(quiesce_calls)" = "-w -k -w " ] || fail "a surviving straggler is not waited for a third time"
+ok "a straggler that survives the stop is reported, and the wait stays bounded"
+
+rm -f "$base/busy"
+run_quiesce ABLETON_TEST_WAIT_EXIT=127
+grep -qx 'rc=127' "$base/out" || fail "a wait that cannot run keeps its exit code"
+[ "$(quiesce_calls)" = "-w " ] || fail "a wait that cannot run does not stop the prefix"
+ok "only an expired wait stops the prefix; any other failure is passed back"
+
+# setup-prefix.sh waits on its staging prefix, which is not the configured one.
+: > "$base/busy"
+run_quiesce "$base/runtime" "$base/staging-prefix"
+grep -qx 'rc=0' "$base/out" || fail "an explicitly named prefix is quiesced"
+grep -qx -- "-k prefix=$base/staging-prefix" "$base/log" || fail "the stop names the prefix it was given"
+! grep -q -- "prefix=$base/prefix\$" "$base/log" || fail "a named prefix displaces the configured one"
+ok "the runtime and prefix a caller names override the configured pair"
+
+# The payload step's own wait, on the promoted prefix.  Every sub-script is stubbed
+# so install_live_payload is reached with a wineserver whose -w never returns.
+base="$(new_env payload-wait)"
+kit="$base/kit"
+mkdir -p "$kit/scripts/lib" "$kit/bin" "$base/runtime/bin"
+cp -- "$here/installer.sh" "$kit/scripts/"
+cp -- "$here/lib/config.sh" "$here/lib/lifecycle.sh" "$here/lib/manifest.sh" \
+    "$here/lib/pipeasio.sh" "$kit/scripts/lib/"
+cat > "$kit/bin/pipewire-version-probe" <<'EOF'
+#!/bin/sh
+printf 'client=1.4.2\ndaemon=1.4.2\n'
+EOF
+cat > "$kit/scripts/install.sh" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'component %s\n' "$*" >> "${ABLETON_TEST_CALL_LOG:?}"
+exit 0
+EOF
+cat > "$kit/scripts/setup-prefix.sh" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'prefix %s\n' "$*" >> "${ABLETON_TEST_CALL_LOG:?}"
+case " $* " in
+    *' --preflight-commit '*|*' --commit '*|*' --preflight-rollback '*|*' --rollback '*) exit 0 ;;
+esac
+mkdir -p -- "${ABLETON_WINEPREFIX:?}"
+printf 'registry\n' > "${ABLETON_WINEPREFIX}/system.reg"
+EOF
+cat > "$kit/scripts/setup-link.sh" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'link %s\n' "$*" >> "${ABLETON_TEST_CALL_LOG:?}"
+EOF
+cat > "$base/runtime/bin/wine" <<'EOF'
+#!/bin/sh
+printf 'wine %s\n' "$*" >> "${ABLETON_TEST_CALL_LOG:?}"
+EOF
+cat > "$base/runtime/bin/wineserver" <<'EOF'
+#!/bin/sh
+printf 'wineserver %s\n' "$*" >> "${ABLETON_TEST_CALL_LOG:?}"
+case "${1:-}" in
+    -w) exit "${ABLETON_TEST_WAIT_EXIT:-0}" ;;
+esac
+EOF
+chmod 755 "$kit/scripts/"*.sh "$kit/bin/pipewire-version-probe" "$base/runtime/bin/"*
+printf 'Ableton Live 12 Suite Installer\n' > "$base/Ableton Live 12 Suite Installer.exe"
+
+run_payload_install()
+{
+    : > "$base/calls.log"
+    rm -rf -- "$base/prefix" "$base/config" "$base/state" "$base/data"
+    run_isolated "$base" env ABLETON_TEST_CALL_LOG="$base/calls.log" "$@" \
+        bash "$kit/scripts/installer.sh" install \
+            --live-installer "$base/Ableton Live 12 Suite Installer.exe" \
+            --link=off --runtime-root "$base/runtime" --prefix "$base/prefix" --yes \
+        >"$base/out" 2>"$base/err"
+}
+
+# 124 is timeout's TERM verdict: the wait ran out with a process still in the prefix.
+run_payload_install ABLETON_TEST_WAIT_EXIT=124 || fail "an expired payload wait fails the install"
+grep -q 'OK: install completed' "$base/out" || fail "an expired payload wait leaves the install incomplete"
+! grep -q 'wineserver -k' "$base/calls.log" || fail "the payload step stops the promoted prefix"
+grep -q 'is still running and' "$base/out" || fail "an unrecognised straggler goes unreported"
+grep -qF -- "$base/runtime/bin/wineserver -k" "$base/out" \
+    || fail "the report withholds the command that ends the prefix"
+ok "an expired payload wait reports the straggler, stops nothing, and still completes"
+
+for image in AbletonPushCpl.exe tusbaudiocplapp.exe MicrosoftEdgeUpdate.exe; do
+    grep -qF "taskkill /f /im $image" "$base/calls.log" \
+        || fail "the payload step does not end $image by name"
+done
+ok "the payload step ends the images it starts, each named exactly"
+
+run_payload_install || fail "a quiet payload wait fails the install"
+! grep -q 'is still running and' "$base/out" || fail "a quiet prefix is reported as busy"
+ok "a quiet prefix after the payload reports nothing"
+
 base="$(new_env launcher-preflight)"
 mkdir -p "$base/runtime/bin" "$base/prefix"
 printf '#!/bin/sh\nexit 0\n' > "$base/runtime/bin/wine"

--- a/scripts/test-installer-lifecycle.sh
+++ b/scripts/test-installer-lifecycle.sh
@@ -671,7 +671,7 @@ grep -qF -- "$base/runtime/bin/wineserver -k" "$base/out" \
 ok "an expired payload wait reports the straggler, stops nothing, and still completes"
 
 for image in AbletonPushCpl.exe tusbaudiocplapp.exe MicrosoftEdgeUpdate.exe; do
-    grep -qF "taskkill /f /im $image" "$base/calls.log" \
+    grep -qF "/im $image" "$base/calls.log" \
         || fail "the payload step does not end $image by name"
 done
 ok "the payload step ends the images it starts, each named exactly"
@@ -682,18 +682,48 @@ ok "a quiet prefix after the payload reports nothing"
 
 base="$(new_env launcher-preflight)"
 mkdir -p "$base/runtime/bin" "$base/prefix"
-printf '#!/bin/sh\nexit 0\n' > "$base/runtime/bin/wine"
+cat > "$base/runtime/bin/wine" <<'EOF'
+#!/bin/sh
+printf 'wine %s\n' "$*" >> "${ABLETON_TEST_LOG:?}"
+exit 0
+EOF
 printf '#!/bin/sh\nexit 0\n' > "$base/runtime/bin/wineserver"
 chmod +x "$base/runtime/bin/wine" "$base/runtime/bin/wineserver"
 printf 'registry\n' > "$base/prefix/system.reg"
+: > "$base/wine.log"
 if run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
-    bash "$here/ableton-live" >"$base/out" 2>"$base/err"; then
+    ABLETON_TEST_LOG="$base/wine.log" bash "$here/ableton-live" \
+    >"$base/out" 2>"$base/err"; then
     fail "launcher without Live fails"
 fi
+# taskkill is a wine process: on an empty prefix it would start a server and a
+# pair of services, which the teardown would then report as the holder.
+! grep -q 'taskkill' "$base/wine.log" || fail "teardown starts wine on a prefix with nothing in it"
 grep -q 'no Ableton Live installation' "$base/err" || fail "launcher reports missing Live"
 [ ! -e "$base/state" ] && [ ! -e "$base/data" ] && [ ! -e "$base/config" ] && [ ! -e "$base/run" ] \
     || fail "launcher preflight mutates no machine state"
 ok "launcher validates runtime, prefix, and Live before mutation"
+
+# The teardown runs on every exit, including the ones that gave up because the
+# prefix was not there.  wine builds a prefix at whatever path it is handed, so
+# a refusal must not leave one behind.
+base="$(new_env launcher-missing-prefix)"
+mkdir -p "$base/runtime/bin"
+cat > "$base/runtime/bin/wine" <<'EOF'
+#!/bin/sh
+mkdir -p -- "${WINEPREFIX:?}/drive_c"
+printf 'registry\n' > "${WINEPREFIX:?}/system.reg"
+exit 0
+EOF
+printf '#!/bin/sh\nexit 0\n' > "$base/runtime/bin/wineserver"
+chmod +x "$base/runtime/bin/wine" "$base/runtime/bin/wineserver"
+if run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" \
+    ABLETON_WINEPREFIX="$base/absent-prefix" bash "$here/ableton-live" \
+    >"$base/out" 2>"$base/err"; then
+    fail "launcher accepts a missing prefix"
+fi
+[ ! -e "$base/absent-prefix" ] || fail "teardown builds a prefix the launcher refused to use"
+ok "a launcher that refuses a missing prefix creates nothing on its way out"
 
 base="$(new_env max-coexist)"
 mkdir -p "$base/runtime/bin" "$base/prefix/drive_c/ProgramData/Ableton/Live 12 Suite/Program" "$base/run"
@@ -719,7 +749,10 @@ printf 'registry\n' > "$base/prefix/system.reg"
 printf 'registry\n' > "$base/prefix/user.reg"
 printf 'exe\n' > "$base/prefix/drive_c/ProgramData/Ableton/Live 12 Suite/Program/Ableton Live 12 Suite.exe"
 : > "$base/wine.log"
-env WINEPREFIX="$base/prefix" bash -c 'exec -a "C:\\Program Files\\Cycling '\''74\\Max 9\\Max.exe" "$1" 60' _ "$base/runtime/bin/wine-client" &
+# 600s, not 60: the launcher waits out its observability timeout before the
+# teardown even runs, so a short-lived stand-in expires mid-case and the
+# coexistence it is meant to prove goes untested.
+env WINEPREFIX="$base/prefix" bash -c 'exec -a "C:\\Program Files\\Cycling '\''74\\Max 9\\Max.exe" "$1" 600' _ "$base/runtime/bin/wine-client" &
 max_pid=$!
 sleep 0.1
 run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
@@ -731,6 +764,23 @@ kill "$max_pid" 2>/dev/null || true
 wait "$max_pid" 2>/dev/null || true
 ! grep -Eq 'wineserver -k|wineboot' "$base/wine.log" || fail "busy prefix avoids kill and boot"
 ok "cold Live launch neither kills Max nor boots its busy prefix"
+
+# The teardown: a session ends the agents it leaves behind, by name, so the
+# wineserver can exit on its own - and never by ending the prefix, which would
+# take a Max or a second Live with it.
+for image in AbletonPushCpl.exe tusbaudiocplapp.exe MicrosoftEdgeUpdate.exe; do
+    grep -qF "/im $image" "$base/wine.log" \
+        || fail "the launcher leaves $image running after the session"
+done
+ok "the launcher ends the agents a session leaves behind, and stops the prefix for none of them"
+
+# Teardown confirms the outcome instead of assuming it: with another program
+# still in the prefix, it reports why the wineserver stays rather than ending it.
+grep -q 'the prefix is still in use' "$base/err" \
+    || fail "teardown does not report a prefix left in use"
+grep -q 'Max\.exe (pid' "$base/err" \
+    || fail "teardown names the holder by something other than its Windows image"
+ok "teardown verifies the prefix came down, and names the holder when it did not"
 
 base="$(new_env foreign-runtime)"
 mkdir -p "$base/runtime/bin"

--- a/scripts/test-pipeasio-installer.sh
+++ b/scripts/test-pipeasio-installer.sh
@@ -1310,7 +1310,11 @@ wait "$saved_busy_pid" 2>/dev/null || true
     || fail "saved-runtime busy refusal changed the runtime layout"
 grep -Eq 'Wine client is running|another Wine prefix is using this runtime' "$base/err" \
     || fail "saved-runtime busy refusal was not explicit"
-ok "rollback refuses a process executing from the selected saved sibling"
+# "close Live" is unactionable when the holder is a windowless agent, so the
+# refusal names what it found rather than guessing at it.
+grep -q 'rollback-busy-client (pid' "$base/err" \
+    || fail "saved-runtime busy refusal does not name what holds the runtime"
+ok "rollback refuses a process executing from the selected saved sibling, and names it"
 
 base="$(new_env rollback-late-current-user)"
 make_rollback_fixture "$base"

--- a/scripts/test-pipeasio-installer.sh
+++ b/scripts/test-pipeasio-installer.sh
@@ -3022,8 +3022,8 @@ make_commit_preflight_kit()
     local base="$1" kit="$1/commit-kit"
     mkdir -p -- "$kit/scripts/lib"
     cp -- "$here/installer.sh" "$kit/scripts/"
-    cp -- "$here/lib/config.sh" "$here/lib/manifest.sh" "$here/lib/pipeasio.sh" \
-        "$kit/scripts/lib/"
+    cp -- "$here/lib/config.sh" "$here/lib/lifecycle.sh" "$here/lib/manifest.sh" \
+        "$here/lib/pipeasio.sh" "$kit/scripts/lib/"
     cat > "$kit/scripts/install.sh" <<'EOF'
 #!/bin/sh
 set -eu

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -472,7 +472,7 @@ if [ "$delete_prefix" -eq 0 ] && [ -f "$safe_prefix/system.reg" ]; then
     }
     uninstall_wineserver_wait()
     {
-        ableton_run_bounded 60 "$safe_runtime/bin/wineserver" -w
+        ableton_prefix_wait "$safe_runtime" "$safe_prefix"
     }
     echo "== unregister PipeASIO from the retained prefix =="
     ableton_pipeasio_unregister uninstall_wine uninstall_wineserver_wait


### PR DESCRIPTION
Fixes #213, #215 

Includes and supercedes #167 

Will impact #212 

Live 12's installer runs the WebView2 bootstrapper, which starts `MicrosoftEdgeUpdate.exe /c`. Under Wine it cannot validate its COM registration, cannot start its update worker, and so parks in `Core::DoRun`, no window, 0% CPU, holding the prefix's `wineserver` open indefinitely. Its own log says: `ShouldRunForever: 1`, `Will stay running`. Which is kind of ridiculous honestly.

That wedged process caused two separate failures.

**Installs were destroyed.** `install_live_payload` ends with a 60s `wineserver -w` and treated any non-zero exit as fatal. The updater never leaves, so the wait always expired, the transaction failed, and the rollback deleted the prefix Live had just installed into — or restored a displaced one and discarded the new runtime.

**Every session leaked.** Closing Live, or Max, left the updater and a live `wineserver` running for the rest of the login session. It is also why `rollback` could refuse with "Live, Max, or another Wine client is running" when nothing was open.

## Changes

The payload step and both launchers end the windowless agents a session leaves behind, by exact name, from one list in `lib/lifecycle.sh`: `AbletonPushCpl.exe`, `tusbaudiocplapp.exe`, `MicrosoftEdgeUpdate.exe`. Removing the holder is enough — Wine's own processes exit once the last client goes, so the `wineserver` follows without being killed. An image that is not running is a no-op, so each Live major matches only what it has.

Ending the prefix instead would be simpler and wrong. `max9` ships its own desktop entry, so a Max and a Live routinely share one prefix; `wineserver -k` from either would take the other down mid-session.

The teardown then confirms the prefix came down rather than assuming it, and names what holds it when it did not:

```
-- the prefix is still in use, so its wineserver stays up for:
   canary.exe (pid 12345)
```

That is reported and left alone: at teardown a program we do not recognise is indistinguishable from a leftover, and users run their own programs in these prefixes. An agent a future installer invents appears there by name instead of leaking silently.

## Behaviour

| condition | before | after |
| --- | --- | --- |
| install, prefix quiet | completes | unchanged |
| install, agent resident | wait expires, rollback deletes the new prefix or restores a displaced one | agents ended, wait returns in ~4s, install completes |
| install, unrecognised process holds the prefix | same fatal path | holder reported with the `wineserver -k` command, install completes |
| app exits, agent resident | updater and `wineserver` persist for the login session | agents ended, prefix fully down |
| app exits, another app still in the prefix | no teardown existed | agents ended, nothing else signalled, server stays up for that app |
| app exits, prefix still held after the stop | — | 5s grace, holder named by Windows image and pid, nothing killed |
| launcher refuses a missing runtime or prefix | — | teardown returns early: no `wine` invoked, no prefix created |

`setup-prefix.sh`'s `[1/5]` barrier still escalates to `wineserver -k`, but only against the staging prefix it just built. `rollback.sh` and `uninstall.sh` keep their bounded waits, now sharing `ableton_prefix_wait`, and `rollback.sh`'s refusal names the processes holding the runtime instead of guessing at them. `wineserver -k` is never issued against a promoted or user-facing prefix on any path.

## Testing

60 checks in `test-installer-lifecycle.sh` and 86 in `test-pipeasio-installer.sh`, covering the expired payload wait, the named kills, a running application surviving and being named, and a refused launcher creating nothing on its way out.

Verified on Fedora 44, driven and closed through the interface. Live 12.4.2 goes `3/1/1` to `0/0/0` and Max 9.1.5 `1+3/1/1` to `0/0/0`, prefix empty both times, no `wineserver -k` on either path. A control install on `58b9656` expires the wait and rolls back where this branch completes in four seconds. Killing the updater under a running Live with seven WebView2 processes left all of them untouched, and none respawned across three further minutes.

Live 11.3.25 was installed and driven in its own prefix, and leaks a different agent by a different route: no WebView2 updater, but the Push driver's tray applet, autostarted from a Startup-folder shortcut that `explorer.exe` runs at session start. It appears as `ABLE~HEG.EXE -hide` through its 8.3 path, and `taskkill /f /im AbletonPushCpl.exe` still matches it — Wine resolves the process to its long image name. Closing Live 11 leaves the prefix empty. Both majors leak, by different agents, and the one list covers both.


## Credit — #167 by @stickyfran

@stickyfran reported this first, in #167: the `wineserver` survives the window closing, it happens from `ableton-live` **and** from standalone `max9`, and the cleanup belongs in the launchers rather than in a `.desktop` workaround. That report is what sent me looking, and the `max9` half in particular held up exactly as described.

The one thing that report could not have is *why* the server stays: a single wedged `MicrosoftEdgeUpdate.exe` holds it. That's only reason this takes a different approach. #167 calls `wineserver -k`, which ends the whole prefix. Since `max9` ships its own desktop entry, a Max and a Live routinely share one, so closing either would take the other down mid-session. Ending the named agent removes the cause instead, and the server exits on its own.

So this supersedes #167 mechanically while being downstream of it in every other sense. If it lands, #167 should close pointing here, with the find credited to @stickyfran.
