### PR TITLE
Ableton Link hardening and troubleshooting docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+- **An install or update now completes when the Link password prompt times
+  out (#258):**
+  - Link setup asks for your password when a firewall is active. If that
+    prompt times out, or you press Ctrl-C at it, the install or update now
+    completes. The installer then names the `link enable` command that
+    finishes Link setup later. Before, the installer removed the Live
+    installation it made in the same run, or restored the previous runtime
+    and dropped the update.
+  - Live only offers Link with an ASIO driver, so the Link button stays hidden
+    while MME/DirectX is the driver type. The README and the troubleshooting
+    guide now say so.
+  - Thanks ΦNYX from Discord for the report.
+
 ## 2026.08.26.1
 
 - **MIDI controllers and audio interfaces find their way back:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,14 @@
 
 ## Unreleased
 
-- **An install or update now completes when the Link password prompt times
-  out (#258):**
-  - Link setup asks for your password when a firewall is active. If that
-    prompt times out, or you press Ctrl-C at it, the install or update now
-    completes. The installer then names the `link enable` command that
-    finishes Link setup later. Before, the installer removed the Live
-    installation it made in the same run, or restored the previous runtime
-    and dropped the update.
-  - Live only offers Link with an ASIO driver, so the Link button stays hidden
-    while MME/DirectX is the driver type. The README and the troubleshooting
-    guide now say so.
-  - Thanks ΦNYX from Discord for the report.
+- installs and updates now finish after interrupted Link setup (#258):
+  - an active firewall makes Link setup ask for your password. The installer
+    now finishes after the prompt expires or you press Ctrl-C. It reports the
+    stopped Link setup. It gives you the command to resume setup. The previous
+    behaviour removed a new Live installation or restored the previous runtime
+  - Live offers Link when you use an ASIO driver. The README shows how to select
+    PipeASIO. The troubleshooting guide shows how to display the Link button
+  - thanks ΦNYX from Discord for the report
 
 ## 2026.08.26.1
 

--- a/README.md
+++ b/README.md
@@ -336,9 +336,11 @@ is open.
 
 ### Using Link
 
-1. Enable **Show Link Toggle** under
+1. Set up PipeASIO as in [First launch](#first-launch). Live only offers Link
+   with an ASIO driver.
+2. Enable **Show Link Toggle** under
    **Settings/Preferences > Link, Tempo & MIDI**.
-2. Enable **Link** in Live's control bar.
+3. Enable **Link** in Live's control bar.
 
 Devices on the same local network appear automatically. See
 [Link troubleshooting](TROUBLESHOOTING.md#ableton-link-does-not-find-peers) if

--- a/README.md
+++ b/README.md
@@ -336,11 +336,11 @@ is open.
 
 ### Using Link
 
-1. Set up PipeASIO as in [First launch](#first-launch). Live only offers Link
-   with an ASIO driver.
-2. Enable **Show Link Toggle** under
-   **Settings/Preferences > Link, Tempo & MIDI**.
-3. Enable **Link** in Live's control bar.
+Live offers Link when you use an ASIO driver.
+
+1. Set up PipeASIO with the [first launch steps](#first-launch).
+2. Enable Show Link Toggle under Settings/Preferences > Link, Tempo & MIDI.
+3. Enable Link in Live's control bar.
 
 Devices on the same local network appear automatically. See
 [Link troubleshooting](TROUBLESHOOTING.md#ableton-link-does-not-find-peers) if

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -52,6 +52,7 @@ have already fixed your issue.
   - [Push 3 plays notes on its own](#push-3-plays-notes-on-its-own)
   - [Ableton Move support](#ableton-move-support)
 - [Ableton Link](#ableton-link)
+  - [The Link button is missing from the control bar](#the-link-button-is-missing-from-the-control-bar)
   - [Ableton Link does not find peers](#ableton-link-does-not-find-peers)
 - [Report a problem](#report-a-problem)
 
@@ -971,6 +972,18 @@ Ableton Move support is in development. The current controller support covers
 Push 1, Push 2, and Push 3 in controller mode.
 
 ## Ableton Link
+
+### The Link button is missing from the control bar
+
+Open **Settings > Audio** and select:
+
+- **Driver Type:** ASIO
+- **Audio Device:** PipeASIO
+
+Live only offers Link with an ASIO driver. While **MME/DirectX** is the driver
+type, Live hides the Link button. After you select PipeASIO, enable
+**Show Link Toggle** under **Settings > Link, Tempo and MIDI**. The button
+returns to the control bar.
 
 ### Ableton Link does not find peers
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -52,7 +52,7 @@ have already fixed your issue.
   - [Push 3 plays notes on its own](#push-3-plays-notes-on-its-own)
   - [Ableton Move support](#ableton-move-support)
 - [Ableton Link](#ableton-link)
-  - [The Link button is missing from the control bar](#the-link-button-is-missing-from-the-control-bar)
+  - [Display the Link button](#display-the-link-button)
   - [Ableton Link does not find peers](#ableton-link-does-not-find-peers)
 - [Report a problem](#report-a-problem)
 
@@ -973,17 +973,17 @@ Push 1, Push 2, and Push 3 in controller mode.
 
 ## Ableton Link
 
-### The Link button is missing from the control bar
+### Display the Link button
 
-Open **Settings > Audio** and select:
+Live displays the Link button when it uses an ASIO driver.
 
-- **Driver Type:** ASIO
-- **Audio Device:** PipeASIO
+1. Open Settings > Audio.
+2. Set Driver Type to ASIO.
+3. Set Audio Device to PipeASIO.
+4. Open Settings > Link, Tempo and MIDI.
+5. Enable Show Link Toggle.
 
-Live only offers Link with an ASIO driver. While **MME/DirectX** is the driver
-type, Live hides the Link button. After you select PipeASIO, enable
-**Show Link Toggle** under **Settings > Link, Tempo and MIDI**. The button
-returns to the control bar.
+The Link button appears in the control bar.
 
 ### Ableton Link does not find peers
 

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -579,6 +579,7 @@ rollback_log="$transaction/rollback.log"
 rollback_sink="$rollback_log"
 committed_cleanup_step=""
 link_transaction=0
+link_setup_failed=0
 live_unpack=""
 config_post_token=""
 
@@ -916,7 +917,19 @@ case "$command_name" in
         if [ "$desired_link" = off ]; then
             "$here/setup-link.sh" disable
         else
-            "$here/setup-link.sh" enable "--mode=$desired_link"
+            # Link setup asks for a sudo password when a firewall is active.
+            # An unanswered prompt, or Ctrl-C at it, fails the step.  Live is
+            # installed by then, so that failure must not undo the install or
+            # the update: report it, name the command that finishes Link on
+            # its own, and go on.  The Link policy stays recorded, so that
+            # command and every later update run the same setup again.
+            trap 'link_setup_failed=1' INT
+            "$here/setup-link.sh" enable "--mode=$desired_link" || link_setup_failed=1
+            trap 'exit 130' INT
+            if [ "$link_setup_failed" -eq 1 ]; then
+                echo "!! Link setup is incomplete; the $command_name continues without it" >&2
+                echo "   To finish it later, run: installer link enable --mode=$desired_link" >&2
+            fi
         fi ;;
 esac
 
@@ -1091,5 +1104,10 @@ echo "OK: $command_name${subcommand:+ $subcommand} completed"
 if [ "$command_name:$subcommand" = runtime:install ]; then
     printf '  runtime: %s\n' "$ABLETON_WINE_ROOT"
 else
-    printf '  runtime: %s\n  prefix: %s\n  Link: %s\n' "$ABLETON_WINE_ROOT" "$ABLETON_WINEPREFIX" "$ABLETON_LINK_MODE"
+    printf '  runtime: %s\n  prefix: %s\n' "$ABLETON_WINE_ROOT" "$ABLETON_WINEPREFIX"
+    if [ "$link_setup_failed" -eq 1 ]; then
+        printf '  Link: incomplete (run: installer link enable --mode=%s)\n' "$ABLETON_LINK_MODE"
+    else
+        printf '  Link: %s\n' "$ABLETON_LINK_MODE"
+    fi
 fi

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -918,17 +918,16 @@ case "$command_name" in
             "$here/setup-link.sh" disable
         else
             # Link setup asks for a sudo password when a firewall is active.
-            # An unanswered prompt, or Ctrl-C at it, fails the step.  Live is
-            # installed by then, so that failure must not undo the install or
-            # the update: report it, name the command that finishes Link on
-            # its own, and go on.  The Link policy stays recorded, so that
-            # command and every later update run the same setup again.
+            # Preserve the completed Live changes when the prompt expires or
+            # receives Ctrl-C. Report the stopped Link step. Show the command that
+            # resumes it. The stored Link choice makes later updates repeat the
+            # setup.
             trap 'link_setup_failed=1' INT
             "$here/setup-link.sh" enable "--mode=$desired_link" || link_setup_failed=1
             trap 'exit 130' INT
             if [ "$link_setup_failed" -eq 1 ]; then
-                echo "!! Link setup is incomplete; the $command_name continues without it" >&2
-                echo "   To finish it later, run: installer link enable --mode=$desired_link" >&2
+                echo "!! Link setup stopped; the $command_name continues" >&2
+                echo "   Run this command to complete Link setup: installer link enable --mode=$desired_link" >&2
             fi
         fi ;;
 esac
@@ -1106,7 +1105,7 @@ if [ "$command_name:$subcommand" = runtime:install ]; then
 else
     printf '  runtime: %s\n  prefix: %s\n' "$ABLETON_WINE_ROOT" "$ABLETON_WINEPREFIX"
     if [ "$link_setup_failed" -eq 1 ]; then
-        printf '  Link: incomplete (run: installer link enable --mode=%s)\n' "$ABLETON_LINK_MODE"
+        printf '  Link: setup stopped (run: installer link enable --mode=%s)\n' "$ABLETON_LINK_MODE"
     else
         printf '  Link: %s\n' "$ABLETON_LINK_MODE"
     fi

--- a/scripts/test-installer-lifecycle.sh
+++ b/scripts/test-installer-lifecycle.sh
@@ -711,11 +711,10 @@ run_payload_install || fail "a quiet payload wait fails the install"
 ! grep -q 'the install is complete\.' "$base/out" || fail "a quiet prefix is reported as busy"
 ok "a quiet prefix after the payload reports nothing"
 
-# Link setup runs after the Live payload, and an unanswered sudo prompt for the
-# firewall rule fails it.  Live is installed by then, so the install must
-# complete, keep the prefix, and name the command that finishes Link on its own.
-# 'int' stands in for Ctrl-C at that prompt: the installer takes the signal
-# while it waits on the step, and the step ends the way a signalled one does.
+# Link setup runs after the Live payload. An expired sudo prompt stops the
+# firewall step. The installer must preserve Live. It must show the command that
+# resumes Link setup. Ctrl-C sends SIGINT while the installer waits. The Link
+# process then exits with status 130.
 cat > "$kit/scripts/setup-link.sh" <<'EOF'
 #!/bin/sh
 set -eu
@@ -736,35 +735,35 @@ run_failed_link_install()
             --link=always --runtime-root "$base/runtime" --prefix "$base/prefix" --yes \
         >"$base/out" 2>"$base/err"
 }
-run_failed_link_install 1 || fail "a failed Link setup after the Live payload fails the install"
-grep -q 'OK: install completed' "$base/out" || fail "a failed Link setup leaves the install incomplete"
-! grep -q 'prefix --rollback' "$base/calls.log" || fail "a failed Link setup rolls the prefix back"
-grep -qF 'run: installer link enable --mode=always' "$base/err" \
-    || fail "a failed Link setup does not name the command and mode that finish it"
-grep -qF 'Link: incomplete (run: installer link enable --mode=always)' "$base/out" \
-    || fail "the summary reports Link as set up after its setup failed"
-ok "a failed Link setup after the Live payload reports itself and keeps the install"
+run_failed_link_install 1 || fail "the install must finish after Link setup failure"
+grep -q 'OK: install completed' "$base/out" || fail "the output must confirm install completion"
+! grep -q 'prefix --rollback' "$base/calls.log" || fail "the installer must preserve the prefix"
+grep -qF 'Run this command to complete Link setup: installer link enable --mode=always' "$base/err" \
+    || fail "the output must include the Link recovery command and mode"
+grep -qF 'Link: setup stopped (run: installer link enable --mode=always)' "$base/out" \
+    || fail "the summary must report the stopped Link setup"
+ok "Link setup failure reports the resume command and preserves the install"
 
-run_failed_link_install int || fail "Ctrl-C at the Link step fails the install"
-grep -q 'OK: install completed' "$base/out" || fail "Ctrl-C at the Link step leaves the install incomplete"
-! grep -q 'prefix --rollback' "$base/calls.log" || fail "Ctrl-C at the Link step rolls the prefix back"
-grep -qF 'run: installer link enable --mode=always' "$base/err" \
-    || fail "Ctrl-C at the Link step does not name the command that finishes it"
-ok "Ctrl-C at the Link step ends only that step"
+run_failed_link_install int || fail "the install must finish after Ctrl-C stops Link setup"
+grep -q 'OK: install completed' "$base/out" || fail "the output must confirm install completion after Ctrl-C"
+! grep -q 'prefix --rollback' "$base/calls.log" || fail "the installer must preserve the prefix after Ctrl-C"
+grep -qF 'Run this command to complete Link setup: installer link enable --mode=always' "$base/err" \
+    || fail "the output must include the Link recovery command after Ctrl-C"
+ok "Ctrl-C stops Link setup and preserves the install"
 
-# The same step on an update: the previous runtime and prefix are kept in
-# place, and the update is not thrown away either.
+# An update preserves the prefix and commits the new runtime after the same
+# Link setup failure.
 : > "$base/calls.log"
 run_isolated "$base" env ABLETON_TEST_CALL_LOG="$base/calls.log" ABLETON_TEST_LINK_ENABLE_EXIT=1 \
     bash "$kit/scripts/installer.sh" update --yes >"$base/out" 2>"$base/err" \
-    || fail "a failed Link setup during an update fails the update"
-grep -q 'OK: update completed' "$base/out" || fail "a failed Link setup leaves the update incomplete"
-! grep -q -- '--rollback' "$base/calls.log" || fail "a failed Link setup rolls the update back"
-grep -q 'the update continues without it' "$base/err" \
-    || fail "a failed Link setup during an update is not reported as such"
-grep -qF 'Link: incomplete (run: installer link enable --mode=always)' "$base/out" \
-    || fail "the update summary reports Link as set up after its setup failed"
-ok "a failed Link setup during an update reports itself and keeps the update"
+    || fail "the update must finish after Link setup failure"
+grep -q 'OK: update completed' "$base/out" || fail "the output must confirm update completion"
+! grep -q -- '--rollback' "$base/calls.log" || fail "the installer must preserve the update"
+grep -q 'Link setup stopped; the update continues' "$base/err" \
+    || fail "the output must report the stopped Link setup"
+grep -qF 'Link: setup stopped (run: installer link enable --mode=always)' "$base/out" \
+    || fail "the update summary must report the stopped Link setup"
+ok "Link setup failure reports the resume action and preserves the update"
 
 base="$(new_env launcher-preflight)"
 mkdir -p "$base/runtime/bin" "$base/prefix"

--- a/scripts/test-installer-lifecycle.sh
+++ b/scripts/test-installer-lifecycle.sh
@@ -711,6 +711,61 @@ run_payload_install || fail "a quiet payload wait fails the install"
 ! grep -q 'the install is complete\.' "$base/out" || fail "a quiet prefix is reported as busy"
 ok "a quiet prefix after the payload reports nothing"
 
+# Link setup runs after the Live payload, and an unanswered sudo prompt for the
+# firewall rule fails it.  Live is installed by then, so the install must
+# complete, keep the prefix, and name the command that finishes Link on its own.
+# 'int' stands in for Ctrl-C at that prompt: the installer takes the signal
+# while it waits on the step, and the step ends the way a signalled one does.
+cat > "$kit/scripts/setup-link.sh" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'link %s\n' "$*" >> "${ABLETON_TEST_CALL_LOG:?}"
+[ "${1:-}" = enable ] || exit 0
+case "${ABLETON_TEST_LINK_ENABLE_EXIT:-0}" in
+    int) kill -INT "$PPID"; exit 130 ;;
+    *) exit "${ABLETON_TEST_LINK_ENABLE_EXIT:-0}" ;;
+esac
+EOF
+run_failed_link_install()
+{
+    : > "$base/calls.log"
+    rm -rf -- "$base/prefix" "$base/config" "$base/state" "$base/data"
+    run_isolated "$base" env ABLETON_TEST_CALL_LOG="$base/calls.log" ABLETON_TEST_LINK_ENABLE_EXIT="$1" \
+        bash "$kit/scripts/installer.sh" install \
+            --live-installer "$base/Ableton Live 12 Suite Installer.exe" \
+            --link=always --runtime-root "$base/runtime" --prefix "$base/prefix" --yes \
+        >"$base/out" 2>"$base/err"
+}
+run_failed_link_install 1 || fail "a failed Link setup after the Live payload fails the install"
+grep -q 'OK: install completed' "$base/out" || fail "a failed Link setup leaves the install incomplete"
+! grep -q 'prefix --rollback' "$base/calls.log" || fail "a failed Link setup rolls the prefix back"
+grep -qF 'run: installer link enable --mode=always' "$base/err" \
+    || fail "a failed Link setup does not name the command and mode that finish it"
+grep -qF 'Link: incomplete (run: installer link enable --mode=always)' "$base/out" \
+    || fail "the summary reports Link as set up after its setup failed"
+ok "a failed Link setup after the Live payload reports itself and keeps the install"
+
+run_failed_link_install int || fail "Ctrl-C at the Link step fails the install"
+grep -q 'OK: install completed' "$base/out" || fail "Ctrl-C at the Link step leaves the install incomplete"
+! grep -q 'prefix --rollback' "$base/calls.log" || fail "Ctrl-C at the Link step rolls the prefix back"
+grep -qF 'run: installer link enable --mode=always' "$base/err" \
+    || fail "Ctrl-C at the Link step does not name the command that finishes it"
+ok "Ctrl-C at the Link step ends only that step"
+
+# The same step on an update: the previous runtime and prefix are kept in
+# place, and the update is not thrown away either.
+: > "$base/calls.log"
+run_isolated "$base" env ABLETON_TEST_CALL_LOG="$base/calls.log" ABLETON_TEST_LINK_ENABLE_EXIT=1 \
+    bash "$kit/scripts/installer.sh" update --yes >"$base/out" 2>"$base/err" \
+    || fail "a failed Link setup during an update fails the update"
+grep -q 'OK: update completed' "$base/out" || fail "a failed Link setup leaves the update incomplete"
+! grep -q -- '--rollback' "$base/calls.log" || fail "a failed Link setup rolls the update back"
+grep -q 'the update continues without it' "$base/err" \
+    || fail "a failed Link setup during an update is not reported as such"
+grep -qF 'Link: incomplete (run: installer link enable --mode=always)' "$base/out" \
+    || fail "the update summary reports Link as set up after its setup failed"
+ok "a failed Link setup during an update reports itself and keeps the update"
+
 base="$(new_env launcher-preflight)"
 mkdir -p "$base/runtime/bin" "$base/prefix"
 cat > "$base/runtime/bin/wine" <<'EOF'


### PR DESCRIPTION
Thanks to user ΦNYX in the discord, this adds additional clarifications in TROUBLESHOOTING, and revises the installer to not fail and rollback when link does not install