### PR TITLE
Let a later opt-in launch change the audio thread count

### DIFF
--- a/scripts/lib/live-options.sh
+++ b/scripts/lib/live-options.sh
@@ -154,6 +154,52 @@ ableton_prepare_live_preferences()
     [ -d "$prefs_path" ] || mkdir -- "$prefs_path" || return 1
 )
 
+# Replace a line the launcher wrote itself, so a second opt-in launch can change
+# the count. Refuses unless the marker is valid, records a different count, and
+# Options.txt still holds exactly the line that marker names: every other state
+# is a user edit and is left alone. Returns 1 only when the rewrite itself fails.
+ableton_max_audio_rewrite_seeded()
+{
+    local prefs_io="$1" option="$2"
+    local marker="$prefs_io/.ableton-linux-max-audio-threads-v1"
+    local options="$prefs_io/Options.txt"
+    local seeded line seen=0 tmp
+
+    [ -f "$marker" ] && [ ! -L "$marker" ] || return 0
+    ableton_max_audio_marker_valid "$marker" || return 0
+    seeded="$(sed -n '2s/^default=//p' "$marker")"
+    [ -n "$seeded" ] && [ "$seeded" != "$option" ] || return 0
+
+    [ -f "$options" ] && [ ! -L "$options" ] || return 0
+    # Exactly one occurrence, CR stripped so a CRLF-edited copy is caught too.
+    while IFS= read -r line || [ -n "$line" ]; do
+        [ "${line%$'\r'}" = "$seeded" ] && seen=$((seen + 1))
+    done < "$options"
+    [ "$seen" -eq 1 ] || return 0
+
+    tmp="$(mktemp "$prefs_io/.Options.txt.XXXXXX")" || return 0
+    if ! awk -v old="$seeded" -v new="$option" \
+        '{ l = $0; sub(/\r$/, "", l) } l == old { print new; next } { print }' \
+        "$options" > "$tmp"; then
+        rm -f -- "$tmp"
+        return 0
+    fi
+    # Write through the existing inode: keeps the file's permissions.
+    if ! cat "$tmp" > "$options"; then
+        rm -f -- "$tmp"
+        return 1
+    fi
+    rm -f -- "$tmp"
+
+    tmp="$(mktemp "$prefs_io/.max-audio-threads-marker.XXXXXX")" || return 0
+    if ! printf 'format=1\ndefault=%s\n' "$option" > "$tmp" || ! chmod 600 "$tmp" \
+       || ! mv -T -f -- "$tmp" "$marker"; then
+        rm -f -- "$tmp"
+        return 0
+    fi
+    echo "   The launcher changed Live to use ${option#*=} audio threads."
+}
+
 ableton_seed_max_audio_threads_in_dir()
 (
     local users_root="$1" prefs="$2" option="$3"
@@ -181,8 +227,13 @@ ableton_seed_max_audio_threads_in_dir()
     options="$prefs_io/Options.txt"
     marker="$prefs_io/.ableton-linux-max-audio-threads-v1"
 
-    # The marker preserves later user edits.
-    [ ! -e "$marker" ] && [ ! -L "$marker" ] || return 0
+    # The marker preserves later user edits. While it still describes the file,
+    # nothing has touched the line since the launcher wrote it, so a changed
+    # request may replace that one line.
+    if [ -e "$marker" ] || [ -L "$marker" ]; then
+        ableton_max_audio_rewrite_seeded "$prefs_io" "$option" || return 1
+        return 0
+    fi
     if [ -L "$options" ] || { [ -e "$options" ] && [ ! -f "$options" ]; }; then
         echo "ableton-live: Use a regular file inside the Wine prefix for Live settings: '$prefs/Options.txt'." >&2
         return 0

--- a/scripts/lib/live-options.sh
+++ b/scripts/lib/live-options.sh
@@ -156,47 +156,102 @@ ableton_prepare_live_preferences()
 
 # Replace a line the launcher wrote itself, so a second opt-in launch can change
 # the count. Refuses unless the marker is valid, records a different count, and
-# Options.txt still holds exactly the line that marker names: every other state
-# is a user edit and is left alone. Returns 1 only when the rewrite itself fails.
+# Options.txt holds exactly one -MaxAudioThreads line that is still the one the
+# marker names: every other state is a user edit and is left alone.
+#
+# Both files are opened and inode-checked before use, and every read and write
+# goes through the resulting descriptor. A name checked here is a different file
+# by the time anything is written to it: replacing Options.txt with a symlink
+# between the check and the write redirects the write outside the Wine prefix.
+#
+# Options.txt and the marker must never disagree. A marker recording a count the
+# file does not contain matches nothing on the next launch, so the directory is
+# declined for good. The old bytes go back if the marker cannot be replaced, and
+# any failure returns 1 so the launcher reports it.
 ableton_max_audio_rewrite_seeded()
 {
     local prefs_io="$1" option="$2"
     local marker="$prefs_io/.ableton-linux-max-audio-threads-v1"
     local options="$prefs_io/Options.txt"
-    local seeded line seen=0 tmp
+    local seeded line total=0 matched=0
+    local marker_token marker_fd marker_io
+    local options_token options_fd options_io saved staged staged_marker
 
     [ -f "$marker" ] && [ ! -L "$marker" ] || return 0
-    ableton_max_audio_marker_valid "$marker" || return 0
-    seeded="$(sed -n '2s/^default=//p' "$marker")"
+    marker_token="$(stat -c '%d:%i' -- "$marker")" || return 0
+    exec {marker_fd}<"$marker" || return 0
+    marker_io="/proc/$BASHPID/fd/$marker_fd"
+    if [ ! -f "$marker_io" ] \
+       || [ "$(stat -Lc '%d:%i' -- "$marker_io")" != "$marker_token" ]; then
+        exec {marker_fd}<&-
+        return 0
+    fi
+    if ableton_max_audio_marker_valid "$marker_io"; then
+        seeded="$(sed -n '2s/^default=//p' "$marker_io")"
+    fi
+    exec {marker_fd}<&-
     [ -n "$seeded" ] && [ "$seeded" != "$option" ] || return 0
 
     [ -f "$options" ] && [ ! -L "$options" ] || return 0
-    # Exactly one occurrence, CR stripped so a CRLF-edited copy is caught too.
-    while IFS= read -r line || [ -n "$line" ]; do
-        [ "${line%$'\r'}" = "$seeded" ] && seen=$((seen + 1))
-    done < "$options"
-    [ "$seen" -eq 1 ] || return 0
-
-    tmp="$(mktemp "$prefs_io/.Options.txt.XXXXXX")" || return 0
-    if ! awk -v old="$seeded" -v new="$option" \
-        '{ l = $0; sub(/\r$/, "", l) } l == old { print new; next } { print }' \
-        "$options" > "$tmp"; then
-        rm -f -- "$tmp"
+    options_token="$(stat -c '%d:%i' -- "$options")" || return 0
+    exec {options_fd}<>"$options" || return 0
+    options_io="/proc/$BASHPID/fd/$options_fd"
+    if [ ! -f "$options_io" ] \
+       || [ "$(stat -Lc '%d:%i' -- "$options_io")" != "$options_token" ]; then
+        exec {options_fd}>&-
         return 0
     fi
-    # Write through the existing inode: keeps the file's permissions.
-    if ! cat "$tmp" > "$options"; then
-        rm -f -- "$tmp"
+
+    # Count every -MaxAudioThreads line, not just the seeded one: a second value
+    # the user added is an edit, and rewriting around it would leave two.
+    # CR stripped so a CRLF-edited copy is caught too.
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        case "$line" in
+            -MaxAudioThreads|-MaxAudioThreads[=[:space:]]*)
+                total=$((total + 1))
+                [ "$line" = "$seeded" ] && matched=$((matched + 1)) ;;
+        esac
+    done < "$options_io"
+    if [ "$total" -ne 1 ] || [ "$matched" -ne 1 ]; then
+        exec {options_fd}>&-
+        return 0
+    fi
+
+    saved="$(mktemp "$prefs_io/.Options.txt.XXXXXX")" || {
+        exec {options_fd}>&-; return 0; }
+    staged="$(mktemp "$prefs_io/.Options.txt.XXXXXX")" || {
+        rm -f -- "$saved"; exec {options_fd}>&-; return 0; }
+    staged_marker="$(mktemp "$prefs_io/.max-audio-threads-marker.XXXXXX")" || {
+        rm -f -- "$saved" "$staged"; exec {options_fd}>&-; return 0; }
+
+    # Stage everything before touching the file, so a failure costs nothing.
+    if ! cat "$options_io" > "$saved" \
+       || ! awk -v old="$seeded" -v new="$option" \
+              '{ l = $0; sub(/\r$/, "", l) } l == old { print new; next } { print }' \
+              "$options_io" > "$staged" \
+       || ! printf 'format=1\ndefault=%s\n' "$option" > "$staged_marker" \
+       || ! chmod 600 "$staged_marker"; then
+        rm -f -- "$saved" "$staged" "$staged_marker"
+        exec {options_fd}>&-
         return 1
     fi
-    rm -f -- "$tmp"
 
-    tmp="$(mktemp "$prefs_io/.max-audio-threads-marker.XXXXXX")" || return 0
-    if ! printf 'format=1\ndefault=%s\n' "$option" > "$tmp" || ! chmod 600 "$tmp" \
-       || ! mv -T -f -- "$tmp" "$marker"; then
-        rm -f -- "$tmp"
-        return 0
+    # Write through the pinned descriptor: keeps the file's permissions, and a
+    # swapped pathname cannot redirect it.
+    if ! cat "$staged" > "$options_io"; then
+        rm -f -- "$saved" "$staged" "$staged_marker"
+        exec {options_fd}>&-
+        return 1
     fi
+    if ! mv -T -f -- "$staged_marker" "$marker"; then
+        cat "$saved" > "$options_io"
+        rm -f -- "$saved" "$staged" "$staged_marker"
+        exec {options_fd}>&-
+        return 1
+    fi
+    rm -f -- "$saved" "$staged"
+    exec {options_fd}>&-
     echo "   The launcher changed Live to use ${option#*=} audio threads."
 }
 

