### PR TITLE
Feat/settle progress and lint

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+external-sources=true
+source-path=SCRIPTDIR

--- a/scripts/ableton-live
+++ b/scripts/ableton-live
@@ -40,11 +40,8 @@ for lifecycle_lib in "$launcher_here/lib/lifecycle.sh" "$ABLETON_DATA_HOME/lib/l
 done
 declare -F ableton_live_running >/dev/null 2>&1 || { echo "ableton-live: lifecycle helper is missing" >&2; exit 1; }
 
-# Live exits cleanly - its extensions, its WebView2 processes and explorer all
-# go with it - but WebView2's updater does not, and one wedged agent keeps the
-# wineserver alive for the whole login session. Ending the agents by name lets
-# the server exit on its own, while a Max or a second Live in the same prefix
-# keeps it as it should.
+# Live exits cleanly; WebView2's updater does not, and one wedged agent keeps the
+# wineserver alive for the whole login session.
 session_teardown()
 {
     local rc=$?

--- a/scripts/ableton-live
+++ b/scripts/ableton-live
@@ -45,7 +45,7 @@ declare -F ableton_live_running >/dev/null 2>&1 || { echo "ableton-live: lifecyc
 session_teardown()
 {
     local rc=$?
-    ableton_session_teardown || true
+    ABLETON_SESSION_LABEL="Ableton Live" ableton_session_teardown || true
     return "$rc"
 }
 trap session_teardown EXIT

--- a/scripts/ableton-live
+++ b/scripts/ableton-live
@@ -40,6 +40,19 @@ for lifecycle_lib in "$launcher_here/lib/lifecycle.sh" "$ABLETON_DATA_HOME/lib/l
 done
 declare -F ableton_live_running >/dev/null 2>&1 || { echo "ableton-live: lifecycle helper is missing" >&2; exit 1; }
 
+# Live exits cleanly - its extensions, its WebView2 processes and explorer all
+# go with it - but WebView2's updater does not, and one wedged agent keeps the
+# wineserver alive for the whole login session. Ending the agents by name lets
+# the server exit on its own, while a Max or a second Live in the same prefix
+# keeps it as it should.
+session_teardown()
+{
+    local rc=$?
+    ableton_session_teardown || true
+    return "$rc"
+}
+trap session_teardown EXIT
+
 WINE_ROOT="$ABLETON_WINE_ROOT"
 export WINEPREFIX="$ABLETON_WINEPREFIX"
 [ -x "$WINE_ROOT/bin/wine" ] || { echo "ableton-live: Wine runtime is missing at $WINE_ROOT" >&2; exit 1; }

--- a/scripts/ableton-live
+++ b/scripts/ableton-live
@@ -48,7 +48,6 @@ session_teardown()
     ABLETON_SESSION_LABEL="Ableton Live" ableton_session_teardown || true
     return "$rc"
 }
-trap session_teardown EXIT
 
 WINE_ROOT="$ABLETON_WINE_ROOT"
 export WINEPREFIX="$ABLETON_WINEPREFIX"
@@ -58,6 +57,10 @@ export WINEPREFIX="$ABLETON_WINEPREFIX"
 case "${ABLETON_LIVE_VERSION:-}" in ''|11|12) ;;
     *) echo "ableton-live: ABLETON_LIVE_VERSION must be 11 or 12" >&2; exit 2 ;;
 esac
+
+# Armed after the guards: teardown ends this prefix's agents, and a launch that
+# refused to start has no session to end - the prefix may hold someone else's.
+trap session_teardown EXIT
 
 find_live_exe()
 {

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -820,11 +820,9 @@ EOF
         rm -f -- "$seed_reg"
     fi
     ableton_stop_leftover_agents
-    # This prefix is the promoted one, so a process no agent name covered is
-    # reported and left running rather than stopped: it is the user's, and the
-    # install is complete either way. The prefix was promoted before the payload ran
-    # and nothing after this point touches it, so the wait is hygiene, not a gate.
-    if ! ableton_prefix_wait; then
+    # The promoted prefix: anything no agent name covered is the user's, and the
+    # install is complete either way.  Hygiene, not a gate.
+    if ! ableton_prefix_wait_progress; then
         echo "-- the install is complete. A program in the prefix is still running and"
         echo "   was left alone:"
         for holder in $(ableton_prefix_pids); do

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -11,6 +11,7 @@ if [ -d "$here/../bin" ]; then
     export PATH="$kit_bin:$PATH"
 fi
 . "$here/lib/config.sh"
+. "$here/lib/lifecycle.sh"
 . "$here/lib/pipeasio.sh"
 . "$here/lib/manifest.sh"
 
@@ -745,7 +746,7 @@ esac
 install_live_payload()
 {
     [ -n "$live_payload" ] || return 0
-    local installer="$live_payload" unpack="" lower flags=() timeout_secs extract_timeout status=0 tray seed_reg=""
+    local installer="$live_payload" unpack="" lower flags=() timeout_secs extract_timeout status=0 tray seed_reg="" holder holder_name
     lower="$(basename "$installer" | tr '[:upper:]' '[:lower:]')"
     if [[ "$lower" = *.zip ]]; then
         unpack="$(mktemp -d "${TMPDIR:-/tmp}/ableton-live-installer.XXXXXX")"
@@ -818,13 +819,35 @@ EOF
         done
         rm -f -- "$seed_reg"
     fi
-    for tray in AbletonPushCpl.exe tusbaudiocplapp.exe; do
+    # Images the payload starts and never stops. Live 12's WebView2 bootstrapper
+    # leaves MicrosoftEdgeUpdate.exe in core mode (/c), which has no window and, in a
+    # prefix, does not reach the exit it takes on Windows; the Push images are the
+    # driver's tray agents. All three are windowless background agents named exactly,
+    # so no application is ended here.
+    for tray in AbletonPushCpl.exe tusbaudiocplapp.exe MicrosoftEdgeUpdate.exe; do
         ableton_run_bounded 15 env WINEPREFIX="$ABLETON_WINEPREFIX" \
             "$ABLETON_WINE_ROOT/bin/wine" taskkill /f /im "$tray" >/dev/null 2>&1 || true
     done
-    ableton_run_bounded 60 env WINEPREFIX="$ABLETON_WINEPREFIX" \
-        "$ABLETON_WINE_ROOT/bin/wineserver" -w >/dev/null 2>&1 || {
-            echo "!! post-installer prefix wait timed out" >&2; return 1; }
+    # This prefix is the promoted one, so anything the names above did not cover is
+    # reported and left running rather than stopped: it is the user's, and the
+    # install is complete either way. The prefix was promoted before the payload ran
+    # and nothing after this point touches it, so the wait is hygiene, not a gate.
+    if ! ableton_prefix_wait; then
+        echo "-- the install is complete. A program in the prefix is still running and"
+        echo "   was left alone:"
+        for holder in $(ableton_prefix_pids); do
+            # comm truncates at 15 characters, which is short of most Windows image
+            # names, so the command line is the one that can be acted on.
+            holder_name="$(tr '\0' '\n' < "/proc/$holder/cmdline" 2>/dev/null | head -n 1)"
+            holder_name="${holder_name##*\\}"
+            holder_name="${holder_name##*/}"
+            [ -n "$holder_name" ] || holder_name="$(cat "/proc/$holder/comm" 2>/dev/null || true)"
+            printf '   %s (pid %s)\n' "${holder_name:-unknown}" "$holder"
+        done
+        echo "-- nothing needs to be done. To end it anyway, close it or run:"
+        printf '   WINEPREFIX=%s %s/bin/wineserver -k\n' \
+            "$ABLETON_WINEPREFIX" "$ABLETON_WINE_ROOT"
+    fi
     [ -z "$unpack" ] || cleanup_live_unpack
 }
 

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -746,7 +746,7 @@ esac
 install_live_payload()
 {
     [ -n "$live_payload" ] || return 0
-    local installer="$live_payload" unpack="" lower flags=() timeout_secs extract_timeout status=0 seed_reg="" holder
+    local installer="$live_payload" unpack="" lower flags=() timeout_secs extract_timeout status=0 seed_reg="" holder holder_image
     lower="$(basename "$installer" | tr '[:upper:]' '[:lower:]')"
     if [[ "$lower" = *.zip ]]; then
         unpack="$(mktemp -d "${TMPDIR:-/tmp}/ableton-live-installer.XXXXXX")"
@@ -825,9 +825,10 @@ EOF
     if ! ableton_prefix_wait_progress; then
         echo "-- the install is complete. A program in the prefix is still running and"
         echo "   was left alone:"
-        for holder in $(ableton_prefix_pids); do
-            printf '   %s (pid %s)\n' "$(ableton_pid_image "$holder")" "$holder"
-        done
+        while IFS="$(printf '\t')" read -r holder holder_image; do
+            [ -n "$holder" ] || continue
+            printf '   %s (pid %s)\n' "$holder_image" "$holder"
+        done < <(ableton_prefix_holders)
         echo "-- nothing needs to be done. To end it anyway, close it or run:"
         printf '   WINEPREFIX=%s %s/bin/wineserver -k\n' \
             "$ABLETON_WINEPREFIX" "$ABLETON_WINE_ROOT"

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -746,7 +746,7 @@ esac
 install_live_payload()
 {
     [ -n "$live_payload" ] || return 0
-    local installer="$live_payload" unpack="" lower flags=() timeout_secs extract_timeout status=0 tray seed_reg="" holder holder_name
+    local installer="$live_payload" unpack="" lower flags=() timeout_secs extract_timeout status=0 seed_reg="" holder
     lower="$(basename "$installer" | tr '[:upper:]' '[:lower:]')"
     if [[ "$lower" = *.zip ]]; then
         unpack="$(mktemp -d "${TMPDIR:-/tmp}/ableton-live-installer.XXXXXX")"
@@ -819,16 +819,8 @@ EOF
         done
         rm -f -- "$seed_reg"
     fi
-    # Images the payload starts and never stops. Live 12's WebView2 bootstrapper
-    # leaves MicrosoftEdgeUpdate.exe in core mode (/c), which has no window and, in a
-    # prefix, does not reach the exit it takes on Windows; the Push images are the
-    # driver's tray agents. All three are windowless background agents named exactly,
-    # so no application is ended here.
-    for tray in AbletonPushCpl.exe tusbaudiocplapp.exe MicrosoftEdgeUpdate.exe; do
-        ableton_run_bounded 15 env WINEPREFIX="$ABLETON_WINEPREFIX" \
-            "$ABLETON_WINE_ROOT/bin/wine" taskkill /f /im "$tray" >/dev/null 2>&1 || true
-    done
-    # This prefix is the promoted one, so anything the names above did not cover is
+    ableton_stop_leftover_agents
+    # This prefix is the promoted one, so a process no agent name covered is
     # reported and left running rather than stopped: it is the user's, and the
     # install is complete either way. The prefix was promoted before the payload ran
     # and nothing after this point touches it, so the wait is hygiene, not a gate.
@@ -836,13 +828,7 @@ EOF
         echo "-- the install is complete. A program in the prefix is still running and"
         echo "   was left alone:"
         for holder in $(ableton_prefix_pids); do
-            # comm truncates at 15 characters, which is short of most Windows image
-            # names, so the command line is the one that can be acted on.
-            holder_name="$(tr '\0' '\n' < "/proc/$holder/cmdline" 2>/dev/null | head -n 1)"
-            holder_name="${holder_name##*\\}"
-            holder_name="${holder_name##*/}"
-            [ -n "$holder_name" ] || holder_name="$(cat "/proc/$holder/comm" 2>/dev/null || true)"
-            printf '   %s (pid %s)\n' "${holder_name:-unknown}" "$holder"
+            printf '   %s (pid %s)\n' "$(ableton_pid_image "$holder")" "$holder"
         done
         echo "-- nothing needs to be done. To end it anyway, close it or run:"
         printf '   WINEPREFIX=%s %s/bin/wineserver -k\n' \

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -828,7 +828,7 @@ EOF
         while IFS="$(printf '\t')" read -r holder holder_image; do
             [ -n "$holder" ] || continue
             printf '   %s (pid %s)\n' "$holder_image" "$holder"
-        done < <(ableton_prefix_holders)
+        done < <(ableton_prefix_foreign_holders)
         echo "-- nothing needs to be done. To end it anyway, close it or run:"
         printf '   WINEPREFIX=%s %s/bin/wineserver -k\n' \
             "$ABLETON_WINEPREFIX" "$ABLETON_WINE_ROOT"

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -828,7 +828,7 @@ EOF
         while IFS="$(printf '\t')" read -r holder holder_image; do
             [ -n "$holder" ] || continue
             printf '   %s (pid %s)\n' "$holder_image" "$holder"
-        done < <(ableton_prefix_foreign_holders)
+        done < <(ableton_prefix_unknown_holders)
         echo "-- nothing needs to be done. To end it anyway, close it or run:"
         printf '   WINEPREFIX=%s %s/bin/wineserver -k\n' \
             "$ABLETON_WINEPREFIX" "$ABLETON_WINE_ROOT"

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -136,34 +136,23 @@ ableton_wait_for_pid_exit()
     return 1
 }
 
-# Windowless agents an install or a session starts and never stops, ended by
-# exact name so no application is touched.  MicrosoftEdgeUpdate.exe is Live 12's
-# WebView2 updater: under Wine its COM registration fails to validate, so it
-# cannot start an update worker and parks in Core::DoRun indefinitely, holding
-# the prefix open after everything else has gone.  A Max session leaves the same
-# process behind.  The Push images are the USB driver's tray applets.  An image
-# that is not running is a no-op, so callers need not know which apply.
+# Windowless agents Live and Max leave behind, ended by exact name so no
+# application is touched.  A name that is not running is a no-op.
 ableton_stop_leftover_agents()
 {
     local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}"
-    # wine builds a prefix at any path it is handed, so a caller that gave up
-    # because the runtime or prefix was missing must not create one on its way
-    # out.  Nothing is running in a prefix that does not exist either.
+    # wine builds a prefix at any path it is handed; a refusal must not create one.
     [ -x "$runtime/bin/wine" ] || return 0
     [ -f "$prefix/system.reg" ] || return 0
-    # One invocation, not one per image: taskkill takes a list, and each wine
-    # start costs a second of a user's exit - or fifteen against a prefix that
-    # has stopped answering, three times over.
+    # One invocation: taskkill takes a list, and each wine start costs exit latency.
     ableton_run_bounded 15 env WINEPREFIX="$prefix" "$runtime/bin/wine" taskkill /f \
         /im AbletonPushCpl.exe /im tusbaudiocplapp.exe /im MicrosoftEdgeUpdate.exe \
         >/dev/null 2>&1 || true
     return 0
 }
 
-# Windows image name from the command line, which carries the full path where
-# /proc/PID/comm is truncated at 15 characters - short of most of them.  argv[0]
-# is read on its own NUL boundary: every Windows path has a space in it, so
-# splitting the joined command line on whitespace yields "Program".
+# Windows image name.  comm truncates at 15 characters, and argv[0] must be read
+# on its NUL boundary: split on whitespace and every C:\Program Files path is "Program".
 ableton_pid_image()
 {
     local image
@@ -175,22 +164,16 @@ ableton_pid_image()
     printf '%s\n' "${image:-unknown}"
 }
 
-# End a session: stop the agents it leaves behind, then confirm the prefix
-# actually came down rather than assume it.  Wine's own processes exit once the
-# last client goes, so a prefix still busy after that grace period is being held
-# by something real - a Max, a second Live, or a program the user started in this
-# prefix themselves.  That is reported and left alone: at this point we cannot
-# tell a user's program from a leftover, and ending the session would take it
-# with us.  Returns non-zero when the prefix is still held.
+# End a session's agents, then confirm the prefix came down.  Whatever still holds
+# it is a Max, a second Live or the user's own program - reported, never ended,
+# since none of them is distinguishable from a leftover here.  Non-zero if held.
 ableton_session_teardown()
 {
     local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}"
     local seconds="${3:-5}" i pid
     seconds="$(ableton_timeout_value "$seconds" teardown-grace 1 60)" || return 2
-    # Nothing to end, and nothing to wait for.  Checked first because taskkill is
-    # itself a wine process: on an empty prefix it starts a server and a pair of
-    # services that outlive the grace period below, and the teardown would then
-    # report the session it started as the thing holding the prefix.
+    # First: taskkill is itself a wine process, so on an empty prefix it would start
+    # a server and services that outlive the grace period and be reported as holders.
     ableton_prefix_busy || return 0
     ableton_stop_leftover_agents "$runtime" "$prefix" || true
     for ((i=0; i<seconds*10; i++)); do
@@ -215,17 +198,38 @@ ableton_prefix_wait()
         "$runtime/bin/wineserver" -w >/dev/null 2>&1
 }
 
