### PR TITLE
Refined installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ For best results, double-check the name of the Ableton installer you have downlo
 
 Once started, this is a mostly automated process.
 
+Near the end, the installer may ask whether to close a background program that
+Ableton's installer left running. Press Enter to close it. Live is already
+installed by then, so either answer keeps it.
+
 ### Running Live
 
 Start Ableton Live the way you normally start applications on your Linux OS.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -16,6 +16,7 @@ have already fixed your issue.
 
 - [Installation and updates](#installation-and-updates)
   - [The installer does not finish after Live installs](#the-installer-does-not-finish-after-live-installs)
+  - [The Ableton installer window never progresses or shows graphical corruption on Hyprland](#the-ableton-installer-window-never-progresses-or-shows-graphical-corruption-on-hyprland)
   - [The installer says PipeWire is too old](#the-installer-says-pipewire-is-too-old)
 - [Live versions and launching](#live-versions-and-launching)
   - [The launcher finds more than one Live installation](#the-launcher-finds-more-than-one-live-installation)
@@ -66,6 +67,20 @@ and run:
 ```bash
 sh ~/Downloads/install-ableton-latest.run update
 ```
+
+### The Ableton installer window never progresses or shows graphical corruption on Hyprland
+
+We've received reports that the Ableton Live installation will display 
+significant graphical corruption or fail to progress at all on Hyprland.
+This appears to be an issue across Wine for Hyprland, and we have not yet
+found a fix for it.
+
+Unfortunately, to fix this you will need to temporarily log in to a GNOME or KDE 
+session and run the installer there. Once the installer is complete, you can
+return to Hyprland afterwards. 
+
+If you find a Hyprland setting that fixes this,
+[open an issue](https://github.com/shibco/ableton-linux/issues) and tell us.
 
 ### The installer says PipeWire is too old
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -973,14 +973,21 @@ install_link_assets()
         ableton_install_file 644 "$here/lib/$tool" "$data/lib/$tool"
     done
     if [ -n "$legacy_custom" ]; then
+        # Seal the proof first and keep it: the VERSION write below stops the live
+        # recogniser matching, and the sealed copy is what authorises this path for
+        # the rest of the transaction.  Then dispose of it the way every other
+        # relinquished managed file is disposed of.  An unmodified object is removed
+        # and any pre-install file it displaced comes back; a changed one is left
+        # exactly where it is and only the ownership claim is dropped.
         ableton_txn_authorize_pr182_custom_link "$legacy_custom" || {
             echo "!! legacy custom Link ownership could not be verified" >&2
             return 1
         }
-        ableton_retire_pr182_custom_link "$legacy_custom" || return 1
-        if [ "$ABLETON_PR182_RETIREMENT" = retired ]; then
+        if ableton_pr182_custom_link_owned "$legacy_custom"; then
+            ableton_remove_managed_file "$legacy_custom" || return 1
             echo "   retired the PR #182 custom Link binary ownership"
         else
+            ableton_abandon_managed_file "$legacy_custom" || return 1
             echo "   kept and de-owned the modified former PR #182 Link binary"
         fi
     fi

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -745,7 +745,8 @@ esac
 install_live_payload()
 {
     [ -n "$live_payload" ] || return 0
-    local installer="$live_payload" unpack="" lower flags=() timeout_secs extract_timeout status=0 tray seed_reg=""
+    local installer="$live_payload" unpack="" lower flags=() timeout_secs extract_timeout status=0 seed_reg=""
+    local zip_name zip_bytes zip_fingerprint zip_kb need_kb avail_kb stop_answer=""
     lower="$(basename "$installer" | tr '[:upper:]' '[:lower:]')"
     if [[ "$lower" = *.zip ]]; then
         unpack="${ABLETON_PAYLOAD_UNPACK_DIR:-$(dirname "$installer")}/ableton-live-installer.d"
@@ -847,13 +848,25 @@ EOF
         done
         rm -f -- "$seed_reg"
     fi
-    for tray in AbletonPushCpl.exe tusbaudiocplapp.exe; do
-        ableton_run_bounded 15 env WINEPREFIX="$ABLETON_WINEPREFIX" \
-            "$ABLETON_WINE_ROOT/bin/wine" taskkill /f /im "$tray" >/dev/null 2>&1 || true
-    done
-    ableton_run_bounded 60 env WINEPREFIX="$ABLETON_WINEPREFIX" \
-        "$ABLETON_WINE_ROOT/bin/wineserver" -w >/dev/null 2>&1 || {
-            echo "!! post-installer prefix wait timed out" >&2; return 1; }
+    # The prefix is promoted and nothing below opens it again, so the install is
+    # complete from here and this step never fails it.  The wait catches an agent
+    # the Live installer left behind: WebView2's MicrosoftEdgeUpdate.exe on Live 12,
+    # the driver tray applet on Live 11, sometimes under an 8.3 name no image list
+    # matches.  Each holds the wineserver, and a later update or rollback refuses
+    # while one does.  Ending the prefix is what reaches an agent we cannot name,
+    # and setup-prefix.sh already refused a busy prefix, so anything alive is ours.
+    if ! ableton_run_bounded 15 env WINEPREFIX="$ABLETON_WINEPREFIX" \
+            "$ABLETON_WINE_ROOT/bin/wineserver" -w >/dev/null 2>&1; then
+        if [ "$assume_yes" -ne 1 ] && [ -t 0 ]; then
+            printf 'Background programs from the Live installer are still running. Close them? [Y/n] ' >&2
+            read -r -t 60 stop_answer || stop_answer=""
+        fi
+        case "$stop_answer" in
+            [nN]*) echo "-- left them running; the next update may ask you to close them" ;;
+            *) ableton_run_bounded 20 env WINEPREFIX="$ABLETON_WINEPREFIX" \
+                   "$ABLETON_WINE_ROOT/bin/wineserver" -k >/dev/null 2>&1 || true ;;
+        esac
+    fi
     [ -z "$unpack" ] || cleanup_live_unpack
 }
 

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -58,13 +58,6 @@ ableton_runtime_pids()
     return 0
 }
 
-ableton_runtime_busy()
-{
-    local root="${1:-$ABLETON_WINE_ROOT}" pid
-    pid="$(ableton_runtime_pids "$root" | head -n 1)"
-    [ -n "$pid" ]
-}
-
 ableton_pid_cmdline()
 {
     tr '\0' ' ' < "/proc/$1/cmdline" 2>/dev/null || true
@@ -111,17 +104,6 @@ ableton_lifecycle_runtime_dir()
     local base="${XDG_RUNTIME_DIR:-$ABLETON_STATE_HOME/run}" key
     key="$(printf '%s\0%s' "$ABLETON_WINE_ROOT" "$ABLETON_WINEPREFIX" | sha256sum | awk '{print substr($1,1,16)}')"
     printf '%s/ableton-wine/%s\n' "$base" "$key"
-}
-
-ableton_wait_for_live()
-{
-    local seconds="${1:-60}" i
-    seconds="$(ableton_timeout_value "$seconds" ABLETON_LAUNCH_TIMEOUT 1 600)" || return 2
-    for ((i=0; i<seconds*10; i++)); do
-        ableton_live_running && return 0
-        sleep 0.1
-    done
-    return 1
 }
 
 ableton_wait_for_pid_exit()

--- a/scripts/lib/manifest.sh
+++ b/scripts/lib/manifest.sh
@@ -275,30 +275,6 @@ ableton_txn_target_allowed()
     return 1
 }
 
-# A transaction that observed a concurrent replacement must never fall back to
-# digest-only rollback/commit checks: another object can have identical bytes.
-# Publish a durable fail-closed marker so every later transaction preflight
-# refuses until a person inspects the retained transaction.
-ableton_txn_mark_concurrent_conflict()
-{
-    local path="$1" marker="${ABLETON_TRANSACTION_DIR:-}/concurrent-conflict" tmp
-    [ -n "${ABLETON_TRANSACTION_DIR:-}" ] || return 1
-    ableton_manifest_path_ok "$path" || return 1
-    if [ -e "$marker" ] || [ -L "$marker" ]; then
-        [ -f "$marker" ] && [ ! -L "$marker" ] && [ -r "$marker" ]
-        return
-    fi
-    tmp="$(mktemp "$ABLETON_TRANSACTION_DIR/.concurrent-conflict.XXXXXX")" || return 1
-    if ! printf 'format=1\npath=%s\n' "$path" > "$tmp" \
-       || ! chmod 600 "$tmp" \
-       || ! mv -T -n -- "$tmp" "$marker" \
-       || [ -e "$tmp" ] \
-       || [ ! -f "$marker" ] || [ -L "$marker" ]; then
-        rm -f -- "$tmp"
-        return 1
-    fi
-}
-
 ableton_txn_validate_files()
 {
     local txn="$1" journal="$1/files.tsv" status path backup post extra index=0 expected digest
@@ -307,10 +283,6 @@ ableton_txn_validate_files()
         ableton_config_error "transaction directory is missing or unsafe"
         return 1
     }
-    if [ -e "$txn/concurrent-conflict" ] || [ -L "$txn/concurrent-conflict" ]; then
-        ableton_config_error "file transaction has a recorded concurrent-object conflict"
-        return 1
-    fi
     if [ ! -e "$journal" ] && [ ! -L "$journal" ]; then return 0; fi
     if ! { [ -f "$journal" ] && [ ! -L "$journal" ] && [ -r "$journal" ] \
            && ableton_file_has_no_nul "$journal"; }; then
@@ -509,51 +481,6 @@ ableton_txn_snapshot()
         unset 'ABLETON_TXN_SEEN[$path]'
         return 1
     fi
-}
-
-# Record an object that has already been atomically moved out of its live path.
-# This closes the check/remove gap for the one historical external path that
-# PR #182 briefly owned: the journal backup is copied from the exact claimed
-# object, while the live destination remains absent until its disposition is
-# decided.
-ableton_txn_snapshot_captured()
-{
-    local path="$1" captured="$2" id backup journal_tmp existing
-    [ -n "${ABLETON_TRANSACTION_DIR:-}" ] || return 1
-    [ ! -e "$path" ] && [ ! -L "$path" ] || return 1
-    { [ -f "$captured" ] || [ -L "$captured" ]; } \
-        && [ -n "$(ableton_manifest_digest "$captured" 2>/dev/null || true)" ] || return 1
-    ableton_txn_init || return 1
-    existing="$(awk -F '\t' -v p="$path" '$2==p { n++ } END { print n+0 }' \
-        "$ABLETON_TRANSACTION_DIR/files.tsv")" || return 1
-    [ "$existing" -eq 0 ] || {
-        ableton_config_error "captured transaction path was already journaled: $path"
-        return 1
-    }
-    id="$(awk 'END { print NR+0 }' "$ABLETON_TRANSACTION_DIR/files.tsv")" || return 1
-    backup="$ABLETON_TRANSACTION_DIR/files/$id"
-    [ ! -e "$backup" ] && [ ! -L "$backup" ] || {
-        ableton_config_error "transaction backup slot is already occupied: $backup"
-        return 1
-    }
-    ableton_atomic_restore_object "$captured" "$backup" || return 1
-    ableton_txn_target_allowed present "$path" "$backup" || {
-        rm -f -- "$backup"
-        ableton_config_error "captured transaction target is outside the allowed lifecycle scope: $path"
-        return 1
-    }
-    journal_tmp="$(mktemp "$ABLETON_TRANSACTION_DIR/.files.tsv.XXXXXX")" || {
-        rm -f -- "$backup"
-        return 1
-    }
-    if ! cp -- "$ABLETON_TRANSACTION_DIR/files.tsv" "$journal_tmp" \
-       || ! printf 'present\t%s\t%s\tabsent\n' "$path" "$backup" >> "$journal_tmp" \
-       || ! chmod 600 "$journal_tmp" \
-       || ! mv -f -- "$journal_tmp" "$ABLETON_TRANSACTION_DIR/files.tsv"; then
-        rm -f -- "$journal_tmp" "$backup"
-        return 1
-    fi
-    ABLETON_TXN_SEEN["$path"]=1
 }
 
 ableton_txn_expect()
@@ -1034,30 +961,6 @@ ableton_install_file()
     ableton_record_owned "$target" "$kind"
 }
 
-ableton_copy_file()
-{
-    local source="$1" target="$2" kind="${3:-file}" post tmp parent
-    [ ! -d "$target" ] || [ -L "$target" ] || {
-        ableton_config_error "refusing to replace directory with a file: $target"
-        return 1
-    }
-    ableton_persist_file_prestate "$target" "$source"
-    ableton_txn_snapshot "$target"
-    post="$(ableton_object_token "$source")" || return 1
-    ableton_txn_expect "$target" "$post" || return 1
-    parent="$(dirname "$target")"
-    mkdir -p -- "$parent"
-    tmp="$(mktemp "$parent/.ableton-copy.XXXXXX")" || return 1
-    rm -f -- "$tmp" || return 1
-    if ! cp -a -- "$source" "$tmp" \
-       || [ "$(ableton_object_token "$tmp" 2>/dev/null || true)" != "$post" ] \
-       || ! mv -T -f -- "$tmp" "$target"; then
-        rm -f -- "$tmp"
-        return 1
-    fi
-    ableton_record_owned "$target" "$kind"
-}
-
 ableton_install_symlink()
 {
     local link_text="$1" target="$2" post tmp parent
@@ -1218,224 +1121,6 @@ ableton_abandon_managed_file()
         fi
     fi
     ableton_record_deowned "$target"
-}
-
-# Retire the narrowly authenticated PR #182 custom Link object without a
-# check-then-delete window. The live object is claimed by an atomic same-dir
-# rename, journaled from that exact object, and only then compared with the
-# immutable proof. A changed object is restored and de-owned; it is never
-# replaced by the historical prestate.
-ableton_retire_pr182_custom_link()
-{
-    local target="$1" proof="$ABLETON_TRANSACTION_DIR/pr182-custom-link"
-    local metadata="$proof/metadata" expected_digest expected_token
-    local index="$ABLETON_STATE_HOME/install-prestate.tsv" id prestate_backup="" prestate_token=""
-    local row_count=0 parent claim_dir capture captured_token captured_identity
-    local stage_dir="" staged="" staged_token="" staged_identity="" final_token=absent
-    local current_token current_identity
-    ABLETON_PR182_RETIREMENT=""
-    export ABLETON_PR182_RETIREMENT
-    ableton_txn_pr182_custom_link_authorized "$target" || return 1
-    ableton_validate_install_state_journals || return 1
-    expected_digest="$(sed -n '3s/^recorded_digest=//p' "$metadata")"
-    [[ "$expected_digest" =~ ^[0-9a-f]{64}$ ]] || return 1
-    expected_token="file:$expected_digest"
-
-    id="$(printf '%s' "$target" | sha256sum | awk '{print $1}')" || return 1
-    if [ -r "$index" ]; then
-        row_count="$(awk -F '\t' -v p="$target" '$2==p { n++ } END { print n+0 }' "$index")"
-        if [ "$row_count" -eq 1 ]; then
-            prestate_backup="$(awk -F '\t' -v p="$target" '$1=="present" && $2==p { print $3 }' "$index")"
-            [ "$prestate_backup" = "$ABLETON_STATE_HOME/install-prestate/$id" ] \
-                && { [ -f "$prestate_backup" ] || [ -L "$prestate_backup" ]; } || return 1
-            prestate_token="$(ableton_object_token "$prestate_backup")" || return 1
-        elif [ "$row_count" -ne 0 ]; then
-            return 1
-        fi
-    fi
-
-    if [ ! -e "$target" ] && [ ! -L "$target" ]; then
-        ableton_abandon_managed_file "$target" || return 1
-        ABLETON_PR182_RETIREMENT=deowned
-        return 0
-    fi
-    { [ -f "$target" ] || [ -L "$target" ]; } && [ ! -d "$target" ] || {
-        ableton_config_error "historical custom Link path has an unsafe object: $target"
-        return 1
-    }
-
-    # This read is intentionally non-authoritative. It proves the live object
-    # is readable, but only the subsequently renamed capture decides whether
-    # it is the historical managed object or a user replacement.
-    current_token="$(ableton_object_token "$target" 2>/dev/null || true)"
-    [ -n "$current_token" ] || return 1
-
-    parent="$(dirname "$target")"
-    claim_dir="$(mktemp -d "$parent/.ableton-pr182-retire.XXXXXX")" || return 1
-    capture="$claim_dir/object"
-
-    # Keep the captured object reachable until its position-bound journal row
-    # is durable. A replacement that appears in this short window is preserved
-    # alongside the capture and makes the whole transaction fail closed.
-    trap '' INT TERM
-    if ! mv -T -n -- "$target" "$capture"; then
-        trap 'exit 130' INT
-        trap 'exit 143' TERM
-        rmdir -- "$claim_dir" 2>/dev/null || true
-        ableton_config_error "could not atomically claim the historical custom Link object"
-        return 1
-    fi
-    if { [ ! -f "$capture" ] && [ ! -L "$capture" ]; }; then
-        trap 'exit 130' INT
-        trap 'exit 143' TERM
-        rmdir -- "$claim_dir" 2>/dev/null || true
-        ableton_config_error "could not atomically claim the historical custom Link object"
-        return 1
-    fi
-    if [ -e "$target" ] || [ -L "$target" ]; then
-        ableton_txn_mark_concurrent_conflict "$target" || true
-        trap 'exit 130' INT
-        trap 'exit 143' TERM
-        ableton_config_error "custom Link changed during retirement; preserved capture at $capture"
-        return 1
-    fi
-    if ! ableton_txn_snapshot_captured "$target" "$capture"; then
-        if [ ! -e "$target" ] && [ ! -L "$target" ]; then
-            mv -T -n -- "$capture" "$target" >/dev/null 2>&1 || true
-        fi
-        trap 'exit 130' INT
-        trap 'exit 143' TERM
-        if [ -e "$capture" ] || [ -L "$capture" ]; then
-            ableton_config_error "could not journal the historical custom Link object; preserved capture at $capture"
-        else
-            rmdir -- "$claim_dir" 2>/dev/null || true
-            ableton_config_error "could not journal the historical custom Link object"
-        fi
-        return 1
-    fi
-    trap 'exit 130' INT
-    trap 'exit 143' TERM
-    captured_token="$(ableton_object_token "$capture" 2>/dev/null || true)"
-    captured_identity="$(stat -c '%d:%i' -- "$capture" 2>/dev/null || true)"
-    if [ -z "$captured_token" ] || [ -z "$captured_identity" ]; then
-        ableton_txn_mark_concurrent_conflict "$target" || true
-        ableton_config_error "captured custom Link object became unreadable; transaction retained"
-        return 1
-    fi
-
-    if [ "$captured_token" != "$expected_token" ]; then
-        # Preserve the exact changed object. If another replacement appeared
-        # during the claim, retain both objects and fail rather than choosing
-        # one or overwriting either.
-        if [ -e "$target" ] || [ -L "$target" ] \
-           || ! mv -T -n -- "$capture" "$target" \
-           || [ -e "$capture" ] || [ -L "$capture" ]; then
-            ableton_txn_mark_concurrent_conflict "$target" || true
-            ableton_config_error "custom Link changed during retirement; preserved capture at $capture"
-            return 1
-        fi
-        current_token="$(ableton_object_token "$target" 2>/dev/null || true)"
-        current_identity="$(stat -c '%d:%i' -- "$target" 2>/dev/null || true)"
-        if [ "$current_token" != "$captured_token" ] \
-           || [ "$current_identity" != "$captured_identity" ]; then
-            ableton_txn_mark_concurrent_conflict "$target" || true
-            ableton_config_error "custom Link changed while its ownership was being relinquished"
-            return 1
-        fi
-        ableton_txn_expect "$target" "$captured_token" || return 1
-        ableton_abandon_managed_file "$target" || return 1
-        current_token="$(ableton_object_token "$target" 2>/dev/null || true)"
-        current_identity="$(stat -c '%d:%i' -- "$target" 2>/dev/null || true)"
-        if [ "$current_token" != "$captured_token" ] \
-           || [ "$current_identity" != "$captured_identity" ]; then
-            ableton_txn_mark_concurrent_conflict "$target" || true
-            ableton_config_error "custom Link changed while its ownership was being relinquished"
-            return 1
-        fi
-        rmdir -- "$claim_dir" || return 1
-        ABLETON_PR182_RETIREMENT=deowned
-        return 0
-    fi
-
-    # If a new object appeared after the owned object was captured, preserve
-    # both objects and fail closed. The transaction journal correctly holds the
-    # captured prior object; reporting success here would let a later outer
-    # rollback overwrite the concurrently created object with that backup.
-    if [ -e "$target" ] || [ -L "$target" ]; then
-        ableton_txn_mark_concurrent_conflict "$target" || true
-        ableton_config_error "custom Link changed during retirement; preserved capture at $capture"
-        return 1
-    fi
-
-    if [ -n "$prestate_backup" ]; then
-        stage_dir="$(mktemp -d "$parent/.ableton-pr182-prestate.XXXXXX")" || return 1
-        staged="$stage_dir/object"
-        if ! cp -a -- "$prestate_backup" "$staged"; then
-            rmdir -- "$stage_dir" 2>/dev/null || true
-            return 1
-        fi
-        staged_token="$(ableton_object_token "$staged" 2>/dev/null || true)"
-        staged_identity="$(stat -c '%d:%i' -- "$staged" 2>/dev/null || true)"
-        if [ "$staged_token" != "$prestate_token" ] || [ -z "$staged_identity" ] \
-           || [ -e "$target" ] || [ -L "$target" ] \
-           || ! mv -T -n -- "$staged" "$target" \
-           || [ -e "$staged" ] || [ -L "$staged" ]; then
-            ableton_txn_mark_concurrent_conflict "$target" || true
-            ableton_config_error "custom Link changed before its previous file could be restored; preserved capture at $capture"
-            return 1
-        fi
-        rmdir -- "$stage_dir" || return 1
-        current_token="$(ableton_object_token "$target" 2>/dev/null || true)"
-        current_identity="$(stat -c '%d:%i' -- "$target" 2>/dev/null || true)"
-        if [ "$current_token" != "$prestate_token" ] \
-           || [ "$current_identity" != "$staged_identity" ]; then
-            ableton_txn_mark_concurrent_conflict "$target" || true
-            ableton_config_error "restored custom Link prestate changed during retirement"
-            return 1
-        fi
-        final_token="$prestate_token"
-        ableton_txn_expect "$target" "$final_token" || return 1
-    else
-        ableton_txn_expect "$target" absent || return 1
-    fi
-
-    # The captured historical object is no longer needed after the known final
-    # state is published. Recheck immediately after deletion, then consume only
-    # metadata. A wrapper/racer that creates a new object during this deletion
-    # is preserved and makes the transaction permanently conflicting.
-    rm -f -- "$capture" || return 1
-    current_token="$(ableton_object_token "$target" 2>/dev/null || true)"
-    if [ "$current_token" != "$final_token" ]; then
-        ableton_txn_mark_concurrent_conflict "$target" || true
-        ableton_config_error "custom Link changed after retirement capture; preserved the new object"
-        return 1
-    fi
-    if [ "$final_token" != absent ]; then
-        current_identity="$(stat -c '%d:%i' -- "$target" 2>/dev/null || true)"
-        if [ "$current_identity" != "$staged_identity" ]; then
-            ableton_txn_mark_concurrent_conflict "$target" || true
-            ableton_config_error "custom Link object identity changed after prestate restoration"
-            return 1
-        fi
-    fi
-    ableton_abandon_managed_file "$target" || return 1
-    current_token="$(ableton_object_token "$target" 2>/dev/null || true)"
-    if [ "$current_token" != "$final_token" ]; then
-        ableton_txn_mark_concurrent_conflict "$target" || true
-        ableton_config_error "custom Link changed while its historical ownership was being removed"
-        return 1
-    fi
-    if [ "$final_token" != absent ]; then
-        current_identity="$(stat -c '%d:%i' -- "$target" 2>/dev/null || true)"
-        if [ "$current_identity" != "$staged_identity" ]; then
-            ableton_txn_mark_concurrent_conflict "$target" || true
-            ableton_config_error "custom Link object identity changed while ownership was being removed"
-            return 1
-        fi
-        printf '   restored your previous %s\n' "$target"
-    fi
-    rmdir -- "$claim_dir" || return 1
-    ABLETON_PR182_RETIREMENT=retired
 }
 
 ableton_write_ownership_manifest()

--- a/scripts/test-pipeasio-installer.sh
+++ b/scripts/test-pipeasio-installer.sh
@@ -1742,13 +1742,12 @@ run_directory_target_guard()
         ableton_txn_init
         case "$2" in
             install) ableton_install_file 755 "$3" "$4" ;;
