### PR TITLE
nix: stage every scripts/lib helper, not a list that goes stale

### DIFF
--- a/nix/ableton-wine.nix
+++ b/nix/ableton-wine.nix
@@ -165,9 +165,13 @@ stdenv.mkDerivation {
         # The launcher and max9 resolve their config/lifecycle helpers beside
         # themselves first ($launcher_here/lib), then under the user's
         # ~/.local/share/ableton-wine (which only installer.sh populates).
+        # Every lib, by glob, not a list: the launcher hard-fails on a helper it
+        # cannot source, and a list here goes stale the moment one is added
+        # upstream. live-options.sh arrived that way and stopped the launcher
+        # starting at all, with the gate below naming the same stale four.
         mkdir -p $out/libexec/lib
-        for helper in config.sh lifecycle.sh manifest.sh pipeasio.sh; do
-          install -m644 ${../scripts/lib}/$helper $out/libexec/lib/$helper
+        for helper in ${../scripts/lib}/*.sh; do
+          install -m644 $helper $out/libexec/lib/$(basename $helper)
         done
         # Quoted heredoc ('SHIM'): nothing shell-expands at build; @out@ is
         # substituted after. Runtime shell ''${...} is written with the '''' escape;
@@ -241,8 +245,8 @@ stdenv.mkDerivation {
         # setup-prefix.sh, setup-link.sh and ableton-linkctl source these from
         # $here/lib before falling back to the user's staging.
         mkdir -p $out/share/ableton-wine/scripts/lib
-        for helper in config.sh lifecycle.sh manifest.sh pipeasio.sh; do
-          install -m644 ${../scripts/lib}/$helper $out/share/ableton-wine/scripts/lib/$helper
+        for helper in ${../scripts/lib}/*.sh; do
+          install -m644 $helper $out/share/ableton-wine/scripts/lib/$(basename $helper)
         done
         # The Link lifecycle controller both launchers call; installer.sh
         # stages it under ~/.local/share, the launchers fall back to this copy.
@@ -510,10 +514,21 @@ stdenv.mkDerivation {
     fi
     # The launchers and setup scripts hard-fail without their config and
     # lifecycle helpers; they resolve them beside themselves first.
-    for d in libexec/lib share/ableton-wine/scripts/lib; do
-      for helper in config.sh lifecycle.sh manifest.sh pipeasio.sh; do
-        [ -r $out/$d/$helper ] || { echo "$helper is not staged in $d"; exit 1; }
+    # Derived from the source directory, so a helper added upstream is covered
+    # without editing this gate. A hardcoded list here missed live-options.sh
+    # and reported success while the launcher refused to start.
+    for helper in ${../scripts/lib}/*.sh; do
+      for d in libexec/lib share/ableton-wine/scripts/lib; do
+        [ -r $out/$d/$(basename $helper) ] \
+          || { echo "$(basename $helper) is not staged in $d"; exit 1; }
       done
+    done
+    # The launcher sources these and exits 1 naming any whose functions are
+    # absent. Check what it checks, rather than that files exist.
+    for fn in ableton_available_physical_cores ableton_live_product_version \
+              ableton_seed_max_audio_threads; do
+      ${stdenv.shell} -c ". $out/libexec/lib/live-options.sh; declare -F $fn >/dev/null" \
+        || { echo "live-options.sh does not define $fn; the launcher would refuse to start"; exit 1; }
     done
     # setup-prefix.sh refuses to run before the PipeWire preflight probe passes.
     [ -x $out/bin/pipewire-version-probe ] \


### PR DESCRIPTION
`nix run github:shibco/ableton-linux` exits before it starts:

    ableton-live: live-options.sh helper is missing or incomplete

scripts/lib/live-options.sh predates the flake landing on main. The launcher sources it and refuses to run without three of its functions, and install.sh and make-installer.sh both stage it, but nix/ableton-wine.nix named four helpers in a list and it was not among them. The packaged launcher therefore cannot start at all.

The installCheckPhase gate did not catch it because it restated the same four names: the staging and the check meant to cover the staging went stale together. Both now derive from scripts/lib itself, so a helper added later is covered without editing this file, and the gate also asserts the three functions the launcher tests for rather than that a file exists - a truncated helper passes a presence check and still produces the reported message.

This is the third gap of this shape, after audio-report.sh and the icon paths, each one a hardcoded list here drifting from what the tarball ships. Hence the glob rather than a fifth name.

tsan.sh is staged as a result. install.sh does not stage it and nothing in the package reads it; it costs a few hundred bytes against not having to judge, per file, whether the launcher will come to need it.

Verified on nixos-cloud from this branch: flake check passes, audit 171 checks, all six helpers staged. `ableton-live` with no arguments reaches "Wine prefix is missing or incomplete", the correct next failure, where main stops at the helper message. Note --version does NOT show this: it answers at line 158, before the check at line 263, on both trees.