+# The same wait, naming what it waits on every 15s: a silent minute in front of an
+# installer reads as a hang.  Same bounded wait, same exit code.
+ableton_prefix_wait_progress()
+{
+    local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}"
+    local waiter rc=0 elapsed=0 names pid
+    ableton_run_bounded 60 env WINEPREFIX="$prefix" \
+        "$runtime/bin/wineserver" -w >/dev/null 2>&1 &
+    waiter=$!
+    while kill -0 "$waiter" 2>/dev/null; do
+        sleep 1
+        elapsed=$((elapsed + 1))
+        [ "$((elapsed % 15))" -eq 0 ] || continue
+        names="$(while IFS= read -r pid; do
+                     [ -n "$pid" ] || continue
+                     ableton_pid_image "$pid"
+                 done < <(ableton_prefix_pids) | sort -u | tr '\n' ' ')"
+        [ -z "${names// /}" ] \
+            || printf -- '   still waiting for the prefix to settle (%ss): %s\n' \
+                "$elapsed" "$names"
+    done
+    wait "$waiter" || rc=$?
+    return "$rc"
+}
+
 # Wait, and on timeout end every process in the prefix and wait again.  The stop is
-# indiscriminate, so this is only for a prefix the caller owns outright - a staging
-# prefix it just built, or one it is about to remove.  On a prefix the user can
-# reach, name the images to end instead and take ableton_prefix_wait's verdict as
-# advisory.  wineserver -k shuts down through SIGINT, so the registry is saved.
-# Returns 1 when a straggler survived the stop, and the wait's own exit code when
-# the wait could not run at all.
+# indiscriminate: only for a prefix the caller owns outright, never one a user can
+# reach.  Returns 1 if a straggler survived, else the wait's own exit code.
 ableton_prefix_quiesce()
 {
     local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}" rc=0
-    ableton_prefix_wait "$runtime" "$prefix" || rc=$?
+    ableton_prefix_wait_progress "$runtime" "$prefix" || rc=$?
     if [ "$rc" -eq 0 ]; then
         return 0
     fi

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -280,15 +280,15 @@ ableton_prefix_wait()
 }
 
 # The same wait, naming what it waits on every 15s: a silent minute in front of an
-# installer reads as a hang.  Same bounded wait, same exit code.  Ticks go to
+# installer reads as a hang.  It is the wait above, run in the background and
+# watched, so the bound and the exit code cannot drift from it.  Ticks go to
 # stdout, where the rest of the install narrative goes; the teardown's messages
 # go to stderr, being diagnostics after an application has closed.
 ableton_prefix_wait_progress()
 {
     local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}"
     local waiter rc=0 elapsed=0 names
-    ableton_run_bounded 60 env WINEPREFIX="$prefix" \
-        "$runtime/bin/wineserver" -w >/dev/null 2>&1 &
+    ableton_prefix_wait "$runtime" "$prefix" &
     waiter=$!
     while kill -0 "$waiter" 2>/dev/null; do
         sleep 1

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -136,6 +136,76 @@ ableton_wait_for_pid_exit()
     return 1
 }
 