--- a/scripts/test-live-options.sh
+++ b/scripts/test-live-options.sh
@@ -320,6 +320,60 @@ ableton_seed_max_audio_threads "$prefix" 8 >/dev/null
     || fail "A later launch retains the user's choice to let Live select the count."
 ok "A later launch retains the user's own count. It retains the user's choice to let Live select the count."
 
+prefix="$work/rewrite-swap"
+prefs="$(make_prefs "$prefix")"
+ableton_seed_max_audio_threads "$prefix" 16 >/dev/null
+outside="$work/rewrite-swap-outside"
+printf '%s\n' '-MaxAudioThreads=16' > "$outside"
+outside_before="$(stat -c '%i:%s' "$outside")"
+swap_flag="$work/rewrite-swap-fired"
+mktemp()
+{
+    if [[ "${1:-}" == /proc/*/fd/*/.Options.txt.* ]] && [ ! -e "$swap_flag" ]; then
+        : > "$swap_flag"
+        command rm -f -- "$prefs/Options.txt"
+        command ln -s -- "$outside" "$prefs/Options.txt"
+    fi
+    command mktemp "$@"
+}
+ableton_seed_max_audio_threads "$prefix" 8 >/dev/null 2>&1 || true
+unset -f mktemp
+[ -e "$swap_flag" ] || fail 'The test replaces the settings file during the rewrite.'
+# Content alone cannot show this: the replacement holds no line the rewrite
+# matches, so a write that followed the name would copy the same bytes back.
+[ "$(stat -c '%i:%s' "$outside")" = "$outside_before" ] \
+    && [ "$(cat "$outside")" = '-MaxAudioThreads=16' ] \
+    || fail 'A settings file replaced during the rewrite keeps every write inside the Wine prefix.'
+ok 'A settings file replaced during the rewrite keeps every write inside the Wine prefix.'
+
+prefix="$work/rewrite-record-fails"
+prefs="$(make_prefs "$prefix")"
+ableton_seed_max_audio_threads "$prefix" 16 >/dev/null
+mv() { return 1; }
+record_rc=0
+ableton_seed_max_audio_threads "$prefix" 8 >/dev/null 2>&1 || record_rc=$?
+unset -f mv
+[ "$record_rc" -ne 0 ] \
+    || fail 'A settings script that cannot record the choice reports the failure.'
+[ "$(tr -d '\n' < "$prefs/Options.txt")" \
+    = "$(sed -n '2s/^default=//p' "$prefs/.ableton-linux-max-audio-threads-v1")" ] \
+    || fail 'The settings file and the recorded choice hold the same count.'
+ableton_seed_max_audio_threads "$prefix" 4 >/dev/null
+grep -qx -- '-MaxAudioThreads=4' "$prefs/Options.txt" \
+    || fail 'A later launch applies a count after a failed record.'
+ok 'A failed record reports the failure, leaves one count in both files, and a later launch still applies.'
+
+prefix="$work/rewrite-duplicate"
+prefs="$(make_prefs "$prefix")"
+ableton_seed_max_audio_threads "$prefix" 8 >/dev/null
+printf '%s\n%s\n' '-MaxAudioThreads=8' '-MaxAudioThreads=24' > "$prefs/Options.txt"
+ableton_seed_max_audio_threads "$prefix" 16 >/dev/null
+[ "$(grep -c '^-MaxAudioThreads=' "$prefs/Options.txt")" -eq 2 ] \
+    && grep -qx -- '-MaxAudioThreads=8' "$prefs/Options.txt" \
+    && grep -qx -- '-MaxAudioThreads=24' "$prefs/Options.txt" \
+    || fail "A second count the user added declines the rewrite."
+ok "A second count the user added declines the rewrite and leaves the file unchanged."
+
 ableton_seed_max_audio_threads "$work/missing-prefix" 16 >/dev/null
 ok 'The settings script accepts a partial Wine prefix.'
 

