### PR TITLE
dwrite: scale the glyph cache with the phase count, and gate the glyph path

### DIFF
--- a/.github/workflows/ci-pr-build.yml
+++ b/.github/workflows/ci-pr-build.yml
@@ -131,6 +131,17 @@ jobs:
       - name: Test installer and launcher lifecycle
         run: make test
 
+      # The glyph path is a property of the built runtime, so `make test`
+      # cannot assert it: its suites are all host-side. The tarball exists by
+      # this point, so extract it and run the gate against that.
+      - name: Test dwrite glyph path
+        run: |
+          sudo apt-get install --yes gcc-mingw-w64-x86-64
+          version="$(cat VERSION)"
+          rt="$(mktemp -d /tmp/ableton-glyph-rt.XXXXXX)"
+          tar --zstd -xf "dist/wine-d2d1-nspa-11.13-$version.tar.zst" -C "$rt"
+          make test-glyph-path RUNTIME="$rt/wine-d2d1-nspa-11.13"
+
       # The generic artifact format permits an explicitly recorded no-Qt
       # driver build. The official release image installs Qt, so its artifact
       # must carry the panel binary, desktop entry and icon together, as well

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Convenience wrapper over the scripts. See README.md.
-.PHONY: all build install setup refresh uninstall test vendor-cache verify check pointer-safety-check clean distclean
+.PHONY: all build install setup refresh uninstall test test-glyph-path vendor-cache verify check pointer-safety-check clean distclean
 
 all: build
 
@@ -25,6 +25,9 @@ test:                         ## run installer and launcher lifecycle gates
 	./scripts/test-desktop-integration.sh
 	./scripts/test-installer-lifecycle.sh
 	./scripts/test-pipeasio-installer.sh
+
+test-glyph-path:              ## assert a built runtime's dwrite glyph path (RUNTIME=<root>)
+	./scripts/test-dwrite-glyph-path.sh $(RUNTIME)
 
 vendor-cache:                 ## populate vendor/winetricks-cache for offline setup
 	./scripts/vendor-winetricks-cache.sh

--- a/patches/0100-dwrite-use-outlines-for-cleartype-glyphs.patch
+++ b/patches/0100-dwrite-use-outlines-for-cleartype-glyphs.patch
@@ -1,84 +1,153 @@
-From: Giang Nguyen <33104857+giang17@users.noreply.github.com>
-Date: Fri, 14 Aug 2026 10:11:28 +0000
-Subject: dwrite: use outlines for ClearType glyphs
+Subject: dwrite: choose strike or outline by rendering mode
 
-Some fonts include small, pre-drawn glyph images called bitmap strikes.
-Each strike provides one brightness value for each pixel. ClearType needs
-3 horizontal samples for each pixel.
+An embedded bitmap strike carries one coverage sample per pixel, which is the
+aliased form. Antialiased and ClearType output need more than one sample per
+pixel, so a strike supplied for either request is expanded back into aliased
+coverage. Wine's own Tahoma, the face MS Shell Dlg resolves to and so the
+default interface font, carries strikes for 8 to 13, 15 and 16 ppem, which
+covers most interface text.
 
-Wine uses the glyph outline for ClearType text. Wine retains bitmap strikes
-when they are the font's sole glyph source. Wine uses the same glyph form to
-calculate the boundary and draw the pixels. Wine stores each result. Later
-requests use the stored result.
----
+dlls/win32u/freetype.c sets FT_LOAD_NO_BITMAP for every requested format except
+GGO_BITMAP: the strike is the aliased form, so any other requested format
+requires the outline. Derive the flag from the rendering mode rather than from
+whether a ClearType texture was requested. That gives greyscale, ClearType and
+GDI the same form for one face at one size, and it removes a size-to-size
+inconsistency, since Tahoma has strikes at 13 and 15 but not 14 and
+neighbouring sizes otherwise render in different forms.
+
+Keying on the requested texture fixes ClearType and leaves greyscale taking the
+strike: create_glyphrunanalysis() selects DWRITE_TEXTURE_ALIASED_1x1 whenever
+the antialias mode is GRAYSCALE, whatever the rendering mode, and Direct2D
+selects that mode whenever can_draw_cleartype() fails.
+
+The chosen form joins the glyph cache key, since a strike and an outline of the
+same glyph at the same size differ in content and cannot share an entry. It is
+carried in both unixlib structures so the bounding box and the rasterised form
+cannot disagree about which was used, which means both halves of dwrite must be
+rebuilt and deployed together.
+
 diff --git a/dlls/dwrite/dwrite_private.h b/dlls/dwrite/dwrite_private.h
-index 530738f4a97992e94fe41175b54357237ec71276..0f1c681e31f3199830ee7fb8ea99ce17950d6df0 100644
+index 530738f..c23ffb8 100644
 --- a/dlls/dwrite/dwrite_private.h
 +++ b/dlls/dwrite/dwrite_private.h