+# Windowless agents an install or a session starts and never stops, ended by
+# exact name so no application is touched.  MicrosoftEdgeUpdate.exe is Live 12's
+# WebView2 updater: under Wine its COM registration fails to validate, so it
+# cannot start an update worker and parks in Core::DoRun indefinitely, holding
+# the prefix open after everything else has gone.  A Max session leaves the same
+# process behind.  The Push images are the USB driver's tray applets.  An image
+# that is not running is a no-op, so callers need not know which apply.
+ableton_stop_leftover_agents()
+{
+    local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}"
+    # wine builds a prefix at any path it is handed, so a caller that gave up
+    # because the runtime or prefix was missing must not create one on its way
+    # out.  Nothing is running in a prefix that does not exist either.
+    [ -x "$runtime/bin/wine" ] || return 0
+    [ -f "$prefix/system.reg" ] || return 0
+    # One invocation, not one per image: taskkill takes a list, and each wine
+    # start costs a second of a user's exit - or fifteen against a prefix that
+    # has stopped answering, three times over.
+    ableton_run_bounded 15 env WINEPREFIX="$prefix" "$runtime/bin/wine" taskkill /f \
+        /im AbletonPushCpl.exe /im tusbaudiocplapp.exe /im MicrosoftEdgeUpdate.exe \
+        >/dev/null 2>&1 || true
+    return 0
+}
+
+# Windows image name from the command line, which carries the full path where
+# /proc/PID/comm is truncated at 15 characters - short of most of them.  argv[0]
+# is read on its own NUL boundary: every Windows path has a space in it, so
+# splitting the joined command line on whitespace yields "Program".
+ableton_pid_image()
+{
+    local image
+    image="$(tr '\0' '\n' < "/proc/$1/cmdline" 2>/dev/null | head -n 1)"
+    image="${image##*\\}"
+    image="${image##*/}"
+    # A process that exits while it is being reported leaves nothing to read.
+    [ -n "$image" ] || image="$(cat "/proc/$1/comm" 2>/dev/null || true)"
+    printf '%s\n' "${image:-unknown}"
+}
+
+# End a session: stop the agents it leaves behind, then confirm the prefix
+# actually came down rather than assume it.  Wine's own processes exit once the
+# last client goes, so a prefix still busy after that grace period is being held
+# by something real - a Max, a second Live, or a program the user started in this
+# prefix themselves.  That is reported and left alone: at this point we cannot
+# tell a user's program from a leftover, and ending the session would take it
+# with us.  Returns non-zero when the prefix is still held.
+ableton_session_teardown()
+{
+    local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}"
+    local seconds="${3:-5}" i pid
+    seconds="$(ableton_timeout_value "$seconds" teardown-grace 1 60)" || return 2
+    # Nothing to end, and nothing to wait for.  Checked first because taskkill is
+    # itself a wine process: on an empty prefix it starts a server and a pair of
+    # services that outlive the grace period below, and the teardown would then
+    # report the session it started as the thing holding the prefix.
+    ableton_prefix_busy || return 0
+    ableton_stop_leftover_agents "$runtime" "$prefix" || true
+    for ((i=0; i<seconds*10; i++)); do
+        ableton_prefix_busy || return 0
+        sleep 0.1
+    done
+    ableton_prefix_busy || return 0
+    printf -- '-- the prefix is still in use, so its wineserver stays up for:\n' >&2
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        printf '   %s (pid %s)\n' "$(ableton_pid_image "$pid")" "$pid" >&2
+    done < <(ableton_prefix_pids)
+    return 1
+}
+
 # Wait for every process in the prefix to exit.  Bounded: a resident that outlives
 # the command that started it holds the server open indefinitely.
 ableton_prefix_wait()

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -176,6 +176,35 @@ ableton_prefix_holders()
     return 0
 }
 
+# A helper this project installed and started, asked by the data home rather than
+# by name so it stays right as helpers come and go.  Each carries its own exit
+# contract - learnheal.exe outlives Live deliberately, to heal the Learn View
+# pane - so one still running does not mean the session is unfinished.
+ableton_vendored_helper_image()
+{
+    [ -n "${ABLETON_DATA_HOME:-}" ] || return 1
+    [ -f "$ABLETON_DATA_HOME/$1" ]
+}
+
+# Holders that are somebody else's: a Max, a second Live, a program the user
+# started.  These are the ones worth naming.  Reads a holder list so a caller
+# that already walked /proc need not walk it again.
+ableton_foreign_holders()
+{
+    local pid image
+    while IFS="$(printf '\t')" read -r pid image; do
+        [ -n "$pid" ] || continue
+        ableton_vendored_helper_image "$image" && continue
+        printf '%s\t%s\n' "$pid" "$image"
+    done
+    return 0
+}
+
+ableton_prefix_foreign_holders()
+{
+    ableton_prefix_holders | ableton_foreign_holders
+}
+
 # Windows image name.  comm truncates at 15 characters, and argv[0] must be read
 # on its NUL boundary: split on whitespace and every C:\Program Files path is "Program".
 ableton_pid_image()
@@ -195,22 +224,35 @@ ableton_pid_image()
 ableton_session_teardown()
 {
     local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}"
-    local seconds="${3:-5}" i pid image
-    seconds="$(ableton_timeout_value "$seconds" teardown-grace 1 60)" || return 2
+    local seconds="${3:-1}" pid image holders foreign=""
+    seconds="$(ableton_timeout_value "$seconds" teardown-settle 1 60)" || return 2
     # First: taskkill is itself a wine process, so on an empty prefix it would start
     # a server and services that outlive the grace period and be reported as holders.
     ableton_prefix_busy || return 0
     ableton_stop_leftover_agents "$runtime" "$prefix" || true
-    for ((i=0; i<seconds*10; i++)); do
-        ableton_prefix_busy || return 0
-        sleep 0.1
-    done
-    ableton_prefix_busy || return 0
+    # One beat for the agents just ended to go, then one look.  Not a poll: each
+    # look walks every pid on the machine, and there is nothing to wait for -
+    # Wine's own processes are already filtered out, and whatever else is here is
+    # an application, which will not leave within a grace period.
+    sleep "$seconds"
+    holders="$(ableton_prefix_holders)"
+    [ -n "$holders" ] || return 0
+    foreign="$(printf '%s\n' "$holders" | ableton_foreign_holders)"
+    # Ours alone: the session is over, the helper finishes on its own, and the
+    # server goes with it.  Said out loud because a wineserver outliving the
+    # window looks like the bug this teardown exists to prevent.
+    if [ -z "$foreign" ]; then
+        printf -- '-- %s closed; a background helper is still finishing and will quit on its own\n' \
+            "${ABLETON_SESSION_LABEL:-the session}" >&2
+        return 0
+    fi
     printf -- '-- the prefix is still in use, so its wineserver stays up for:\n' >&2
+    # Here-string, not a pipe from printf '%s': command substitution stripped the
+    # trailing newline above, and read drops an unterminated final line.
     while IFS="$(printf '\t')" read -r pid image; do
         [ -n "$pid" ] || continue
         printf '   %s (pid %s)\n' "$image" "$pid" >&2
-    done < <(ableton_prefix_holders)
+    done <<< "$foreign"
     return 1
 }
 

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -2,11 +2,12 @@
 # Prefix- and runtime-scoped Wine lifecycle inspection.  No process is selected
 # by a global image-name match: both /proc/PID/exe and WINEPREFIX must match.
 
+# Definitions only: callers resolve the configuration themselves, because the
+# command line reaches some of them after this file is sourced.
 _ableton_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if ! declare -F ableton_config_init >/dev/null 2>&1; then
     . "$_ableton_lib_dir/config.sh"
 fi
-ableton_config_init
 
 ableton_pid_has_env()
 {
@@ -133,6 +134,38 @@ ableton_wait_for_pid_exit()
         sleep 0.1
     done
     return 1
+}
+
+# Wait for every process in the prefix to exit.  Bounded: a resident that outlives
+# the command that started it holds the server open indefinitely.
+ableton_prefix_wait()
+{
+    local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}"
+    ableton_run_bounded 60 env WINEPREFIX="$prefix" \
+        "$runtime/bin/wineserver" -w >/dev/null 2>&1
+}
+
+# Wait, and on timeout end every process in the prefix and wait again.  The stop is
+# indiscriminate, so this is only for a prefix the caller owns outright - a staging
+# prefix it just built, or one it is about to remove.  On a prefix the user can
+# reach, name the images to end instead and take ableton_prefix_wait's verdict as
+# advisory.  wineserver -k shuts down through SIGINT, so the registry is saved.
+# Returns 1 when a straggler survived the stop, and the wait's own exit code when
+# the wait could not run at all.
+ableton_prefix_quiesce()
+{
+    local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}" rc=0
+    ableton_prefix_wait "$runtime" "$prefix" || rc=$?
+    if [ "$rc" -eq 0 ]; then
+        return 0
+    fi
+    if [ "$rc" -ne 124 ] && [ "$rc" -ne 137 ]; then
+        return "$rc"
+    fi
+    echo "-- a leftover background program is holding the prefix open; stopping it"
+    ableton_run_bounded 20 env WINEPREFIX="$prefix" \
+        "$runtime/bin/wineserver" -k >/dev/null 2>&1 || true
+    ableton_prefix_wait "$runtime" "$prefix" || return 1
 }
 
 ableton_stop_prefix()

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -221,6 +221,8 @@ ableton_pid_image()
 # End a session's agents, then confirm the prefix came down.  Whatever still holds
 # it is a Max, a second Live or the user's own program - reported, never ended,
 # since none of them is distinguishable from a leftover here.  Non-zero if held.
+# Callers name themselves through ABLETON_SESSION_LABEL, which each launcher sets
+# on the call; unset reads as "the session".
 ableton_session_teardown()
 {
     local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}"
@@ -266,7 +268,9 @@ ableton_prefix_wait()
 }
 
 # The same wait, naming what it waits on every 15s: a silent minute in front of an
-# installer reads as a hang.  Same bounded wait, same exit code.
+# installer reads as a hang.  Same bounded wait, same exit code.  Ticks go to
+# stdout, where the rest of the install narrative goes; the teardown's messages
+# go to stderr, being diagnostics after an application has closed.
 ableton_prefix_wait_progress()
 {
     local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}"
@@ -278,7 +282,7 @@ ableton_prefix_wait_progress()
         sleep 1
         elapsed=$((elapsed + 1))
         [ "$((elapsed % 15))" -eq 0 ] || continue