--- a/scripts/test-live-options.sh
+++ b/scripts/test-live-options.sh
@@ -294,6 +294,32 @@ done
     || fail 'The tested values outside one to 63 preserve the initial Live settings.'
 ok 'The tested values outside one to 63 preserve the initial Live settings.'
 
+prefix="$work/change-count"
+prefs="$(make_prefs "$prefix")"
+printf '%s\n' '-ExistingOption=yes' > "$prefs/Options.txt"
+chmod 644 "$prefs/Options.txt"
+ableton_seed_max_audio_threads "$prefix" 16 >/dev/null
+ableton_seed_max_audio_threads "$prefix" 8 >/dev/null
+grep -qx -- '-MaxAudioThreads=8' "$prefs/Options.txt" \
+    || fail 'A later launch applies a different count for audio threads.'
+[ "$(grep -c '^-MaxAudioThreads=' "$prefs/Options.txt")" -eq 1 ] \
+    || fail 'The settings file contains one entry for audio threads after a changed count.'
+grep -qx -- '-ExistingOption=yes' "$prefs/Options.txt" \
+    || fail 'A changed count retains the other settings in the file.'
+[ "$(stat -c '%a' "$prefs/Options.txt")" = 644 ] \
+    || fail 'A changed count retains the mode of the settings file.'
+ok 'A later launch applies a different count for audio threads. It retains the other settings and the file mode.'
+
+printf '%s\n' '-MaxAudioThreads=24' > "$prefs/Options.txt"
+ableton_seed_max_audio_threads "$prefix" 8 >/dev/null
+[ "$(cat "$prefs/Options.txt")" = '-MaxAudioThreads=24' ] \
+    || fail "A later launch retains the user's own count for audio threads."
+printf '\n' > "$prefs/Options.txt"
+ableton_seed_max_audio_threads "$prefix" 8 >/dev/null
+[ -z "$(tr -d '[:space:]' < "$prefs/Options.txt")" ] \
+    || fail "A later launch retains the user's choice to let Live select the count."
+ok "A later launch retains the user's own count. It retains the user's choice to let Live select the count."
+
 ableton_seed_max_audio_threads "$work/missing-prefix" 16 >/dev/null
 ok 'The settings script accepts a partial Wine prefix.'
 