-@@ -900,6 +900,6 @@ extern HRESULT shape_check_typographic_feature(struct scriptshaping_context *con
+@@ -900,6 +900,7 @@ extern HRESULT shape_check_typographic_feature(struct scriptshaping_context *con
  struct font_data_context;
  extern HMODULE dwrite_module;
  
 -extern void dwrite_fontface_get_glyph_bbox(IDWriteFontFace *fontface, struct dwrite_glyphbitmap *bitmap);
-+extern void dwrite_fontface_get_glyph_bbox(IDWriteFontFace *fontface, BOOL lcd, struct dwrite_glyphbitmap *bitmap);
++extern void dwrite_fontface_get_glyph_bbox(IDWriteFontFace *fontface, BOOL lcd, BOOL outline,
++        struct dwrite_glyphbitmap *bitmap);
  
  #endif /* __WINE_DWRITE_PRIVATE_H */
 diff --git a/dlls/dwrite/font.c b/dlls/dwrite/font.c
-index efe85d538cecea13e62cc333666ea8b8cc1e4a31..54a7df1ae9b58f37c841ad5ba144300b2e6a0e26 100644
+index efe85d5..21ba87d 100644
 --- a/dlls/dwrite/font.c
 +++ b/dlls/dwrite/font.c
-@@ -156,9 +156,10 @@ static int fontface_get_glyph_advance(struct dwrite_fontface *fontface, float fo
+@@ -50,6 +50,7 @@ struct cache_key
+     unsigned short glyph;
+     unsigned short mode;
+     unsigned short lcd;
++    unsigned short outline;
+ };
+ 
+ struct cache_entry
+@@ -156,9 +157,15 @@ static int fontface_get_glyph_advance(struct dwrite_fontface *fontface, float fo
      return entry->advance;
  }
  
 -void dwrite_fontface_get_glyph_bbox(IDWriteFontFace *iface, struct dwrite_glyphbitmap *bitmap)
-+void dwrite_fontface_get_glyph_bbox(IDWriteFontFace *iface, BOOL lcd, struct dwrite_glyphbitmap *bitmap)
++/* The bounding box must describe the same form the rasteriser produces, so the
++ * lcd and outline flags are passed to both paths and both are part of the cache
++ * key. Dropping either from the key returns a box for one form and pixels for
++ * the other. */
++void dwrite_fontface_get_glyph_bbox(IDWriteFontFace *iface, BOOL lcd, BOOL outline,
++        struct dwrite_glyphbitmap *bitmap)
  {
 -    struct cache_key key = { .size = bitmap->emsize, .glyph = bitmap->glyph, .mode = DWRITE_MEASURING_MODE_NATURAL };
 +    struct cache_key key = { .size = bitmap->emsize, .glyph = bitmap->glyph, .mode = DWRITE_MEASURING_MODE_NATURAL,
-+            .lcd = !!lcd };
++            .lcd = !!lcd, .outline = !!outline };
      struct dwrite_fontface *fontface = unsafe_impl_from_IDWriteFontFace(iface);
      struct get_glyph_bbox_params params;
      struct cache_entry *entry;
-@@ -166,6 +167,7 @@ void dwrite_fontface_get_glyph_bbox(IDWriteFontFace *iface, struct dwrite_glyphb
+@@ -166,6 +173,8 @@ void dwrite_fontface_get_glyph_bbox(IDWriteFontFace *iface, struct dwrite_glyphb
      params.object = fontface->get_font_object(fontface);
      params.simulations = bitmap->simulations;
      params.glyph = bitmap->glyph;
 +    params.lcd = !!lcd;
++    params.outline = !!outline;
      params.emsize = bitmap->emsize;
      matrix_2x2_from_dwrite_matrix(&params.m, bitmap->m ? bitmap->m : &identity);
  
-@@ -5866,7 +5868,8 @@ static void glyphrunanalysis_get_texturebounds(struct dwrite_glyphrunanalysis *a
+@@ -203,8 +212,13 @@ static unsigned int get_glyph_bitmap_pitch(DWRITE_RENDERING_MODE1 rendering_mode
+ static HRESULT dwrite_fontface_get_glyph_bitmap(struct dwrite_fontface *fontface, DWRITE_RENDERING_MODE1 rendering_mode,
+         BOOL lcd, unsigned int *is_1bpp, struct dwrite_glyphbitmap *bitmap)
+ {
++    /* dlls/win32u/freetype.c sets FT_LOAD_NO_BITMAP for every requested format
++     * except GGO_BITMAP. Deriving the flag from the rendering mode rather than
++     * from lcd alone gives greyscale, ClearType and GDI the same form for one
++     * face at one size. */
++    BOOL outline = rendering_mode != DWRITE_RENDERING_MODE1_ALIASED;
+     struct cache_key key = { .size = bitmap->emsize, .glyph = bitmap->glyph, .mode = DWRITE_MEASURING_MODE_NATURAL,
+-            .lcd = !!lcd };
++            .lcd = !!lcd, .outline = !!outline };
+     struct get_glyph_bitmap_params params;
+     const RECT *bbox = &bitmap->bbox;
+     unsigned int bitmap_size, _1bpp;
+@@ -219,6 +233,7 @@ static HRESULT dwrite_fontface_get_glyph_bitmap(struct dwrite_fontface *fontface
+     params.glyph = bitmap->glyph;
+     params.mode = rendering_mode;
+     params.lcd = !!lcd;
++    params.outline = !!outline;
+     params.emsize = bitmap->emsize;
+     params.bbox = bitmap->bbox;
+     params.pitch = bitmap->pitch;
+@@ -267,6 +282,7 @@ static int fontface_cache_compare(const void *k, const struct wine_rb_entry *e)
+     if (key->glyph != key2->glyph) return (int)key->glyph - (int)key2->glyph;
+     if (key->mode != key2->mode) return (int)key->mode - (int)key2->mode;
+     if (key->lcd != key2->lcd) return (int)key->lcd - (int)key2->lcd;
++    if (key->outline != key2->outline) return (int)key->outline - (int)key2->outline;
+     return 0;
+ }
+ 
+@@ -5866,7 +5882,9 @@ static void glyphrunanalysis_get_texturebounds(struct dwrite_glyphrunanalysis *a
          UINT32 bitmap_size;
  
          glyph_bitmap.glyph = analysis->run.glyphIndices[i];
 -        dwrite_fontface_get_glyph_bbox(analysis->run.fontFace, &glyph_bitmap);
 +        dwrite_fontface_get_glyph_bbox(analysis->run.fontFace,
-+                analysis->texture_type == DWRITE_TEXTURE_CLEARTYPE_3x1, &glyph_bitmap);
++                analysis->texture_type == DWRITE_TEXTURE_CLEARTYPE_3x1,
++                analysis->rendering_mode != DWRITE_RENDERING_MODE1_ALIASED, &glyph_bitmap);
  
          /* FreeType's five-tap LCD filter extends an outline by two subpixels
           * on either side. DWrite exposes whole-pixel texture bounds, so retain
-@@ -5969,7 +5972,7 @@ static HRESULT glyphrunanalysis_render(struct dwrite_glyphrunanalysis *analysis)
+@@ -5969,7 +5987,8 @@ static HRESULT glyphrunanalysis_render(struct dwrite_glyphrunanalysis *analysis)
          unsigned int is_1bpp;
  
          glyph_bitmap.glyph = analysis->run.glyphIndices[i];
 -        dwrite_fontface_get_glyph_bbox(analysis->run.fontFace, &glyph_bitmap);
-+        dwrite_fontface_get_glyph_bbox(analysis->run.fontFace, is_cleartype, &glyph_bitmap);
++        dwrite_fontface_get_glyph_bbox(analysis->run.fontFace, is_cleartype,
++                analysis->rendering_mode != DWRITE_RENDERING_MODE1_ALIASED, &glyph_bitmap);
  
          if (is_cleartype)
          {
 diff --git a/dlls/dwrite/freetype.c b/dlls/dwrite/freetype.c
-index 87979daf3f258949fb6bcede9769746ec5b32d49..dbbf3846ca9437c0a5cb944d89b82bc61d766060 100644
+index 87979da..a1d850e 100644
 --- a/dlls/dwrite/freetype.c
 +++ b/dlls/dwrite/freetype.c
-@@ -527,6 +527,16 @@ static BOOL get_glyph_transform(unsigned int simulations, const MATRIX_2X2 *m, F
+@@ -527,6 +527,22 @@ static BOOL get_glyph_transform(unsigned int simulations, const MATRIX_2X2 *m, F
      return TRUE;
  }
  
-+/* ClearType uses outlines. Fonts with bitmap strikes as their sole glyph source retain those strikes. */
-+static FT_Error freetype_load_glyph(FT_Face face, unsigned int glyph, FT_Int32 flags, BOOL lcd)
++/* An embedded bitmap strike carries one coverage sample per pixel, which is the
++ * aliased form. Antialiased and ClearType output need more than one sample per
++ * pixel, so a strike supplied for either is expanded back into aliased coverage.
++ * dlls/win32u/freetype.c sets FT_LOAD_NO_BITMAP for every requested format
++ * except GGO_BITMAP; outline is derived the same way, so the aliased mode keeps
++ * the strike and every other mode loads the outline. A face carrying no outline
++ * for this glyph loads its strike regardless, leaving such faces unchanged. */
++static FT_Error freetype_load_glyph(FT_Face face, unsigned int glyph, FT_Int32 flags, BOOL outline)
 +{
-+    if (lcd && !(flags & FT_LOAD_NO_BITMAP)
++    if (outline && !(flags & FT_LOAD_NO_BITMAP)
 +            && !pFT_Load_Glyph(face, glyph, flags | FT_LOAD_NO_BITMAP)
 +            && face->glyph->format == FT_GLYPH_FORMAT_OUTLINE)
 +        return 0;
@@ -88,43 +157,60 @@ index 87979daf3f258949fb6bcede9769746ec5b32d49..dbbf3846ca9437c0a5cb944d89b82bc6
  static NTSTATUS get_glyph_bbox(void *args)
  {
      struct get_glyph_bbox_params *params = args;
-@@ -544,7 +554,7 @@ static NTSTATUS get_glyph_bbox(void *args)
+@@ -544,7 +560,7 @@ static NTSTATUS get_glyph_bbox(void *args)
  
      needs_transform = FT_IS_SCALABLE(face) && get_glyph_transform(params->simulations, &params->m, &m);
  
 -    if (pFT_Load_Glyph(face, params->glyph, needs_transform ? FT_LOAD_NO_BITMAP : 0))
-+    if (freetype_load_glyph(face, params->glyph, needs_transform ? FT_LOAD_NO_BITMAP : 0, params->lcd))
++    if (freetype_load_glyph(face, params->glyph, needs_transform ? FT_LOAD_NO_BITMAP : 0, params->outline))
      {
          WARN("Failed to load glyph %u.\n", params->glyph);
          pFT_Done_Size(size);
-@@ -778,7 +788,8 @@ static NTSTATUS get_glyph_bitmap(void *args)
+@@ -778,7 +794,7 @@ static NTSTATUS get_glyph_bitmap(void *args)
  
      needs_transform = FT_IS_SCALABLE(face) && get_glyph_transform(params->simulations, &params->m, &m);
  
 -    if (!pFT_Load_Glyph(face, params->glyph, needs_transform ? FT_LOAD_NO_BITMAP : 0))
-+    if (!freetype_load_glyph(face, params->glyph, needs_transform ? FT_LOAD_NO_BITMAP : 0,
-+            params->lcd && params->mode != DWRITE_RENDERING_MODE1_ALIASED))
++    if (!freetype_load_glyph(face, params->glyph, needs_transform ? FT_LOAD_NO_BITMAP : 0, params->outline))
      {
          pFT_Get_Glyph(face->glyph, &glyph);
  
-@@ -1045,6 +1056,7 @@ static NTSTATUS wow64_get_glyph_bbox(void *args)
+@@ -1045,6 +1061,8 @@ static NTSTATUS wow64_get_glyph_bbox(void *args)
          UINT64 object;
          ULONG simulations;
          ULONG glyph;
 +        ULONG lcd;
++        ULONG outline;
          float emsize;
          MATRIX_2X2 m;
          PTR32 bbox;
-@@ -1054,6 +1066,7 @@ static NTSTATUS wow64_get_glyph_bbox(void *args)
+@@ -1054,6 +1072,8 @@ static NTSTATUS wow64_get_glyph_bbox(void *args)
          params32->object,
          params32->simulations,
          params32->glyph,
 +        params32->lcd,
++        params32->outline,
          params32->emsize,
          params32->m,
          ULongToPtr(params32->bbox),
+@@ -1071,6 +1091,7 @@ static NTSTATUS wow64_get_glyph_bitmap(void *args)
+         ULONG glyph;
+         ULONG mode;
+         ULONG lcd;
++        ULONG outline;
+         float emsize;
+         MATRIX_2X2 m;
+         RECT bbox;
+@@ -1085,6 +1106,7 @@ static NTSTATUS wow64_get_glyph_bitmap(void *args)
+         params32->glyph,
+         params32->mode,
+         params32->lcd,
++        params32->outline,
+         params32->emsize,
+         params32->m,
+         params32->bbox,
 diff --git a/dlls/dwrite/layout.c b/dlls/dwrite/layout.c
-index e362aba59ef57125707fe87935f40e46e6744f42..85c28c1391eab0da7c9e61bc9b3f1b0bf5925775 100644
+index e362aba..0b5129c 100644
 --- a/dlls/dwrite/layout.c
 +++ b/dlls/dwrite/layout.c
 @@ -4212,7 +4212,7 @@ static void layout_get_text_run_bbox(struct dwrite_textlayout *layout, struct la
@@ -132,19 +218,28 @@ index e362aba59ef57125707fe87935f40e46e6744f42..85c28c1391eab0da7c9e61bc9b3f1b0b
  
              glyph_bitmap.glyph = glyph_run.glyphIndices[i];
 -            dwrite_fontface_get_glyph_bbox(glyph_run.fontFace, &glyph_bitmap);
-+            dwrite_fontface_get_glyph_bbox(glyph_run.fontFace, FALSE, &glyph_bitmap);
++            dwrite_fontface_get_glyph_bbox(glyph_run.fontFace, FALSE, FALSE, &glyph_bitmap);
  
              glyph_bbox.left = glyph_bitmap.bbox.left;
              glyph_bbox.top = glyph_bitmap.bbox.top;
 diff --git a/dlls/dwrite/unixlib.h b/dlls/dwrite/unixlib.h
-index 11254871cbd828f9da1dd55e8fb6aa9a2b8db1f8..82c16dc6a4dbe8a9c28c525e772f6abfe70f0e35 100644
+index 1125487..e20ae98 100644
 --- a/dlls/dwrite/unixlib.h
 +++ b/dlls/dwrite/unixlib.h
-@@ -66,6 +66,7 @@ struct get_glyph_bbox_params
+@@ -66,6 +66,8 @@ struct get_glyph_bbox_params
      UINT64 object;
      unsigned int simulations;
      unsigned int glyph;
 +    unsigned int lcd;
++    unsigned int outline;
      float emsize;
      MATRIX_2X2 m;
      RECT *bbox;
+@@ -78,6 +80,7 @@ struct get_glyph_bitmap_params
+     unsigned int glyph;
+     unsigned int mode;
+     unsigned int lcd;
++    unsigned int outline;
+     float emsize;
+     MATRIX_2X2 m;
+     RECT bbox;

--- a/patches/0101-dwrite-preserve-fractional-glyph-positions.patch
+++ b/patches/0101-dwrite-preserve-fractional-glyph-positions.patch
@@ -1,29 +1,46 @@
 Subject: dwrite: preserve fractional horizontal glyph positions
 
 Glyph layout produces fractional horizontal origins. Texture bounds and
-rasterisation converted each origin to an integer, so glyphs moved in
-whole-pixel steps.
+rasterisation converted each origin to an integer, so a glyph does not move at
+all across a full pixel of requested travel and then jumps the whole pixel.
+DWRITE_RENDERING_MODE_NATURAL is specified as positioning glyphs at subpixel
+accuracy.
 
-Quantise origins in natural rendering modes to 16 phases per pixel. Apply each
-phase to the outline. Store each result with its phase. Sixteen phases limited
-the measured position error to 0.0031 px.
+Quantise origins in the natural rendering modes to 16 phases per pixel, apply
+the phase to the outline, and store each result under its phase. Sixteen phases
+limit the measured position error to 0.0031 px. The GDI modes are grid-fitted
+and aliased output is whole-pixel by definition, so both keep integer origins
+and are byte-identical to before. A glyph shifted right can place ink one pixel
+beyond its unshifted box, so the box gains that pixel.
+
+The phase joins the glyph cache key, which multiplies the key space by
+DWRITE_SUBPIXEL_PHASES, so the per-fontface budget scales with it. Left at
+32 KB a 54-glyph run at em 12 no longer fits three phases and every glyph is
+re-rasterised on every draw: 0.2246 ms per run against 0.0078 ms for the same
+run in GDI_NATURAL on the same binary. With the budget scaled the same
+comparison is 0.0128 against 0.0075.
 
 diff --git a/dlls/dwrite/font.c b/dlls/dwrite/font.c
-index 54a7df1ae9b58f37c841ad5ba144300b2e6a0e26..05d42be4c18608f4b981ad2cae3d73b15f78feb0 100644
+index 21ba87d..9f2e60a 100644
 --- a/dlls/dwrite/font.c
 +++ b/dlls/dwrite/font.c
-@@ -50,6 +50,7 @@ struct cache_key
-     unsigned short glyph;
+@@ -51,6 +51,7 @@ struct cache_key
      unsigned short mode;
      unsigned short lcd;
+     unsigned short outline;
 +    unsigned short subpixel_phase;
  };
  
  struct cache_entry
-@@ -202,11 +203,30 @@ static unsigned int get_glyph_bitmap_pitch(DWRITE_RENDERING_MODE1 rendering_mode
+@@ -209,8 +210,32 @@ static unsigned int get_glyph_bitmap_pitch(DWRITE_RENDERING_MODE1 rendering_mode
      return (width + 3) / 4 * 4;
  }
  
++/* Glyph layout produces fractional horizontal origins. Split one into the whole
++ * pixel the bitmap is blitted to and a phase, quantised to DWRITE_SUBPIXEL_PHASES
++ * per pixel, which the rasteriser applies to the outline. Only the natural modes
++ * are subpixel-positioned; the GDI modes are grid-fitted and aliased output is
++ * whole-pixel by definition. */
 +static int split_glyph_origin(float origin, DWRITE_RENDERING_MODE1 rendering_mode, unsigned int *phase)
 +{
 +    int integer;
@@ -47,30 +64,44 @@ index 54a7df1ae9b58f37c841ad5ba144300b2e6a0e26..05d42be4c18608f4b981ad2cae3d73b1
 -        BOOL lcd, unsigned int *is_1bpp, struct dwrite_glyphbitmap *bitmap)
 +        BOOL lcd, unsigned int subpixel_phase, unsigned int *is_1bpp, struct dwrite_glyphbitmap *bitmap)
  {
+     /* dlls/win32u/freetype.c sets FT_LOAD_NO_BITMAP for every requested format
+      * except GGO_BITMAP. Deriving the flag from the rendering mode rather than
+@@ -218,7 +243,7 @@ static HRESULT dwrite_fontface_get_glyph_bitmap(struct dwrite_fontface *fontface
+      * face at one size. */
+     BOOL outline = rendering_mode != DWRITE_RENDERING_MODE1_ALIASED;
      struct cache_key key = { .size = bitmap->emsize, .glyph = bitmap->glyph, .mode = DWRITE_MEASURING_MODE_NATURAL,
--            .lcd = !!lcd };
-+            .lcd = !!lcd, .subpixel_phase = subpixel_phase };
+-            .lcd = !!lcd, .outline = !!outline };
++            .lcd = !!lcd, .outline = !!outline, .subpixel_phase = subpixel_phase };
      struct get_glyph_bitmap_params params;
      const RECT *bbox = &bitmap->bbox;
      unsigned int bitmap_size, _1bpp;
-@@ -221,6 +241,7 @@ static HRESULT dwrite_fontface_get_glyph_bitmap(struct dwrite_fontface *fontface
-     params.glyph = bitmap->glyph;
+@@ -234,6 +259,7 @@ static HRESULT dwrite_fontface_get_glyph_bitmap(struct dwrite_fontface *fontface
      params.mode = rendering_mode;
      params.lcd = !!lcd;
+     params.outline = !!outline;
 +    params.subpixel_phase = subpixel_phase;
      params.emsize = bitmap->emsize;
      params.bbox = bitmap->bbox;
      params.pitch = bitmap->pitch;
-@@ -269,6 +290,8 @@ static int fontface_cache_compare(const void *k, const struct wine_rb_entry *e)
-     if (key->glyph != key2->glyph) return (int)key->glyph - (int)key2->glyph;
+@@ -283,6 +309,8 @@ static int fontface_cache_compare(const void *k, const struct wine_rb_entry *e)
      if (key->mode != key2->mode) return (int)key->mode - (int)key2->mode;
      if (key->lcd != key2->lcd) return (int)key->lcd - (int)key2->lcd;
+     if (key->outline != key2->outline) return (int)key->outline - (int)key2->outline;
 +    if (key->subpixel_phase != key2->subpixel_phase)
 +        return (int)key->subpixel_phase - (int)key2->subpixel_phase;
      return 0;
  }
  
-@@ -5865,8 +5888,11 @@ static void glyphrunanalysis_get_texturebounds(struct dwrite_glyphrunanalysis *a
+@@ -290,7 +318,7 @@ static void fontface_cache_init(struct dwrite_fontface *fontface)
+ {
+     wine_rb_init(&fontface->cache.tree, fontface_cache_compare);
+     list_init(&fontface->cache.mru);
+-    fontface->cache.max_size = 0x8000;
++    fontface->cache.max_size = 0x8000 * DWRITE_SUBPIXEL_PHASES;
+ }
+ 
+ static void fontface_cache_clear(struct dwrite_fontface *fontface)
+@@ -5879,8 +5907,11 @@ static void glyphrunanalysis_get_texturebounds(struct dwrite_glyphrunanalysis *a
  
      for (i = 0; i < analysis->run.glyphCount; i++) {
          RECT *bbox = &glyph_bitmap.bbox;
@@ -81,11 +112,13 @@ index 54a7df1ae9b58f37c841ad5ba144300b2e6a0e26..05d42be4c18608f4b981ad2cae3d73b1
 +        origin_x = split_glyph_origin(analysis->origins[i].x, analysis->rendering_mode, &subpixel_phase);
          glyph_bitmap.glyph = analysis->run.glyphIndices[i];
          dwrite_fontface_get_glyph_bbox(analysis->run.fontFace,
-                 analysis->texture_type == DWRITE_TEXTURE_CLEARTYPE_3x1, &glyph_bitmap);
-@@ -5888,12 +5914,15 @@ static void glyphrunanalysis_get_texturebounds(struct dwrite_glyphrunanalysis *a
+                 analysis->texture_type == DWRITE_TEXTURE_CLEARTYPE_3x1,
+@@ -5903,12 +5934,17 @@ static void glyphrunanalysis_get_texturebounds(struct dwrite_glyphrunanalysis *a
              }
          }
  
++        /* a glyph shifted by part of a pixel can place ink one pixel beyond
++         * the right edge of its unshifted box */
 +        if (subpixel_phase && !IsRectEmpty(bbox))
 +            ++bbox->right;
 +
@@ -99,7 +132,7 @@ index 54a7df1ae9b58f37c841ad5ba144300b2e6a0e26..05d42be4c18608f4b981ad2cae3d73b1
          UnionRect(&analysis->bounds, &analysis->bounds, bbox);
      }
  
-@@ -5969,8 +5998,11 @@ static HRESULT glyphrunanalysis_render(struct dwrite_glyphrunanalysis *analysis)
+@@ -5984,8 +6020,11 @@ static HRESULT glyphrunanalysis_render(struct dwrite_glyphrunanalysis *analysis)
      {
          BYTE *src = glyph_bitmap.buf, *dst;
          int x, y, width, height;
@@ -109,9 +142,9 @@ index 54a7df1ae9b58f37c841ad5ba144300b2e6a0e26..05d42be4c18608f4b981ad2cae3d73b1
  
 +        origin_x = split_glyph_origin(analysis->origins[i].x, analysis->rendering_mode, &subpixel_phase);
          glyph_bitmap.glyph = analysis->run.glyphIndices[i];
-         dwrite_fontface_get_glyph_bbox(analysis->run.fontFace, is_cleartype, &glyph_bitmap);
- 
-@@ -5990,6 +6022,9 @@ static HRESULT glyphrunanalysis_render(struct dwrite_glyphrunanalysis *analysis)
+         dwrite_fontface_get_glyph_bbox(analysis->run.fontFace, is_cleartype,
+                 analysis->rendering_mode != DWRITE_RENDERING_MODE1_ALIASED, &glyph_bitmap);
+@@ -6006,6 +6045,9 @@ static HRESULT glyphrunanalysis_render(struct dwrite_glyphrunanalysis *analysis)
          if (IsRectEmpty(bbox))
              continue;
  
@@ -121,7 +154,7 @@ index 54a7df1ae9b58f37c841ad5ba144300b2e6a0e26..05d42be4c18608f4b981ad2cae3d73b1
          width = bbox->right - bbox->left;
          height = bbox->bottom - bbox->top;
  
-@@ -5997,13 +6032,13 @@ static HRESULT glyphrunanalysis_render(struct dwrite_glyphrunanalysis *analysis)
+@@ -6013,13 +6055,13 @@ static HRESULT glyphrunanalysis_render(struct dwrite_glyphrunanalysis *analysis)
          memset(src, 0, height * glyph_bitmap.pitch);
  
          if (FAILED(dwrite_fontface_get_glyph_bitmap(fontface, analysis->rendering_mode, is_cleartype,
@@ -138,10 +171,10 @@ index 54a7df1ae9b58f37c841ad5ba144300b2e6a0e26..05d42be4c18608f4b981ad2cae3d73b1
          /* blit to analysis bitmap */
          dst = get_pixel_ptr(analysis->bitmap, analysis->texture_type, bbox, &analysis->bounds);
 diff --git a/dlls/dwrite/freetype.c b/dlls/dwrite/freetype.c
-index dbbf3846ca9437c0a5cb944d89b82bc61d766060..9d879f8370bbcb3ac46aff76715d0c9c7f5f57e9 100644
+index a1d850e..a2e94f9 100644
 --- a/dlls/dwrite/freetype.c
 +++ b/dlls/dwrite/freetype.c
-@@ -704,7 +704,8 @@ static NTSTATUS freetype_get_lcd_glyph_bitmap(struct get_glyph_bitmap_params *pa
+@@ -710,7 +710,8 @@ static NTSTATUS freetype_get_lcd_glyph_bitmap(struct get_glyph_bitmap_params *pa
              return STATUS_UNSUCCESSFUL;
          }
          pFT_Outline_Transform(&copy, &scale);
@@ -151,7 +184,7 @@ index dbbf3846ca9437c0a5cb944d89b82bc61d766060..9d879f8370bbcb3ac46aff76715d0c9c
          if (pFT_Outline_Get_Bitmap(library, &copy, &ft_bitmap))
          {
              pFT_Outline_Done(library, &copy);
-@@ -743,7 +744,8 @@ static NTSTATUS freetype_get_aa_glyph_bitmap(struct get_glyph_bitmap_params *par
+@@ -749,7 +750,8 @@ static NTSTATUS freetype_get_aa_glyph_bitmap(struct get_glyph_bitmap_params *par
          /* Note: FreeType will only set 'black' bits for us. */
          if (pFT_Outline_New(library, src->n_points, src->n_contours, &copy) == 0) {
              pFT_Outline_Copy(src, &copy);
@@ -161,24 +194,24 @@ index dbbf3846ca9437c0a5cb944d89b82bc61d766060..9d879f8370bbcb3ac46aff76715d0c9c
              pFT_Outline_Get_Bitmap(library, &copy, &ft_bitmap);
              pFT_Outline_Done(library, &copy);
          }
-@@ -1084,6 +1086,7 @@ static NTSTATUS wow64_get_glyph_bitmap(void *args)
-         ULONG glyph;
+@@ -1092,6 +1094,7 @@ static NTSTATUS wow64_get_glyph_bitmap(void *args)
          ULONG mode;
          ULONG lcd;
+         ULONG outline;
 +        ULONG subpixel_phase;
          float emsize;
          MATRIX_2X2 m;
          RECT bbox;
-@@ -1098,6 +1101,7 @@ static NTSTATUS wow64_get_glyph_bitmap(void *args)
-         params32->glyph,
+@@ -1107,6 +1110,7 @@ static NTSTATUS wow64_get_glyph_bitmap(void *args)
          params32->mode,
          params32->lcd,
+         params32->outline,
 +        params32->subpixel_phase,
          params32->emsize,
          params32->m,
          params32->bbox,
 diff --git a/dlls/dwrite/unixlib.h b/dlls/dwrite/unixlib.h
-index 82c16dc6a4dbe8a9c28c525e772f6abfe70f0e35..312b93bbcf4d335ce2571aa379abaa973c85045c 100644
+index e20ae98..ef3eda6 100644
 --- a/dlls/dwrite/unixlib.h
 +++ b/dlls/dwrite/unixlib.h
 @@ -23,6 +23,8 @@
@@ -190,10 +223,10 @@ index 82c16dc6a4dbe8a9c28c525e772f6abfe70f0e35..312b93bbcf4d335ce2571aa379abaa97
  struct create_font_object_params
  {
      const void *data;
-@@ -79,6 +81,7 @@ struct get_glyph_bitmap_params
-     unsigned int glyph;
+@@ -81,6 +83,7 @@ struct get_glyph_bitmap_params
      unsigned int mode;
      unsigned int lcd;
+     unsigned int outline;
 +    unsigned int subpixel_phase;
      float emsize;
      MATRIX_2X2 m;

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -95,7 +95,7 @@ b644c922888e201e1ae525ab22993d89bee835410cd36a739b9f84387009d009  0095-winex11-s
 80c69a6f555ecc8fcf36fb5d7f466ab9fe4cc1a09f48db7c1cbac442197faef7  0097-winex11-restore-pointer-inertia-and-ignore-held-scroll.patch
 5296ad3f9f91911cf13849e2edf33793d97c2c4d0c06fbee0f119cb06e1114fc  0098-winex11-suspend-XI-scroll-selection-during-core-drags.patch
 84e8c5bf8a7916361449d15abf675815c4a1fa7183f800a23632e00f1e6ae44b  0099-ntdll-grow-the-reserved-pool-instead-of-unordered-mmap.patch
-1906e2412c0b433ad5c86e69b43ba4e3ddab15a9b7b787f05bac50e0a6439f48  0100-dwrite-use-outlines-for-cleartype-glyphs.patch
+08cc39bd2f32ed645d2d129647cd140741ac04f13b6ad13b78ed46d891656e7c  0100-dwrite-use-outlines-for-cleartype-glyphs.patch
 428cc515ba28d978a72623065ab1ae9d13f0ffe9c21bf78869c98efcc46a8c0b  0101-dwrite-preserve-fractional-glyph-positions.patch
 e2759a5aee2cc5820a3ed27d2d4f954a6a5262c1a95172ad11ffa5302c487387  pipeasio/0001-asio-clamp-unavailable-sample-rate-requests.patch
 b4d53b6ebb24e39c7d23efcbddd837149d4d08886167637a73bb085af851d2c1  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch

--- a/patches/SERIES.sha256
+++ b/patches/SERIES.sha256
@@ -96,7 +96,7 @@ b644c922888e201e1ae525ab22993d89bee835410cd36a739b9f84387009d009  0095-winex11-s
 5296ad3f9f91911cf13849e2edf33793d97c2c4d0c06fbee0f119cb06e1114fc  0098-winex11-suspend-XI-scroll-selection-during-core-drags.patch
 84e8c5bf8a7916361449d15abf675815c4a1fa7183f800a23632e00f1e6ae44b  0099-ntdll-grow-the-reserved-pool-instead-of-unordered-mmap.patch
 08cc39bd2f32ed645d2d129647cd140741ac04f13b6ad13b78ed46d891656e7c  0100-dwrite-use-outlines-for-cleartype-glyphs.patch
-428cc515ba28d978a72623065ab1ae9d13f0ffe9c21bf78869c98efcc46a8c0b  0101-dwrite-preserve-fractional-glyph-positions.patch
+814e13534fffeb7f6229e5a85cc6dde6eeb2f1669d00c8df54cc550b55aae1be  0101-dwrite-preserve-fractional-glyph-positions.patch
 e2759a5aee2cc5820a3ed27d2d4f954a6a5262c1a95172ad11ffa5302c487387  pipeasio/0001-asio-clamp-unavailable-sample-rate-requests.patch
 b4d53b6ebb24e39c7d23efcbddd837149d4d08886167637a73bb085af851d2c1  pipeasio/0002-asio-report-timeGetTime-in-ASIO-systemTime.patch
 65555e38187564f77ac4f2ba1dd76d812e452c5442e21474b9c8a31706beb7ba  pipeasio/0004-accept-any-buffer-size-in-range-log-every-adjustment.patch

--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -408,8 +408,8 @@ STAMP_ONLY='
 0078|logic-only (initial monitor DPI seeded in the create_window request; MR 11573 backport, no new string literal)
 0079|logic-only (standalone-surface window search gated on a private-data marker; adds no string literal)
 0099|logic-only (reserved pool grown with further arenas once map_reserved_area declines, keeping anonymous views ascending; new TRACE only, adds no string literal)
-0100|ClearType uses glyph outlines. The audit checks the patch and patch list.
-0101|Natural rendering uses 16 horizontal positions and stores each result.
+0100|logic-only (glyph form selected by rendering mode, mirroring win32u; adds no string literal)
+0101|logic-only (natural rendering quantised to 16 horizontal phases, glyph cache budget scaled with the phase count; adds no string literal)
 '
 wide_pattern() {  # ascii string -> PCRE matching its UTF-16LE bytes
     printf '%s' "$1" | od -An -v -tx1 | tr -d '\n' | tr -s ' ' ' ' \

--- a/scripts/test-dwrite-glyph-path.sh
+++ b/scripts/test-dwrite-glyph-path.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Assert the DirectWrite glyph path of a built runtime: patches 0100, 0101 and
+# 0103.
+#
+#     scripts/test-dwrite-glyph-path.sh [runtime-root]
+#
+# runtime-root defaults to the tree an extracted dist tarball leaves behind. It
+# must contain bin/wine. Unlike the other suites this one needs a built runtime,
+# so it is not part of `make test`; run it after a build, or against any
+# extracted runtime.
+#
+# The prefix is a throwaway created under /tmp and removed on exit. It is seeded
+# with FontSmoothingType=2, without which can_draw_cleartype()'s pixel geometry
+# test fails on its own and the greyscale checks read as failures for a reason
+# unrelated to these patches.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+runtime="${1:-}"
+probe_src="$root/tools/dwrite-glyph-path-probe.c"
+
+fail()
+{
+    printf 'not ok - %s\n' "$*" >&2
+    exit 1
+}
+
+# preconditions are reported, never allowed to abort silently: a set -e exit
+# with no output reads as a short passing run.
+#
+# The runtime is never guessed. dist/ holds a tarball rather than an extracted
+# tree, so a search finds the installed runtime instead of the one just built,
+# and a run against the wrong build reports failures that say nothing about the
+# tree under test.
+[ -n "$runtime" ] || fail "no runtime given. Extract one and pass its root:
+    mkdir -p /tmp/rt && tar --zstd -xf dist/wine-*.tar.zst -C /tmp/rt
+    make test-glyph-path RUNTIME=/tmp/rt/wine-d2d1-nspa-11.13"
+[ -x "$runtime/bin/wine" ] || fail "no bin/wine under $runtime"
+[ -r "$probe_src" ] || fail "probe source missing at $probe_src"
+command -v x86_64-w64-mingw32-gcc >/dev/null \
+    || fail "x86_64-w64-mingw32-gcc is missing; install the mingw-w64 cross compiler"
+
+tmp="$(mktemp -d /tmp/ableton-dwrite-glyph-test.XXXXXX)"
+cleanup()
+{
+    case "$tmp" in
+        /tmp/ableton-dwrite-glyph-test.*)
+            "$runtime/bin/wineserver" -k >/dev/null 2>&1 || true
+            rm -rf -- "${tmp:?}"
+            ;;
+        *) printf 'refusing to remove unexpected test path: %s\n' "$tmp" >&2; return 1 ;;
+    esac
+}
+trap cleanup EXIT
+
+x86_64-w64-mingw32-gcc -Wall -O1 "$probe_src" -o "$tmp/probe.exe" -ldwrite -lole32 \
+    || fail "probe did not build"
+
+export WINEPREFIX="$tmp/prefix"
+export WINEDEBUG=-all
+mkdir -p "$WINEPREFIX"
+"$runtime/bin/wine" wineboot -u >/dev/null 2>&1 || fail "wineboot failed in the test prefix"
+"$runtime/bin/wine" reg add 'HKCU\Control Panel\Desktop' \
+    /v FontSmoothingType /t REG_DWORD /d 2 /f >/dev/null 2>&1 \
+    || fail "could not seed FontSmoothingType"
+"$runtime/bin/wineserver" -k >/dev/null 2>&1 || true
+
+printf 'runtime: %s\n' "$runtime"
+[ -r "$runtime/ABLETON-WINE-BUILD-INFO.txt" ] &&
+    grep -E 'dist-version|wine-patches|patch-stack' "$runtime/ABLETON-WINE-BUILD-INFO.txt" || true
+
+out="$tmp/out.txt"
+if "$runtime/bin/wine" "$tmp/probe.exe" --check >"$out" 2>/dev/null; then
+    cat "$out"
+    printf 'ok - dwrite glyph path: form and sub-pixel positioning as expected\n'
+else
+    status=$?
+    cat "$out"
+    [ "$status" = 2 ] && fail "probe could not run; see the line above"
+    fail "dwrite glyph path regressed; see the not ok lines above"
+fi

--- a/tools/dwrite-glyph-path-probe.c
+++ b/tools/dwrite-glyph-path-probe.c
@@ -1,0 +1,239 @@
+/*
+ * Assert the DirectWrite glyph path: which form a glyph is rasterised from,
+ * and whether a fractional origin moves it.
+ *
+ * Covers patches 0100, 0101 and 0103. Each check has a known failing value, so
+ * no reference image is needed:
+ *
+ *   a bitmap strike carries one coverage sample per pixel. Expanded into a
+ *   ClearType texture it sets every covered subpixel to exactly 255, so the
+ *   count of distinct non-zero values collapses to 1. A rasterised outline
+ *   spreads across dozens.
+ *
+ *   an origin quantised to whole pixels leaves the coverage centroid unmoved
+ *   across a full pixel of requested travel. A sub-pixel origin moves it by
+ *   the amount asked for.
+ *
+ * --check runs the battery and exits non-zero on the first failure. With no
+ * arguments it prints one measurement per rendering mode for inspection.
+ *
+ * The prefix must have FontSmoothingType = 2. At 1 the greyscale checks read
+ * as failures for a reason that has nothing to do with these patches.
+ *
+ * Built as a PE with mingw rather than winegcc: a winegcc object links against
+ * the Wine that built it, and the whole point here is to run one binary
+ * against several runtimes.
+ */
+#define COBJMACROS
+#define INITGUID
+#include <windows.h>
+#include <initguid.h>
+#include <dwrite_2.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Wine's bundled Tahoma carries strikes for 8..13, 15 and 16 ppem. 11 is
+ * inside that range, 24 is outside it and acts as the control. */
+#define STRIKE_EM   11.0f
+#define OUTLINE_EM  24.0f
+
+struct sample {
+    int    ok;
+    double centroid;
+    int    distinct;
+    int    saturated;
+    LONG   left, right;
+};
+
+static IDWriteFactory2 *factory;
+static IDWriteFontFace  *face;
+static UINT16 glyph;
+static int failures, checks;
+
+static struct sample measure(float emsize, DWRITE_RENDERING_MODE mode,
+        DWRITE_TEXT_ANTIALIAS_MODE aa, float originx)
+{
+    struct sample s = {0, 0.0, 0, 0, 0, 0};
+    DWRITE_TEXTURE_TYPE ttype = (aa == DWRITE_TEXT_ANTIALIAS_MODE_GRAYSCALE
+            || mode == DWRITE_RENDERING_MODE_ALIASED)
+            ? DWRITE_TEXTURE_ALIASED_1x1 : DWRITE_TEXTURE_CLEARTYPE_3x1;
+    int bpp = (ttype == DWRITE_TEXTURE_CLEARTYPE_3x1) ? 3 : 1;
+    IDWriteGlyphRunAnalysis *analysis = NULL;
+    DWRITE_GLYPH_OFFSET offset = {0.0f, 0.0f};
+    float advance = 0.0f;
+    DWRITE_GLYPH_RUN run;
+    double wsum = 0.0, csum = 0.0;
+    int seen[256], i, x, y, w, h;
+    UINT32 size;
+    BYTE *tex;
+    RECT b;
+
+    memset(&run, 0, sizeof(run));
+    run.fontFace = face; run.fontEmSize = emsize; run.glyphCount = 1;
+    run.glyphIndices = &glyph; run.glyphAdvances = &advance; run.glyphOffsets = &offset;
+
+    if (FAILED(IDWriteFactory2_CreateGlyphRunAnalysis(factory, &run, NULL, mode,
+            DWRITE_MEASURING_MODE_NATURAL, DWRITE_GRID_FIT_MODE_DEFAULT, aa,
+            originx, 0.0f, &analysis)))
+        return s;
+    if (FAILED(IDWriteGlyphRunAnalysis_GetAlphaTextureBounds(analysis, ttype, &b)))
+        { IDWriteGlyphRunAnalysis_Release(analysis); return s; }
+
+    w = b.right - b.left; h = b.bottom - b.top;
+    if (w <= 0 || h <= 0) { IDWriteGlyphRunAnalysis_Release(analysis); return s; }
+
+    size = (UINT32)(w * h * bpp);
+    if (!(tex = calloc(1, size))) { IDWriteGlyphRunAnalysis_Release(analysis); return s; }
+    if (FAILED(IDWriteGlyphRunAnalysis_CreateAlphaTexture(analysis, ttype, &b, tex, size)))
+        { free(tex); IDWriteGlyphRunAnalysis_Release(analysis); return s; }
+
+    memset(seen, 0, sizeof(seen));
+    for (y = 0; y < h; y++)
+        for (x = 0; x < w * bpp; x++) {
+            BYTE v = tex[y * w * bpp + x];
+            if (v) {
+                wsum += v;
+                csum += v * (b.left + (double)x / bpp);
+                seen[v] = 1;
+                if (v == 255) s.saturated++;
+            }
+        }
+    for (i = 1; i < 256; i++) s.distinct += seen[i];
+
+    s.centroid = wsum > 0 ? csum / wsum : 0.0;
+    s.left = b.left; s.right = b.right;
+    s.ok = wsum > 0;
+
+    free(tex);
+    IDWriteGlyphRunAnalysis_Release(analysis);
+    return s;
+}
+
+static void check(int pass, const char *what, const char *detail)
+{
+    checks++;
+    if (pass) {
+        printf("  ok - %s\n", what);
+    } else {
+        printf("  not ok - %s\n", what);
+        printf("    %s\n", detail);
+        failures++;
+    }
+}
+
+/* a glyph rasterised from an outline carries many coverage values; a strike
+ * expanded into the texture carries exactly one */
+static void check_form(const char *what, float em, DWRITE_RENDERING_MODE mode,
+        DWRITE_TEXT_ANTIALIAS_MODE aa)
+{
+    struct sample s = measure(em, mode, aa, 0.0f);
+    char detail[160];
+
+    if (!s.ok) { check(0, what, "no coverage rendered"); return; }
+    snprintf(detail, sizeof(detail),
+             "distinct=%d saturated=%d; a strike gives distinct=1 with every "
+             "covered sample at 255", s.distinct, s.saturated);
+    check(s.distinct > 8, what, detail);
+}
+
+/* a natural rendering mode must move the ink by the fraction asked for; every
+ * other mode must not move it at all */
+static void check_position(const char *what, DWRITE_RENDERING_MODE mode,
+        DWRITE_TEXT_ANTIALIAS_MODE aa, int expect_movement)
+{
+    struct sample a = measure(OUTLINE_EM, mode, aa, 0.0f);
+    struct sample b = measure(OUTLINE_EM, mode, aa, 0.5f);
+    double moved;
+    char detail[160];
+
+    if (!a.ok || !b.ok) { check(0, what, "no coverage rendered"); return; }
+    moved = b.centroid - a.centroid;
+    snprintf(detail, sizeof(detail),
+             "centroid moved %.4f px for a requested 0.5 px (%.4f -> %.4f)",
+             moved, a.centroid, b.centroid);
+
+    if (expect_movement)
+        check(moved > 0.3 && moved < 0.7, what, detail);
+    else
+        check(moved == 0.0, what, detail);
+}
+
+int main(int argc, char **argv)
+{
+    int run_checks = argc > 1 && !strcmp(argv[1], "--check");
+    IDWriteFontCollection *coll = NULL;
+    IDWriteFontFamily *family = NULL;
+    IDWriteFont *font = NULL;
+    UINT32 index = 0, cp = 'n';
+    BOOL exists = FALSE;
+
+    if (FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, &IID_IDWriteFactory2,
+            (IUnknown **)&factory)))
+    { printf("not ok - IDWriteFactory2 unavailable\n"); return 2; }
+    IDWriteFactory2_GetSystemFontCollection(factory, &coll, FALSE);
+    if (FAILED(IDWriteFontCollection_FindFamilyName(coll, L"Tahoma", &index, &exists)) || !exists)
+    { printf("not ok - Tahoma is not in the prefix; the strike checks need it\n"); return 2; }
+    IDWriteFontCollection_GetFontFamily(coll, index, &family);
+    IDWriteFontFamily_GetFirstMatchingFont(family, DWRITE_FONT_WEIGHT_NORMAL,
+            DWRITE_FONT_STRETCH_NORMAL, DWRITE_FONT_STYLE_NORMAL, &font);
+    IDWriteFont_CreateFontFace(font, &face);
+    IDWriteFontFace_GetGlyphIndices(face, &cp, 1, &glyph);
+
+    if (!run_checks) {
+        struct sample s;
+        int m;
+        printf("# Tahoma 'n', origin 0.0, one measurement per mode\n");
+        printf("# %-22s %-9s %-9s %s\n", "mode", "centroid", "distinct", "saturated");
+        for (m = 1; m <= 5; m++) {
+            static const char *names[] = {"", "ALIASED", "GDI_CLASSIC", "GDI_NATURAL",
+                                          "NATURAL", "NATURAL_SYMMETRIC"};
+            s = measure(STRIKE_EM, (DWRITE_RENDERING_MODE)m,
+                        DWRITE_TEXT_ANTIALIAS_MODE_CLEARTYPE, 0.0f);
+            printf("  em11 cleartype %-8s %-9.4f %-9d %d\n", names[m],
+                   s.centroid, s.distinct, s.saturated);
+        }
+        s = measure(STRIKE_EM, DWRITE_RENDERING_MODE_NATURAL,
+                    DWRITE_TEXT_ANTIALIAS_MODE_GRAYSCALE, 0.0f);
+        printf("  em11 greyscale NATURAL  %-9.4f %-9d %d\n",
+               s.centroid, s.distinct, s.saturated);
+        return 0;
+    }
+
+    printf("# dwrite glyph path\n");
+
+    /* 0100: a ClearType texture must not be built from a strike */
+    check_form("cleartype at a strike size rasterises the outline",
+               STRIKE_EM, DWRITE_RENDERING_MODE_NATURAL,
+               DWRITE_TEXT_ANTIALIAS_MODE_CLEARTYPE);
+
+    /* 0103: neither must a greyscale one, which 0100 alone does not cover */
+    check_form("greyscale at a strike size rasterises the outline",
+               STRIKE_EM, DWRITE_RENDERING_MODE_NATURAL,
+               DWRITE_TEXT_ANTIALIAS_MODE_GRAYSCALE);
+
+    /* the control: above the strike range every mode already used the outline */
+    check_form("cleartype above the strike range rasterises the outline",
+               OUTLINE_EM, DWRITE_RENDERING_MODE_NATURAL,
+               DWRITE_TEXT_ANTIALIAS_MODE_CLEARTYPE);
+
+    /* 0101: sub-pixel positioning, and its gate */
+    check_position("natural rendering positions sub-pixel",
+                   DWRITE_RENDERING_MODE_NATURAL,
+                   DWRITE_TEXT_ANTIALIAS_MODE_CLEARTYPE, 1);
+    check_position("natural symmetric positions sub-pixel",
+                   DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
+                   DWRITE_TEXT_ANTIALIAS_MODE_CLEARTYPE, 1);
+    check_position("gdi classic stays on whole pixels",
+                   DWRITE_RENDERING_MODE_GDI_CLASSIC,
+                   DWRITE_TEXT_ANTIALIAS_MODE_CLEARTYPE, 0);
+    check_position("gdi natural stays on whole pixels",
+                   DWRITE_RENDERING_MODE_GDI_NATURAL,
+                   DWRITE_TEXT_ANTIALIAS_MODE_CLEARTYPE, 0);
+    check_position("aliased stays on whole pixels",
+                   DWRITE_RENDERING_MODE_ALIASED,
+                   DWRITE_TEXT_ANTIALIAS_MODE_CLEARTYPE, 0);
+
+    printf("# %d checks, %d failed\n", checks, failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Three commits. The first is the 0100 amendment, submitted separately against `fix/cleartype-outline-strikes`, and included here because the amended 0101 conflicts on the original 0100 in `font.c`, `freetype.c` and `unixlib.h`. Once that one lands and this branch merges up, the commit drops out and this reduces to 0101 alone.

0101 adds `subpixel_phase` to the glyph cache key, multiplying its space by 16, and leaves `fontface_cache_init()` at `max_size = 0x8000`. A 54-glyph run at em 12 then no longer fits three phases, so every glyph is re-rasterised on every draw: 0.2246 ms per run against 0.0078 ms for the same run in GDI_NATURAL on the same binary, which is the same texture type and the same outline path with the phase at zero. At em 24, where the face carries no bitmap strike at all, the comparison is 0.3760 against 0.0131.

A phase sweep at 200 iterations puts the cliff between 2 and 3 phases and stays flat after it, and cost rises with the number of distinct glyphs while a 6-glyph run stays at 0.0024 ms. That is a capacity miss rather than per-phase rasterisation cost. Scaling the budget with `DWRITE_SUBPIXEL_PHASES` takes the em 12 comparison to 0.0128 against 0.0075.

The third commit adds a probe and a suite asserting what 0100 and 0101 do: that neither a ClearType nor a greyscale texture is built from a bitmap strike, that the natural rendering modes position sub-pixel, and that the GDI and aliased modes do not. Failing values are known in advance, so no reference image is needed. A strike expanded into a texture gives one distinct coverage value with every covered sample at exactly 255, and a truncated origin moves the coverage centroid by exactly zero.

The suite needs a built runtime, so it is `make test-glyph-path RUNTIME=<root>` rather than part of `make test`, whose suites are all host-side. The runtime is never guessed: `dist/` holds a tarball rather than an extracted tree, so a search reaches the installed runtime instead and reports failures that say nothing about the tree under test.

Verified on this branch: build audit 171 checks, gate 8 of 8. The same gate reports 4 failures against `main` and 1 against the unamended stack, that one being the greyscale case above.