-        names="$(ableton_prefix_holders | cut -f2 | sort -u | tr '\n' ' ')"
+        names="$(ableton_prefix_foreign_holders | cut -f2 | sort -u | tr '\n' ' ')"
         [ -z "${names// /}" ] \
             || printf -- '   still waiting for the prefix to settle (%ss): %s\n' \
                 "$elapsed" "$names"

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -151,6 +151,31 @@ ableton_stop_leftover_agents()
     return 0
 }
 
+# Wine's own processes, alive only while a client is.  Naming them in a report
+# buries the one process that is actually holding the prefix.
+ableton_wine_own_image()
+{
+    case "$1" in
+        services.exe|winedevice.exe|plugplay.exe|svchost.exe|rpcss.exe|explorer.exe|\
+        winemenubuilder.exe|start.exe|conhost.exe|wineboot.exe|rundll32.exe|wineserver)
+            return 0 ;;
+    esac
+    return 1
+}
+
+# The prefix's processes worth reporting: everything Wine did not start itself.
+ableton_prefix_holders()
+{
+    local pid image
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        image="$(ableton_pid_image "$pid")"
+        ableton_wine_own_image "$image" && continue
+        printf '%s\t%s\n' "$pid" "$image"
+    done < <(ableton_prefix_pids)
+    return 0
+}
+
 # Windows image name.  comm truncates at 15 characters, and argv[0] must be read
 # on its NUL boundary: split on whitespace and every C:\Program Files path is "Program".
 ableton_pid_image()
@@ -170,7 +195,7 @@ ableton_pid_image()
 ableton_session_teardown()
 {
     local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}"
-    local seconds="${3:-5}" i pid
+    local seconds="${3:-5}" i pid image
     seconds="$(ableton_timeout_value "$seconds" teardown-grace 1 60)" || return 2
     # First: taskkill is itself a wine process, so on an empty prefix it would start
     # a server and services that outlive the grace period and be reported as holders.
@@ -182,10 +207,10 @@ ableton_session_teardown()
     done
     ableton_prefix_busy || return 0
     printf -- '-- the prefix is still in use, so its wineserver stays up for:\n' >&2
-    while IFS= read -r pid; do
+    while IFS="$(printf '\t')" read -r pid image; do
         [ -n "$pid" ] || continue
-        printf '   %s (pid %s)\n' "$(ableton_pid_image "$pid")" "$pid" >&2
-    done < <(ableton_prefix_pids)
+        printf '   %s (pid %s)\n' "$image" "$pid" >&2
+    done < <(ableton_prefix_holders)
     return 1
 }
 
@@ -203,7 +228,7 @@ ableton_prefix_wait()
 ableton_prefix_wait_progress()
 {
     local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}"
-    local waiter rc=0 elapsed=0 names pid
+    local waiter rc=0 elapsed=0 names
     ableton_run_bounded 60 env WINEPREFIX="$prefix" \
         "$runtime/bin/wineserver" -w >/dev/null 2>&1 &
     waiter=$!
@@ -211,10 +236,7 @@ ableton_prefix_wait_progress()
         sleep 1
         elapsed=$((elapsed + 1))
         [ "$((elapsed % 15))" -eq 0 ] || continue
-        names="$(while IFS= read -r pid; do
-                     [ -n "$pid" ] || continue
-                     ableton_pid_image "$pid"
-                 done < <(ableton_prefix_pids) | sort -u | tr '\n' ' ')"
+        names="$(ableton_prefix_holders | cut -f2 | sort -u | tr '\n' ' ')"
         [ -z "${names// /}" ] \
             || printf -- '   still waiting for the prefix to settle (%ss): %s\n' \
                 "$elapsed" "$names"

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -31,18 +31,22 @@ ableton_pid_uses_runtime()
     esac
 }
 
+# The prefix and runtime default to the configured pair, but every walker below
+# takes them, so a caller working on a prefix that is not the configured one -
+# setup-prefix.sh, inside its staging window - inspects the prefix it named
+# rather than the user's.
 ableton_pid_uses_prefix()
 {
-    ableton_pid_has_env "$1" "WINEPREFIX=$ABLETON_WINEPREFIX"
+    ableton_pid_has_env "$1" "WINEPREFIX=${2:-$ABLETON_WINEPREFIX}"
 }
 
 ableton_prefix_pids()
 {
-    local proc pid
+    local root="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}" proc pid
     for proc in /proc/[0-9]*; do
         pid="${proc#/proc/}"
-        ableton_pid_uses_runtime "$pid" || continue
-        ableton_pid_uses_prefix "$pid" || continue
+        ableton_pid_uses_runtime "$pid" "$root" || continue
+        ableton_pid_uses_prefix "$pid" "$prefix" || continue
         printf '%s\n' "$pid"
     done
     return 0
@@ -103,7 +107,7 @@ ableton_live_running()
 ableton_prefix_busy()
 {
     local pid
-    pid="$(ableton_prefix_pids | head -n 1)"
+    pid="$(ableton_prefix_pids "${1:-}" "${2:-}" | head -n 1)"
     [ -n "$pid" ]
 }
 
@@ -172,7 +176,7 @@ ableton_prefix_holders()
         image="$(ableton_pid_image "$pid")"
         ableton_wine_own_image "$image" && continue
         printf '%s\t%s\n' "$pid" "$image"
-    done < <(ableton_prefix_pids)
+    done < <(ableton_prefix_pids "${1:-}" "${2:-}")
     return 0
 }
 
@@ -189,7 +193,7 @@ ableton_vendored_helper_image()
 # Holders that are somebody else's: a Max, a second Live, a program the user
 # started.  These are the ones worth naming.  Reads a holder list so a caller
 # that already walked /proc need not walk it again.
-ableton_foreign_holders()
+ableton_unknown_holders()
 {
     local pid image
     while IFS="$(printf '\t')" read -r pid image; do
@@ -200,9 +204,9 @@ ableton_foreign_holders()
     return 0
 }
 
-ableton_prefix_foreign_holders()
+ableton_prefix_unknown_holders()
 {
-    ableton_prefix_holders | ableton_foreign_holders
+    ableton_prefix_holders "${1:-}" "${2:-}" | ableton_unknown_holders
 }
 
 # Windows image name.  comm truncates at 15 characters, and argv[0] must be read
@@ -210,7 +214,9 @@ ableton_prefix_foreign_holders()
 ableton_pid_image()
 {
     local image
-    image="$(tr '\0' '\n' < "/proc/$1/cmdline" 2>/dev/null | head -n 1)"
+    # 2>/dev/null first: redirections are applied left to right, so with the input
+    # last the open failure is reported before stderr has been silenced.
+    image="$(tr '\0' '\n' 2>/dev/null < "/proc/$1/cmdline" | head -n 1)"
     image="${image##*\\}"
     image="${image##*/}"
     # A process that exits while it is being reported leaves nothing to read.
@@ -226,35 +232,41 @@ ableton_pid_image()
 ableton_session_teardown()
 {
     local runtime="${1:-$ABLETON_WINE_ROOT}" prefix="${2:-$ABLETON_WINEPREFIX}"
-    local seconds="${3:-1}" pid image holders foreign=""
+    local seconds="${3:-1}" pid image holders unknown=""
     seconds="$(ableton_timeout_value "$seconds" teardown-settle 1 60)" || return 2
     # First: taskkill is itself a wine process, so on an empty prefix it would start
     # a server and services that outlive the grace period and be reported as holders.
-    ableton_prefix_busy || return 0
+    ableton_prefix_busy "$runtime" "$prefix" || return 0
     ableton_stop_leftover_agents "$runtime" "$prefix" || true
     # One beat for the agents just ended to go, then one look.  Not a poll: each
     # look walks every pid on the machine, and there is nothing to wait for -
     # Wine's own processes are already filtered out, and whatever else is here is
     # an application, which will not leave within a grace period.
     sleep "$seconds"
-    holders="$(ableton_prefix_holders)"
+    holders="$(ableton_prefix_holders "$runtime" "$prefix")"
     [ -n "$holders" ] || return 0
-    foreign="$(printf '%s\n' "$holders" | ableton_foreign_holders)"
+    unknown="$(printf '%s\n' "$holders" | ableton_unknown_holders)"
     # Ours alone: the session is over, the helper finishes on its own, and the
     # server goes with it.  Said out loud because a wineserver outliving the
     # window looks like the bug this teardown exists to prevent.
-    if [ -z "$foreign" ]; then
+    if [ -z "$unknown" ]; then
         printf -- '-- %s closed; a background helper is still finishing and will quit on its own\n' \
             "${ABLETON_SESSION_LABEL:-the session}" >&2
         return 0
     fi
-    printf -- '-- the prefix is still in use, so its wineserver stays up for:\n' >&2
+    printf -- '-- %s closed. Other unknown processes were left running:\n' \
+        "${ABLETON_SESSION_LABEL:-the session}" >&2
     # Here-string, not a pipe from printf '%s': command substitution stripped the
     # trailing newline above, and read drops an unterminated final line.
     while IFS="$(printf '\t')" read -r pid image; do
         [ -n "$pid" ] || continue
         printf '   %s (pid %s)\n' "$image" "$pid" >&2
-    done <<< "$foreign"
+    done <<< "$unknown"
+    # Naming them is half an answer: someone who wants them gone needs the means,
+    # and the paths are the ones this session actually used.  Printed rather than
+    # run, because whether they should go is the user's call.
+    printf -- '-- Ableton-Linux helpers close themselves once the prefix is free. To kill the prefix forcefully instead:\n' >&2
+    printf -- '   WINEPREFIX=%s %s/bin/wineserver -k\n' "$prefix" "$runtime" >&2
     return 1
 }
 
@@ -282,7 +294,8 @@ ableton_prefix_wait_progress()
         sleep 1
         elapsed=$((elapsed + 1))
         [ "$((elapsed % 15))" -eq 0 ] || continue
-        names="$(ableton_prefix_foreign_holders | cut -f2 | sort -u | tr '\n' ' ')"
+        names="$(ableton_prefix_unknown_holders "$runtime" "$prefix" \
+            | cut -f2 | sort -u | tr '\n' ' ')"
         [ -z "${names// /}" ] \
             || printf -- '   still waiting for the prefix to settle (%ss): %s\n' \
                 "$elapsed" "$names"

--- a/scripts/max9
+++ b/scripts/max9
@@ -13,6 +13,17 @@ for lib in "$here/lib/lifecycle.sh" "$ABLETON_DATA_HOME/lib/lifecycle.sh"; do
 done
 declare -F ableton_max_pids >/dev/null 2>&1 || { echo "max9: lifecycle helper is missing" >&2; exit 1; }
 
+# Max exits cleanly - its node.exe helpers and console host go with it - but a
+# Max session leaves WebView2's updater behind exactly as a Live session does,
+# and that one agent holds the wineserver for the rest of the login session.
+session_teardown()
+{
+    local rc=$?
+    ableton_session_teardown || true
+    return "$rc"
+}
+trap session_teardown EXIT
+
 WINE_ROOT="$ABLETON_WINE_ROOT"
 export WINEPREFIX="$ABLETON_WINEPREFIX"
 MAX_EXE="C:\\Program Files\\Cycling '74\\Max 9\\Max.exe"

--- a/scripts/max9
+++ b/scripts/max9
@@ -21,7 +21,6 @@ session_teardown()
     ABLETON_SESSION_LABEL="Max" ableton_session_teardown || true
     return "$rc"
 }