### PR DESCRIPTION
The marker short-circuited the preferences directory, so only the first ABLETON_MAX_AUDIO_THREADS value ever reached Options.txt. One prefix, four launches: =16 then =8 then =30 then =off all left -MaxAudioThreads=16. TROUBLESHOOTING asks the reader to "Play a demanding Set with 8 and 16 workers. Choose the value that preserves audio timing", which through the launcher compares 16 against 16 and returns a false result rather than no result.

The marker already recorded the value the launcher wrote, so separating "my own line, untouched" from "the user edited this" needs no new state. Rewrite that one line while the marker still describes the file, and leave every other state alone: an edited value, a removed line, a corrupt marker and a doubled line all end the pass untouched.

ableton_max_audio_rewrite_seeded is a { } function, not ( ) like its neighbours, so BASHPID is unchanged and the pinned /proc/BASHPID/fd/N directory path still resolves. It writes through the existing inode, which is what keeps the file's mode.

Suites with this applied: live-options 21/21 (19 existing plus two cases that fail without it), pipeasio-installer 84/84, installer-lifecycle 72/72, release-policy 7/7, desktop-integration 3/3.

Armed separately, since no suite covers the rewrite path: Options.txt deleted, marker corrupted, the seeded line present twice, and the directory replaced by a symlink while the rewrite creates its temp file. A mode-444 file forces the failure branch, which returns 1 and leaves the file intact because the redirection fails before truncation.

Tested and confrimed.