-            copy) ableton_copy_file "$3" "$4" ;;
             symlink) ableton_install_symlink "$3" "$4" ;;
         esac
     ' _ "$here" "$operation" "$base/source" "$target"
 }
 
-for operation in install copy symlink; do
+for operation in install symlink; do
     base="$(new_env "directory-target-$operation")"
     target="$base/managed-target"
     txn="$base/txn"
@@ -1767,7 +1766,7 @@ for operation in install copy symlink; do
         && [ ! -e "$base/xdg/state/ableton-wine/install-prestate" ] \
         || fail "$operation directory refusal persisted prestate"
 done
-ok "file, copy, and symlink directory refusals leave transaction and prestate journals untouched"
+ok "file and symlink directory refusals leave transaction and prestate journals untouched"
 
 run_guarded_file_install()
 {
@@ -2310,48 +2309,32 @@ for corrupt_kind in symlink-dir orphan-slot; do
 done
 ok "persistent prestate rejects symlink directories and unindexed exact backup slots"
 
-for operation in install copy; do
-    base="$(new_env "atomic-${operation}-failure")"
-    txn="$base/txn"
-    target="$base/xdg/data/ableton-wine/${operation}-target"
-    mkdir -p -- "$txn" "$base/fakebin" "$(dirname "$target")"
-    printf 'stable original bytes\n' > "$base/source"
-    cp -- "$base/source" "$target"
-    case "$operation" in
-        install)
-            cat > "$base/fakebin/install" <<'EOF'
+base="$(new_env atomic-install-failure)"
+txn="$base/txn"
+target="$base/xdg/data/ableton-wine/install-target"
+mkdir -p -- "$txn" "$base/fakebin" "$(dirname "$target")"
+printf 'stable original bytes\n' > "$base/source"
+cp -- "$base/source" "$target"
+cat > "$base/fakebin/install" <<'EOF'
 #!/bin/bash
 target="${@: -1}"
 printf 'partial replacement\n' > "$target"
 exit 99
 EOF