-trap session_teardown EXIT
 
 WINE_ROOT="$ABLETON_WINE_ROOT"
 export WINEPREFIX="$ABLETON_WINEPREFIX"
@@ -30,6 +29,10 @@ MAX_UNIX="$WINEPREFIX/drive_c/Program Files/Cycling '74/Max 9/Max.exe"
 [ -x "$WINE_ROOT/bin/wine" ] || { echo "max9: Wine runtime is missing at $WINE_ROOT" >&2; exit 1; }
 [ -f "$WINEPREFIX/system.reg" ] || { echo "max9: Wine prefix is missing at $WINEPREFIX" >&2; exit 1; }
 [ -f "$MAX_UNIX" ] || { echo "max9: no Max 9 installation in $WINEPREFIX" >&2; exit 1; }
+
+# Armed after the guards: teardown ends this prefix's agents, and a launch that
+# refused to start has no session to end - Live may be running in this prefix.
+trap session_teardown EXIT
 
 caller_winedlloverrides="${WINEDLLOVERRIDES:-}"
 unset WINELOADER WINEDLLPATH WINEDLLOVERRIDES WINEARCH

--- a/scripts/max9
+++ b/scripts/max9
@@ -18,7 +18,7 @@ declare -F ableton_max_pids >/dev/null 2>&1 || { echo "max9: lifecycle helper is
 session_teardown()
 {
     local rc=$?
-    ableton_session_teardown || true
+    ABLETON_SESSION_LABEL="Max" ableton_session_teardown || true
     return "$rc"
 }
 trap session_teardown EXIT

--- a/scripts/max9
+++ b/scripts/max9
@@ -13,9 +13,8 @@ for lib in "$here/lib/lifecycle.sh" "$ABLETON_DATA_HOME/lib/lifecycle.sh"; do
 done
 declare -F ableton_max_pids >/dev/null 2>&1 || { echo "max9: lifecycle helper is missing" >&2; exit 1; }
 
-# Max exits cleanly - its node.exe helpers and console host go with it - but a
-# Max session leaves WebView2's updater behind exactly as a Live session does,
-# and that one agent holds the wineserver for the rest of the login session.
+# Max exits cleanly, but a Max session leaves the same updater behind as a Live
+# one, and it holds the wineserver for the rest of the login session.
 session_teardown()
 {
     local rc=$?

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -155,6 +155,12 @@ refuse_runtime_users()
         else
             echo "!! another Wine prefix is using this runtime; close it before rollback" >&2
         fi
+        # Naming them matters here: a windowless agent left in the prefix reads
+        # as "close Live" with no Live to close, and rollback is what someone
+        # reaches for when something is already wrong.
+        for pid in $runtime_users; do
+            printf '   %s (pid %s)\n' "$(ableton_pid_image "$pid")" "$pid" >&2
+        done
         return 1
     }
 }

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -201,7 +201,7 @@ rollback_wine()
 }
 rollback_wineserver_wait()
 {
-    ableton_run_bounded 60 "$runtime/bin/wineserver" -w
+    ableton_prefix_wait "$runtime"
 }
 
 move_runtime_to_empty()

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -155,9 +155,7 @@ refuse_runtime_users()
         else
             echo "!! another Wine prefix is using this runtime; close it before rollback" >&2
         fi
-        # Naming them matters here: a windowless agent left in the prefix reads
-        # as "close Live" with no Live to close, and rollback is what someone
-        # reaches for when something is already wrong.
+        # "close Live" is unactionable when the holder is a windowless agent.
         for pid in $runtime_users; do
             printf '   %s (pid %s)\n' "$(ableton_pid_image "$pid")" "$pid" >&2
         done

--- a/scripts/setup-prefix.sh
+++ b/scripts/setup-prefix.sh
@@ -445,13 +445,15 @@ wineboot()
 {
     ableton_run_bounded "$wine_command_timeout" "$WINE_ROOT/bin/wineboot" "$@"
 }
+# WINEPREFIX moves from the staging path to the final one partway through, so
+# both helpers name the prefix in force rather than the configured one.
 ableton_wineserver_wait()
 {
-    ableton_run_bounded 60 "$WINESERVER" -w
+    ableton_prefix_wait "$WINE_ROOT" "$WINEPREFIX"
 }
-ableton_wineserver_kill()
+ableton_wineserver_quiesce()
 {
-    ableton_run_bounded 20 "$WINESERVER" -k
+    ableton_prefix_quiesce "$WINE_ROOT" "$WINEPREFIX"
 }
 
 # DPI blocks: a detected scale maps to a calibrated set by compositor family (see
@@ -660,21 +662,14 @@ for startup_root in "$WINEPREFIX/drive_c/users" "$WINEPREFIX/drive_c/ProgramData
     find "$startup_root" -ipath '*Start Menu/Programs/Startup/*' \
         \( -iname '*ableton*' -o -iname '*push*' -o -iname '*tusbaudio*' \) -delete 2>/dev/null || true
 done
-# Bounded, because any resident wineboot started parks this barrier forever: the agent
-# under a name the taskkill missed, or WebView2's MicrosoftEdgeUpdate.exe, whose scheduled
-# task fires about two minutes after a boot and has no window (the --update half of issue
-# #111 is exactly this wait). On timeout, end every process in the prefix and continue -
-# the boot's registry writes are persisted when the server exits. The second wait stays
-# bounded too, in case a straggler survives even SIGKILL.
+# Any resident wineboot started parks this barrier forever: the agent under a name the
+# taskkill missed, or WebView2's MicrosoftEdgeUpdate.exe, whose scheduled task fires about
+# two minutes after a boot and has no window (the --update half of issue #111 is exactly
+# this wait). The boot's registry writes are persisted when the server exits, so a
+# straggler that survives the stop does not block the setup that follows.
 boot_wait_rc=0
-ableton_wineserver_wait || boot_wait_rc=$?
-if [ "$boot_wait_rc" -eq 124 ] || [ "$boot_wait_rc" -eq 137 ]; then
-    echo "-- a leftover background program is holding the prefix open; stopping it"
-    ableton_wineserver_kill 2>/dev/null || true
-    ableton_wineserver_wait 2>/dev/null || true
-elif [ "$boot_wait_rc" -ne 0 ]; then
-    exit "$boot_wait_rc"
-fi
+ableton_wineserver_quiesce || boot_wait_rc=$?
+[ "$boot_wait_rc" -le 1 ] || exit "$boot_wait_rc"
 
 if [ "$refresh" -eq 1 ]; then
     echo "== [2/5] winetricks: skipped (--refresh keeps the installed fonts/runtimes) =="

--- a/scripts/test-installer-lifecycle.sh
+++ b/scripts/test-installer-lifecycle.sh
@@ -527,6 +527,159 @@ grep -q 'appears to be Live 11' "$base/err" || fail "payload mismatch is explici
 [ ! -e "$base/runtime" ] && [ ! -e "$base/prefix" ] && [ ! -e "$base/config" ] || fail "payload mismatch mutates no installation state"
 ok "Live payload major is validated before installation"
 
+base="$(new_env prefix-quiesce)"
+mkdir -p "$base/runtime/bin" "$base/prefix"
+# 124 is timeout's TERM verdict, so the stub reports an expired wait without the
+# suite spending the wait's wall clock on it.
+cat > "$base/runtime/bin/wineserver" <<'EOF'
+#!/usr/bin/env bash
+printf '%s prefix=%s\n' "$1" "${WINEPREFIX-unset}" >> "${ABLETON_TEST_LOG:?}"
+case "$1" in
+    -w)
+        [ "${ABLETON_TEST_WAIT_EXIT:-0}" -eq 0 ] || exit "${ABLETON_TEST_WAIT_EXIT}"
+        [ ! -e "${ABLETON_TEST_BUSY:?}" ] || exit 124
+        exit 0 ;;
+    -k)
+        [ "${ABLETON_TEST_UNKILLABLE:-0}" -eq 1 ] || rm -f -- "${ABLETON_TEST_BUSY:?}"
+        exit 0 ;;
+esac
+exit 2
+EOF
+cat > "$base/run-quiesce" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+. "$here/lib/lifecycle.sh"
+ableton_config_init
+status=0
+ableton_prefix_quiesce "\$@" || status=\$?
+printf 'rc=%s\n' "\$status"
+EOF
+chmod +x "$base/runtime/bin/wineserver" "$base/run-quiesce"
+quiesce_calls()
+{
+    awk '{print $1}' "$base/log" | tr '\n' ' '
+}
+run_quiesce()
+{
+    local assignments=()
+    while [ "$#" -gt 0 ] && [[ "$1" = *=* ]]; do assignments+=("$1"); shift; done
+    : > "$base/log"
+    run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
+        ABLETON_TEST_LOG="$base/log" ABLETON_TEST_BUSY="$base/busy" "${assignments[@]}" \
+        bash "$base/run-quiesce" "$@" >"$base/out" 2>"$base/err"
+}
+
+rm -f "$base/busy"
+run_quiesce
+grep -qx 'rc=0' "$base/out" || fail "a quiet prefix reports success"
+[ "$(quiesce_calls)" = "-w " ] || fail "a quiet prefix is waited for exactly once"
+grep -qx -- "-w prefix=$base/prefix" "$base/log" || fail "the wait names the configured prefix"
+ok "a quiet prefix is waited for once and never stopped"
+
+: > "$base/busy"
+run_quiesce
+grep -qx 'rc=0' "$base/out" || fail "a stopped straggler reports success"
+[ "$(quiesce_calls)" = "-w -k -w " ] || fail "a held prefix is stopped and waited for again"
+grep -q 'holding the prefix open' "$base/out" || fail "stopping the prefix is reported"
+ok "a straggler holding the prefix open is stopped, not made fatal"
+
+: > "$base/busy"
+run_quiesce ABLETON_TEST_UNKILLABLE=1
+grep -qx 'rc=1' "$base/out" || fail "a surviving straggler is reported as still busy"
+[ "$(quiesce_calls)" = "-w -k -w " ] || fail "a surviving straggler is not waited for a third time"
+ok "a straggler that survives the stop is reported, and the wait stays bounded"
+
+rm -f "$base/busy"
+run_quiesce ABLETON_TEST_WAIT_EXIT=127
+grep -qx 'rc=127' "$base/out" || fail "a wait that cannot run keeps its exit code"
+[ "$(quiesce_calls)" = "-w " ] || fail "a wait that cannot run does not stop the prefix"
+ok "only an expired wait stops the prefix; any other failure is passed back"
+
+# setup-prefix.sh waits on its staging prefix, which is not the configured one.
+: > "$base/busy"
+run_quiesce "$base/runtime" "$base/staging-prefix"
+grep -qx 'rc=0' "$base/out" || fail "an explicitly named prefix is quiesced"
+grep -qx -- "-k prefix=$base/staging-prefix" "$base/log" || fail "the stop names the prefix it was given"
+! grep -q -- "prefix=$base/prefix\$" "$base/log" || fail "a named prefix displaces the configured one"
+ok "the runtime and prefix a caller names override the configured pair"
+
+# The payload step's own wait, on the promoted prefix.  Every sub-script is stubbed
+# so install_live_payload is reached with a wineserver whose -w never returns.
+base="$(new_env payload-wait)"
+kit="$base/kit"
+mkdir -p "$kit/scripts/lib" "$kit/bin" "$base/runtime/bin"
+cp -- "$here/installer.sh" "$kit/scripts/"
+cp -- "$here/lib/config.sh" "$here/lib/lifecycle.sh" "$here/lib/manifest.sh" \
+    "$here/lib/pipeasio.sh" "$kit/scripts/lib/"
+cat > "$kit/bin/pipewire-version-probe" <<'EOF'
+#!/bin/sh
+printf 'client=1.4.2\ndaemon=1.4.2\n'
+EOF
+cat > "$kit/scripts/install.sh" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'component %s\n' "$*" >> "${ABLETON_TEST_CALL_LOG:?}"
+exit 0
+EOF
+cat > "$kit/scripts/setup-prefix.sh" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'prefix %s\n' "$*" >> "${ABLETON_TEST_CALL_LOG:?}"
+case " $* " in
+    *' --preflight-commit '*|*' --commit '*|*' --preflight-rollback '*|*' --rollback '*) exit 0 ;;
+esac
+mkdir -p -- "${ABLETON_WINEPREFIX:?}"
+printf 'registry\n' > "${ABLETON_WINEPREFIX}/system.reg"
+EOF
+cat > "$kit/scripts/setup-link.sh" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'link %s\n' "$*" >> "${ABLETON_TEST_CALL_LOG:?}"
+EOF
+cat > "$base/runtime/bin/wine" <<'EOF'
+#!/bin/sh
+printf 'wine %s\n' "$*" >> "${ABLETON_TEST_CALL_LOG:?}"
+EOF
+cat > "$base/runtime/bin/wineserver" <<'EOF'
+#!/bin/sh
+printf 'wineserver %s\n' "$*" >> "${ABLETON_TEST_CALL_LOG:?}"
+case "${1:-}" in
+    -w) exit "${ABLETON_TEST_WAIT_EXIT:-0}" ;;
+esac
+EOF
+chmod 755 "$kit/scripts/"*.sh "$kit/bin/pipewire-version-probe" "$base/runtime/bin/"*
+printf 'Ableton Live 12 Suite Installer\n' > "$base/Ableton Live 12 Suite Installer.exe"
+
+run_payload_install()
+{
+    : > "$base/calls.log"
+    rm -rf -- "$base/prefix" "$base/config" "$base/state" "$base/data"
+    run_isolated "$base" env ABLETON_TEST_CALL_LOG="$base/calls.log" "$@" \
+        bash "$kit/scripts/installer.sh" install \
+            --live-installer "$base/Ableton Live 12 Suite Installer.exe" \
+            --link=off --runtime-root "$base/runtime" --prefix "$base/prefix" --yes \
+        >"$base/out" 2>"$base/err"
+}
+
+# 124 is timeout's TERM verdict: the wait ran out with a process still in the prefix.
+run_payload_install ABLETON_TEST_WAIT_EXIT=124 || fail "an expired payload wait fails the install"
+grep -q 'OK: install completed' "$base/out" || fail "an expired payload wait leaves the install incomplete"
+! grep -q 'wineserver -k' "$base/calls.log" || fail "the payload step stops the promoted prefix"
+grep -q 'is still running and' "$base/out" || fail "an unrecognised straggler goes unreported"
+grep -qF -- "$base/runtime/bin/wineserver -k" "$base/out" \
+    || fail "the report withholds the command that ends the prefix"
+ok "an expired payload wait reports the straggler, stops nothing, and still completes"
+
+for image in AbletonPushCpl.exe tusbaudiocplapp.exe MicrosoftEdgeUpdate.exe; do
+    grep -qF "taskkill /f /im $image" "$base/calls.log" \
+        || fail "the payload step does not end $image by name"
+done
+ok "the payload step ends the images it starts, each named exactly"
+
+run_payload_install || fail "a quiet payload wait fails the install"
+! grep -q 'is still running and' "$base/out" || fail "a quiet prefix is reported as busy"
+ok "a quiet prefix after the payload reports nothing"
+
 base="$(new_env launcher-preflight)"
 mkdir -p "$base/runtime/bin" "$base/prefix"
 printf '#!/bin/sh\nexit 0\n' > "$base/runtime/bin/wine"

--- a/scripts/test-installer-lifecycle.sh
+++ b/scripts/test-installer-lifecycle.sh
@@ -782,6 +782,69 @@ grep -q 'Max\.exe (pid' "$base/err" \
     || fail "teardown names the holder by something other than its Windows image"
 ok "teardown verifies the prefix came down, and names the holder when it did not"
 
+# A helper this project installed outlives the window on purpose - learnheal.exe
+# heals the Learn View pane after Live has gone - so the launcher must hand the
+# terminal back rather than wait on one, and must not report it as a holder.
+base="$(new_env vendored-helper-holder)"
+mkdir -p "$base/runtime/bin" "$base/prefix/drive_c/ProgramData/Ableton/Live 12 Suite/Program" \
+    "$base/data/ableton-wine" "$base/run"
+cp /bin/sleep "$base/runtime/bin/wine-client"
+for tool in wine wineserver wineboot; do
+    printf '#!/bin/sh\nexit 0\n' > "$base/runtime/bin/$tool"
+done
+printf '#!/bin/sh\nexit 0\n' > "$base/runtime/bin/winepath"
+chmod +x "$base/runtime/bin/"*
+printf 'registry\n' > "$base/prefix/system.reg"
+printf 'registry\n' > "$base/prefix/user.reg"
+printf 'exe\n' > "$base/prefix/drive_c/ProgramData/Ableton/Live 12 Suite/Program/Ableton Live 12 Suite.exe"
+# The data home is what makes it ours: the image name resolves to a file we installed.
+printf 'helper\n' > "$base/data/ableton-wine/learnheal.exe"
+env WINEPREFIX="$base/prefix" \
+    bash -c 'exec -a "C:\\learnheal.exe" "$1" 600' _ "$base/runtime/bin/wine-client" &
+helper_pid=$!
+sleep 0.3
+start_s=$SECONDS
+run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
+    ABLETON_LINK_MODE=off ABLETON_POWER=off ABLETON_RT=off ABLETON_THEME_MODE=preserve \
+    ABLETON_DPI_MODE=preserve ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+    bash "$here/ableton-live" >"$base/out" 2>"$base/err" || true
+kill -0 "$helper_pid" 2>/dev/null || fail "the launcher ended a helper it installed"
+! grep -q 'the prefix is still in use' "$base/err" \
+    || fail "teardown reports this project's own helper as a holder"
+grep -q 'Ableton Live closed; a background helper' "$base/err" \
+    || fail "teardown leaves a wineserver up without naming the app or saying why"
+ok "a helper we installed keeps running through a session, is not reported, and is explained"
+
+# Timed against the teardown itself, not the launcher around it: the launcher's
+# own observability wait dwarfs the grace period, so a lost early return would
+# not move the total.
+cat > "$base/time-teardown" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+. "$here/lib/config.sh"
+ableton_config_init
+. "$here/lib/lifecycle.sh"
+start=\$SECONDS
+ableton_session_teardown >/dev/null 2>&1 || true
+printf '%s\n' "\$((SECONDS - start))"
+EOF
+chmod +x "$base/time-teardown"
+helper_only_s="$(run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" \
+    ABLETON_WINEPREFIX="$base/prefix" bash "$base/time-teardown")"
+env WINEPREFIX="$base/prefix" \
+    bash -c 'exec -a "C:\\some-daw.exe" "$1" 600' _ "$base/runtime/bin/wine-client" &
+foreign_pid=$!
+sleep 0.3
+foreign_s="$(run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" \
+    ABLETON_WINEPREFIX="$base/prefix" bash "$base/time-teardown")"
+kill "$helper_pid" "$foreign_pid" 2>/dev/null || true
+wait "$helper_pid" "$foreign_pid" 2>/dev/null || true
+# Neither case may poll: a look costs a walk of every pid on the machine, so the
+# difference between them is the report, not the wall clock.
+[ "$helper_only_s" -le 10 ] && [ "$foreign_s" -le 10 ] \
+    || fail "teardown polls instead of looking once (${helper_only_s}s, ${foreign_s}s)"
+ok "teardown looks once whoever holds the prefix (${helper_only_s}s, ${foreign_s}s)"
+
 base="$(new_env foreign-runtime)"
 mkdir -p "$base/runtime/bin"
 cp /bin/sleep "$base/runtime/bin/wine-client"