-            helper='ableton_install_file 600 "$2" "$3"'
-            ;;
-        copy)
-            cat > "$base/fakebin/cp" <<'EOF'
-#!/bin/bash
-target="${@: -1}"
-printf 'partial replacement\n' > "$target"
-exit 99
-EOF
-            helper='ableton_copy_file "$2" "$3"'
-            ;;
-    esac
-    chmod 755 "$base/fakebin/"*
-    # shellcheck disable=SC2016
-    if run_isolated "$base" env PATH="$base/fakebin:$PATH" ABLETON_TRANSACTION_DIR="$txn" bash -c '
-        set -euo pipefail
-        . "$1/lib/config.sh"
-        ableton_config_init
-        . "$1/lib/manifest.sh"
-        ableton_txn_init
-        '"$helper"'
-    ' _ "$here" "$base/source" "$target" >"$base/out" 2>"$base/err"; then
-        fail "$operation helper unexpectedly succeeded after its staged writer failed"
-    fi
-    grep -qxF 'stable original bytes' "$target" \
-        || fail "$operation helper destroyed the original target after a staged write failure"
-done
+chmod 755 "$base/fakebin/"*
+# shellcheck disable=SC2016
+if run_isolated "$base" env PATH="$base/fakebin:$PATH" ABLETON_TRANSACTION_DIR="$txn" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ableton_config_init
+    . "$1/lib/manifest.sh"
+    ableton_txn_init
+    ableton_install_file 600 "$2" "$3"
+' _ "$here" "$base/source" "$target" >"$base/out" 2>"$base/err"; then
+    fail "install helper unexpectedly succeeded after its staged writer failed"
+fi
+grep -qxF 'stable original bytes' "$target" \
+    || fail "install helper destroyed the original target after a staged write failure"
 ok "atomic file installers keep the original target when a staged write fails"
 
 base="$(new_env rollback-current-config-directory)"