--- a/scripts/test-installer-lifecycle.sh
+++ b/scripts/test-installer-lifecycle.sh
@@ -671,7 +671,7 @@ grep -qF -- "$base/runtime/bin/wineserver -k" "$base/out" \
 ok "an expired payload wait reports the straggler, stops nothing, and still completes"
 
 for image in AbletonPushCpl.exe tusbaudiocplapp.exe MicrosoftEdgeUpdate.exe; do
-    grep -qF "taskkill /f /im $image" "$base/calls.log" \
+    grep -qF "/im $image" "$base/calls.log" \
         || fail "the payload step does not end $image by name"
 done
 ok "the payload step ends the images it starts, each named exactly"
@@ -682,18 +682,48 @@ ok "a quiet prefix after the payload reports nothing"
 
 base="$(new_env launcher-preflight)"
 mkdir -p "$base/runtime/bin" "$base/prefix"
-printf '#!/bin/sh\nexit 0\n' > "$base/runtime/bin/wine"
+cat > "$base/runtime/bin/wine" <<'EOF'
+#!/bin/sh
+printf 'wine %s\n' "$*" >> "${ABLETON_TEST_LOG:?}"
+exit 0
+EOF
 printf '#!/bin/sh\nexit 0\n' > "$base/runtime/bin/wineserver"
 chmod +x "$base/runtime/bin/wine" "$base/runtime/bin/wineserver"
 printf 'registry\n' > "$base/prefix/system.reg"
+: > "$base/wine.log"
 if run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
-    bash "$here/ableton-live" >"$base/out" 2>"$base/err"; then
+    ABLETON_TEST_LOG="$base/wine.log" bash "$here/ableton-live" \
+    >"$base/out" 2>"$base/err"; then
     fail "launcher without Live fails"
 fi
+# taskkill is a wine process: on an empty prefix it would start a server and a
+# pair of services, which the teardown would then report as the holder.
+! grep -q 'taskkill' "$base/wine.log" || fail "teardown starts wine on a prefix with nothing in it"
 grep -q 'no Ableton Live installation' "$base/err" || fail "launcher reports missing Live"
 [ ! -e "$base/state" ] && [ ! -e "$base/data" ] && [ ! -e "$base/config" ] && [ ! -e "$base/run" ] \
     || fail "launcher preflight mutates no machine state"
 ok "launcher validates runtime, prefix, and Live before mutation"
+
+# The teardown runs on every exit, including the ones that gave up because the
+# prefix was not there.  wine builds a prefix at whatever path it is handed, so
+# a refusal must not leave one behind.
+base="$(new_env launcher-missing-prefix)"
+mkdir -p "$base/runtime/bin"
+cat > "$base/runtime/bin/wine" <<'EOF'
+#!/bin/sh
+mkdir -p -- "${WINEPREFIX:?}/drive_c"
+printf 'registry\n' > "${WINEPREFIX:?}/system.reg"
+exit 0
+EOF
+printf '#!/bin/sh\nexit 0\n' > "$base/runtime/bin/wineserver"
+chmod +x "$base/runtime/bin/wine" "$base/runtime/bin/wineserver"
+if run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" \
+    ABLETON_WINEPREFIX="$base/absent-prefix" bash "$here/ableton-live" \
+    >"$base/out" 2>"$base/err"; then
+    fail "launcher accepts a missing prefix"
+fi
+[ ! -e "$base/absent-prefix" ] || fail "teardown builds a prefix the launcher refused to use"
+ok "a launcher that refuses a missing prefix creates nothing on its way out"
 
 base="$(new_env max-coexist)"
 mkdir -p "$base/runtime/bin" "$base/prefix/drive_c/ProgramData/Ableton/Live 12 Suite/Program" "$base/run"
@@ -719,7 +749,10 @@ printf 'registry\n' > "$base/prefix/system.reg"
 printf 'registry\n' > "$base/prefix/user.reg"
 printf 'exe\n' > "$base/prefix/drive_c/ProgramData/Ableton/Live 12 Suite/Program/Ableton Live 12 Suite.exe"
 : > "$base/wine.log"
-env WINEPREFIX="$base/prefix" bash -c 'exec -a "C:\\Program Files\\Cycling '\''74\\Max 9\\Max.exe" "$1" 60' _ "$base/runtime/bin/wine-client" &
+# 600s, not 60: the launcher waits out its observability timeout before the
+# teardown even runs, so a short-lived stand-in expires mid-case and the
+# coexistence it is meant to prove goes untested.
+env WINEPREFIX="$base/prefix" bash -c 'exec -a "C:\\Program Files\\Cycling '\''74\\Max 9\\Max.exe" "$1" 600' _ "$base/runtime/bin/wine-client" &
 max_pid=$!
 sleep 0.1
 run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
@@ -731,6 +764,23 @@ kill "$max_pid" 2>/dev/null || true
 wait "$max_pid" 2>/dev/null || true
 ! grep -Eq 'wineserver -k|wineboot' "$base/wine.log" || fail "busy prefix avoids kill and boot"
 ok "cold Live launch neither kills Max nor boots its busy prefix"
+
+# The teardown: a session ends the agents it leaves behind, by name, so the
+# wineserver can exit on its own - and never by ending the prefix, which would
+# take a Max or a second Live with it.
+for image in AbletonPushCpl.exe tusbaudiocplapp.exe MicrosoftEdgeUpdate.exe; do
+    grep -qF "/im $image" "$base/wine.log" \
+        || fail "the launcher leaves $image running after the session"
+done
+ok "the launcher ends the agents a session leaves behind, and stops the prefix for none of them"
+
+# Teardown confirms the outcome instead of assuming it: with another program
+# still in the prefix, it reports why the wineserver stays rather than ending it.
+grep -q 'the prefix is still in use' "$base/err" \
+    || fail "teardown does not report a prefix left in use"
+grep -q 'Max\.exe (pid' "$base/err" \
+    || fail "teardown names the holder by something other than its Windows image"
+ok "teardown verifies the prefix came down, and names the holder when it did not"
 
 base="$(new_env foreign-runtime)"
 mkdir -p "$base/runtime/bin"

--- a/scripts/test-installer-lifecycle.sh
+++ b/scripts/test-installer-lifecycle.sh
@@ -776,11 +776,13 @@ ok "the launcher ends the agents a session leaves behind, and stops the prefix f
 
 # Teardown confirms the outcome instead of assuming it: with another program
 # still in the prefix, it reports why the wineserver stays rather than ending it.
-grep -q 'the prefix is still in use' "$base/err" \
+grep -q 'Other unknown processes were left running' "$base/err" \
     || fail "teardown does not report a prefix left in use"
 grep -q 'Max\.exe (pid' "$base/err" \
     || fail "teardown names the holder by something other than its Windows image"
-ok "teardown verifies the prefix came down, and names the holder when it did not"
+grep -qF "wineserver -k" "$base/err" \
+    || fail "teardown names a holder without saying how to end it"
+ok "teardown verifies the prefix came down, and names the holder and the remedy"
 
 # A helper this project installed outlives the window on purpose - learnheal.exe
 # heals the Learn View pane after Live has gone - so the launcher must hand the
@@ -809,7 +811,7 @@ run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$
     ABLETON_DPI_MODE=preserve ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
     bash "$here/ableton-live" >"$base/out" 2>"$base/err" || true
 kill -0 "$helper_pid" 2>/dev/null || fail "the launcher ended a helper it installed"
-! grep -q 'the prefix is still in use' "$base/err" \
+! grep -q 'unknown processes' "$base/err" \
     || fail "teardown reports this project's own helper as a holder"
 grep -q 'Ableton Live closed; a background helper' "$base/err" \
     || fail "teardown leaves a wineserver up without naming the app or saying why"
@@ -833,17 +835,88 @@ helper_only_s="$(run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" \
     ABLETON_WINEPREFIX="$base/prefix" bash "$base/time-teardown")"
 env WINEPREFIX="$base/prefix" \
     bash -c 'exec -a "C:\\some-daw.exe" "$1" 600' _ "$base/runtime/bin/wine-client" &
-foreign_pid=$!
+unknown_pid=$!
 sleep 0.3
-foreign_s="$(run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" \
+unknown_s="$(run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" \
     ABLETON_WINEPREFIX="$base/prefix" bash "$base/time-teardown")"
-kill "$helper_pid" "$foreign_pid" 2>/dev/null || true
-wait "$helper_pid" "$foreign_pid" 2>/dev/null || true
+kill "$helper_pid" "$unknown_pid" 2>/dev/null || true
+wait "$helper_pid" "$unknown_pid" 2>/dev/null || true
 # Neither case may poll: a look costs a walk of every pid on the machine, so the
 # difference between them is the report, not the wall clock.
-[ "$helper_only_s" -le 10 ] && [ "$foreign_s" -le 10 ] \
-    || fail "teardown polls instead of looking once (${helper_only_s}s, ${foreign_s}s)"
-ok "teardown looks once whoever holds the prefix (${helper_only_s}s, ${foreign_s}s)"
+[ "$helper_only_s" -le 10 ] && [ "$unknown_s" -le 10 ] \
+    || fail "teardown polls instead of looking once (${helper_only_s}s, ${unknown_s}s)"
+ok "teardown looks once whoever holds the prefix (${helper_only_s}s, ${unknown_s}s)"
+
+# Every walker takes the prefix, so setup-prefix.sh inside its staging window
+# reports on the prefix it named rather than on the user's.  The wait itself was
+# always right; the /proc walk behind the progress tick was not.
+base="$(new_env named-prefix-walk)"
+mkdir -p "$base/runtime/bin" "$base/prefix" "$base/staging-prefix" "$base/data/ableton-wine" "$base/run"
+cp /bin/sleep "$base/runtime/bin/wine-client"
+chmod +x "$base/runtime/bin/"*
+cat > "$base/name-holders" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+. "$here/lib/config.sh"
+ableton_config_init
+. "$here/lib/lifecycle.sh"
+ableton_prefix_unknown_holders "\$@" | cut -f2 | sort | paste -sd, -
+EOF
+chmod +x "$base/name-holders"
+env WINEPREFIX="$base/prefix" \
+    bash -c 'exec -a "C:\\configured-app.exe" "$1" 600' _ "$base/runtime/bin/wine-client" &
+configured_pid=$!
+env WINEPREFIX="$base/staging-prefix" \
+    bash -c 'exec -a "C:\\staging-app.exe" "$1" 600' _ "$base/runtime/bin/wine-client" &
+staging_pid=$!
+sleep 0.3
+named_walk="$(run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" \
+    ABLETON_WINEPREFIX="$base/prefix" bash "$base/name-holders" \
+    "$base/runtime" "$base/staging-prefix")"
+default_walk="$(run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" \
+    ABLETON_WINEPREFIX="$base/prefix" bash "$base/name-holders")"
+kill "$configured_pid" "$staging_pid" 2>/dev/null || true
+wait "$configured_pid" "$staging_pid" 2>/dev/null || true
+[ "$named_walk" = 'staging-app.exe' ] \
+    || fail "a named prefix is walked as the configured one (got '$named_walk')"
+[ "$default_walk" = 'configured-app.exe' ] \
+    || fail "the configured prefix is not walked by default (got '$default_walk')"
+ok "the /proc walk follows the prefix a caller names, not the configured one"
+
+# A launcher that refuses to start has no session to end, and the prefix it
+# refused in may hold a Live the user is working in.  Teardown ends agents, so
+# the trap must arm after the guards rather than before them.
+base="$(new_env guard-abort-teardown)"
+mkdir -p "$base/runtime/bin" "$base/prefix" "$base/data/ableton-wine" "$base/run"
+cp /bin/sleep "$base/runtime/bin/wine-client"
+cat > "$base/runtime/bin/wine" <<EOF
+#!/bin/sh
+printf '%s\n' "\$*" >> "$base/wine.log"
+exit 0
+EOF
+for tool in wineserver wineboot winepath; do
+    printf '#!/bin/sh\nexit 0\n' > "$base/runtime/bin/$tool"
+done
+chmod +x "$base/runtime/bin/"*
+printf 'registry\n' > "$base/prefix/system.reg"
+: > "$base/wine.log"
+env WINEPREFIX="$base/prefix" \
+    bash -c 'exec -a "C:\\Ableton Live 12 Suite.exe" "$1" 600' _ "$base/runtime/bin/wine-client" &
+live_pid=$!
+sleep 0.3
+if run_isolated "$base" env ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
+    bash "$here/max9" >"$base/out" 2>"$base/err"; then
+    fail "max9 started with no installation present"
+fi
+kill -0 "$live_pid" 2>/dev/null || fail "a refused launch ended a process in the prefix"
+kill "$live_pid" 2>/dev/null || true
+wait "$live_pid" 2>/dev/null || true
+grep -q 'no Max 9 installation' "$base/err" || fail "max9 does not say why it refused"
+! grep -q 'taskkill' "$base/wine.log" \
+    || fail "a refused launch ends agents in a prefix another session is using"
+! grep -q 'unknown processes' "$base/err" \
+    || fail "a refused launch reports a teardown it never performed"
+ok "a launcher that refuses to start leaves the prefix and its agents alone"
 
 base="$(new_env foreign-runtime)"
 mkdir -p "$base/runtime/bin"

--- a/scripts/test-pipeasio-installer.sh
+++ b/scripts/test-pipeasio-installer.sh
@@ -1310,7 +1310,11 @@ wait "$saved_busy_pid" 2>/dev/null || true
     || fail "saved-runtime busy refusal changed the runtime layout"
 grep -Eq 'Wine client is running|another Wine prefix is using this runtime' "$base/err" \
     || fail "saved-runtime busy refusal was not explicit"
-ok "rollback refuses a process executing from the selected saved sibling"
+# "close Live" is unactionable when the holder is a windowless agent, so the
+# refusal names what it found rather than guessing at it.
+grep -q 'rollback-busy-client (pid' "$base/err" \
+    || fail "saved-runtime busy refusal does not name what holds the runtime"
+ok "rollback refuses a process executing from the selected saved sibling, and names it"
 
 base="$(new_env rollback-late-current-user)"
 make_rollback_fixture "$base"

--- a/scripts/test-pipeasio-installer.sh
+++ b/scripts/test-pipeasio-installer.sh
@@ -3022,8 +3022,8 @@ make_commit_preflight_kit()
     local base="$1" kit="$1/commit-kit"
     mkdir -p -- "$kit/scripts/lib"
     cp -- "$here/installer.sh" "$kit/scripts/"
-    cp -- "$here/lib/config.sh" "$here/lib/manifest.sh" "$here/lib/pipeasio.sh" \
-        "$kit/scripts/lib/"
+    cp -- "$here/lib/config.sh" "$here/lib/lifecycle.sh" "$here/lib/manifest.sh" \
+        "$here/lib/pipeasio.sh" "$kit/scripts/lib/"
     cat > "$kit/scripts/install.sh" <<'EOF'
 #!/bin/sh
 set -eu

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -472,7 +472,7 @@ if [ "$delete_prefix" -eq 0 ] && [ -f "$safe_prefix/system.reg" ]; then
     }
     uninstall_wineserver_wait()
     {
-        ableton_run_bounded 60 "$safe_runtime/bin/wineserver" -w
+        ableton_prefix_wait "$safe_runtime" "$safe_prefix"
     }
     echo "== unregister PipeASIO from the retained prefix =="
     ableton_pipeasio_unregister uninstall_wine uninstall_wineserver_wait


### PR DESCRIPTION
Stacked on #220 — review that first; this assumes its teardown exists.

## Behaviour

**Closing Live, nothing else in the prefix.** The terminal comes straight back; the helper finishes and the wineserver exits with it.

```
-- Ableton Live closed; a background helper is still finishing and will quit on its own
```

**Closing Live with something else still in the prefix.** Nothing is killed.

```
-- Ableton Live closed. Other unknown processes were left running:
   reaper.exe (pid 412402)
-- Ableton-Linux helpers close themselves once the prefix is free. To kill the prefix forcefully instead:
   WINEPREFIX=/home/you/.wine-ableton /home/you/.local/opt/wine-d2d1-nspa-11.13/bin/wineserver -k
```

**Waiting during an install.** Was a silent minute, which reads as a hang.

```
   still waiting for the prefix to settle (15s): MicrosoftEdgeUpdate.exe
```

**A busy prefix at the end of an install.** The install is done, exit.

```
-- the install is complete. A program in the prefix is still running and
   was left alone:
   reaper.exe (pid 412402)
-- nothing needs to be done. To end it anyway, close it or run:
   WINEPREFIX=/home/you/.wine-ableton /home/you/.local/opt/wine-d2d1-nspa-11.13/bin/wineserver -k
```

**A launcher that refuses to start** — missing runtime, no Max installed, bad `ABLETON_LIVE_VERSION` — now says only that, and touches nothing. Previously it ran teardown against whatever session was already using the prefix.

Three defects from a review of `lib/lifecycle.sh`

Each has a test that fails without its fix, confirmed by reverting the fix and watching it go red.

- **EXIT trap armed above the preflight guards.** A refused launch `taskkill`ed three agents inside a running Live, then advised `wineserver -k` on the prefix the user was working in.
- **`ableton_pid_image` opened `/proc/PID/cmdline` before stderr was silenced.** Redirections apply left to right, so a pid exiting mid-scan printed a shell error — from the EXIT trap, as Live closes.
- **The `/proc` walkers hardcoded the configured prefix** while callers passed one explicitly, so setup-prefix.sh's staging window reported on the user's prefix. They now take runtime/prefix defaulting to the globals. The operations always used the prefix they were given; this was a reporting defect.

Also: the ticking wait is now the bounded wait, backgrounded and watched, not a second copy with its own 60s bound to drift. And `.shellcheckrc` lets ShellCheck follow the sourced libraries — six SC1091s become none, surfacing one previously invisible diagnostic.

## Testing

Suites at 64 and 86, green on the host and on a Fedora 44 guest — the distro both issues were filed from — against a checksum-verified identical tree.

By hand there, on a real Live 12 session:

- Closed Live with six `msedgewebview2.exe` running; all six went with it, the wineserver stayed up while `learnheal.exe` finished, gone by +90s. #215's symptom.
- A session ending with an updater parked killed exactly one process, `MicrosoftEdgeUpdate.exe`. Live, WebView2 and `Ableton Index.exe` were named and left alive.
- A refused launch with the prefix busy left the holder list byte-identical and printed nothing.
- Not reproduced: #213's wedged updater. Omaha parks one on its own schedule, not on every launch; that comparison was made earlier against `58b9656`.

## Not addressed here

- `uninstall.sh:458` — `ableton_prefix_busy && ableton_stop_prefix` under `set -euo pipefail`, and `ableton_stop_prefix` ends on `! ableton_prefix_busy`. One surviving process exits the script silently, after the trap is cleared, skipping PipeASIO unregister, shortcut restore, MIME cleanup and runtime removal. Byte-identical on `main`, so it wants its own change.
- The SIGTERM loop lacks the identity guard its SIGKILL counterpart has. Same story.

## Credits

- **@realitymolder** — #212, source of the `.shellcheckrc` and progress-tick ideas. Ports of the ideas, not the code: that PR's `settle()` is entangled with a `setup-prefix.sh` predating the installer transactions, and its companion refusal matches `pgrep -af` across every prefix on the machine.
- **@Version33** — #27, the Flake work #212 was split out of.
- **@yioannides** (#213) and **@K4M11111** (#215) — the reports that started this.