@@ -3215,90 +3198,5 @@ for migration_mode in owned-prestate modified unowned-off; do
     fi
 done
 ok "PR182 custom-Link migration restores owned prestate, de-owns edits, and preserves --link=off paths"
-
-base="$(new_env pr182-custom-link-retirement-race)"
-make_pr182_custom_link_fixture "$base" owned-prestate
-custom="$PR182_CUSTOM_LINK"
-real_sha256sum="$(command -v sha256sum)"
-cat > "$base/fakebin/sha256sum" <<EOF
-#!/bin/sh
-set -eu
-if [ "\${1:-}" = -- ] && [ "\${2:-}" = "\${ABLETON_TEST_RACE_TARGET:-}" ]; then
-    count=0
-    [ ! -f "\${ABLETON_TEST_RACE_COUNT:?}" ] \
-        || count="\$(cat "\${ABLETON_TEST_RACE_COUNT:?}")"
-    count=\$((count + 1))
-    printf '%s\n' "\$count" > "\${ABLETON_TEST_RACE_COUNT:?}"
-    result="\$("$real_sha256sum" "\$@")"
-    if [ "\$count" -eq 2 ]; then
-        printf 'user edit during guarded retirement\n' > "\${ABLETON_TEST_RACE_TARGET:?}"
-        chmod 755 "\${ABLETON_TEST_RACE_TARGET:?}"
-    fi
-    printf '%s\n' "\$result"
-    exit 0
-fi
-exec "$real_sha256sum" "\$@"
-EOF
-chmod 755 "$base/fakebin/sha256sum"
-run_isolated "$base" env PATH="$base/fakebin:$PATH" \
-    ABLETON_TEST_RACE_TARGET="$custom" \
-    ABLETON_TEST_RACE_COUNT="$base/sha-count" \
-    bash "$base/kit/scripts/installer.sh" link disable \
-    >"$base/out" 2>"$base/err" \
-    || fail "guarded PR182 custom-Link retirement could not de-own a concurrent edit"
-[ "$(cat "$base/sha-count")" -ge 2 ] \
-    || fail "custom-Link race fixture did not reach the guarded live-object recheck"
-grep -qxF 'user edit during guarded retirement' "$custom" \
-    || fail "guarded retirement overwrote the concurrent custom-Link edit"
-grep -qF 'kept and de-owned the modified former PR #182 Link binary' "$base/out" \
-    || fail "guarded retirement did not report the concurrent edit as de-owned"
-if awk -F '\t' -v p="$custom" '$2==p { found=1 } END { exit !found }' \
-    "$PR182_MANIFEST"; then
-    fail "guarded retirement retained ownership of the concurrent edit"
-fi
-if [ -e "$PR182_PRESTATE_INDEX" ] \
-   && awk -F '\t' -v p="$custom" '$2==p { found=1 } END { exit !found }' \
-        "$PR182_PRESTATE_INDEX"; then
-    fail "guarded retirement retained stale prestate authority over the concurrent edit"
-fi
-ok "guarded PR182 retirement preserves and de-owns an edit made after the old digest check"
-
-base="$(new_env pr182-custom-link-post-capture-race)"
-make_pr182_custom_link_fixture "$base" owned-prestate
-custom="$PR182_CUSTOM_LINK"
-real_rm="$(command -v rm)"
-cat > "$base/fakebin/rm" <<EOF
-#!/bin/sh
-set -eu
-captured=0
-for arg do
-    case "\$arg" in
-        */.ableton-pr182-retire.*/object) captured=1 ;;
-    esac
-done
-"$real_rm" "\$@"
-if [ "\$captured" -eq 1 ]; then
-    printf 'user edit after capture\n' > "\${ABLETON_TEST_RACE_TARGET:?}"
-    chmod 755 "\${ABLETON_TEST_RACE_TARGET:?}"
-fi
-EOF
-chmod 755 "$base/fakebin/rm"
-if run_isolated "$base" env PATH="$base/fakebin:$PATH" \
-    ABLETON_TEST_RACE_TARGET="$custom" \
-    bash "$base/kit/scripts/installer.sh" link disable \
-    >"$base/out" 2>"$base/err"; then
-    fail "post-capture custom-Link replacement did not fail closed"
-fi
-grep -qF 'custom Link changed after retirement capture; preserved the new object' "$base/err" \
-    || fail "post-capture custom-Link replacement missed the guarded-retirement diagnostic"
-grep -qxF 'user edit after capture' "$custom" \
-    || fail "post-capture custom-Link replacement was overwritten"
-find "$base/xdg/state/ableton-wine/transactions" -type f \
-    -name concurrent-conflict -print -quit | grep -q . \
-    || fail "post-capture custom-Link replacement did not seal a transaction conflict"
-if [ ! -s "$PR182_PRESTATE_INDEX" ]; then
-    fail "post-capture custom-Link conflict consumed the retained prestate"
-fi
-ok "post-capture custom-Link replacement is preserved and leaves a sealed conflict"
 
 printf 'PASS: %s focused PipeASIO installer checks\n' "$pass"


### PR DESCRIPTION
The previous iteration of this installer waited 60 seconds for background processes we know will never quit by themselves, and then failed entirely. This would happen reliably despite a completed runtime, prefix and Ableton Live install. The rollback then deleted that finished install. On an upgrade it restored the old prefix instead and discarded the new runtime.

These changes fix #213 and #215, both of which are the result of this overly cautious behaviour.

- Cut install time delays to 15 seconds or less, so a slow background process no longer fails the install.
- Prompt the user in the CLI during an Installer flow to ask them directly whether to terminate running Wine instances. This can be automatically agreed to via a `--yes` flag.
- Shut down the prefix instead of listing processes, including Live 11 specific weirdness.
- Dropped the two hardcoded process names, which is now redundant thanks to the above changes.
- Made six variables in the payload step local, as they were global by mistake.
- Retired the old PR #182 Link binary by standardising the Link install with the helpers used across the installer.
- Removed stale installer code from the refactor from last week.
- Added README and TROUBLESHOOTING entries for the new user prompting question (to kill running Wine processes) and how to mitigate the Hyprland stall.
- Removed two additional race checks.