### PR TITLE
Simplify installer lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 2026.08.26.2 — in progress
 
-<!-- doc-update tracking: #281 -->
-
 ### Installation and desktop integration
 
 - The installer now treats the Wine runtime, prefix, Live result, and PipeASIO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,48 +1,79 @@
 # Changelog
 
-## Unreleased
+## 2026.08.26.2 — in progress
 
-- Updates replace launchers when their saved checksums differ. The installer
-  saves the most recently replaced file or symlink beside its launcher as
-  `<name>.bak`. This behaviour covers Live, Max, protocol handlers, and
-  PipeASIO.
-- Launcher-name collisions are now replaced instead of preserved, including
-  Wine's `wine-protocol-c74max.desktop`, and the project's associations are made
-  active. Uninstall restores the previous launcher and associations.
-- Adjacent backup paths are managed as part of the installation. Uninstall
-  removes a `.bak` created in an empty path, or restores a `.bak` that existed
-  before installation. Runtime-only updates record replaced PipeASIO launchers
-  and adjacent backup paths for the same uninstall handling.
+<!-- doc-update tracking: #281 -->
 
-Live keeps more audio workers on processors with fewer cores. Audio workers
-divide Set processing among CPU cores. The `auto` setting uses the physical core
-count and half of Live's own worker count. It selects the larger value, up to
-Live's own count.
+### Installation and desktop integration
 
-On the measured 16-core, 32-thread computer, `auto` selects 16 of Live's 31
-workers. An existing user or launcher setting takes priority. Select `auto` to
-calculate the value again.
+- The installer now treats the Wine runtime, prefix, Live result, and PipeASIO
+  registry state as the core install. A warning from desktop integration, Link,
+  saved settings, the installed-file list, or cleanup keeps that working core
+  and reports what still needs attention.
+- The installed-file list now stays outside runtime and prefix recovery.
+  Install and update rebuild a stale list instead of rejecting a valid
+  install. This fixes the false end-of-install failure from issue 280.
+- Generated launchers, protocol handlers, file associations, icons, and panel
+  entries are replaced with the current project versions. Live repairs its own
+  generated desktop entries before launch. Repair failures produce one warning
+  and Live continues (#279).
+- Each shortcut and support file is repaired independently. One blocked path,
+  stale recovery record, or failed status message no longer stops later files
+  from being updated or reverses a valid Wine, prefix, or Live result.
+- Desktop database refreshes are now silent best-effort work, and the installer
+  no longer rebuilds the user-wide GTK icon cache. Unrelated icons or a
+  follow-up default-app query can no longer turn successfully written shortcuts
+  and file associations into a retry result.
+- When a generated launcher replaces an existing file or symlink, the installer
+  keeps that object beside it as `<name>.bak`. Removing the generated launcher
+  restores the displaced object and anything that already occupied the `.bak`
+  path. If the launcher changed again, all recovery copies are preserved and
+  the installer explains what remains (#279).
+- Uninstall clears generated Ableton handler defaults and preserves unrelated
+  desktop associations. Optional desktop and Link cleanup failures keep the
+  completed core removal.
+- Interrupted Link setup keeps Live installed and prints the command that
+  resumes Link setup. This covers issue 258 (#268).
 
-- audio reports now show the CPU layout that Linux gives Live:
-  - the report records the available CPU set, physical layout and Linux
-    processor preferences
+### Live, Wine, and audio
 
-- **Live's dialogs keep their content when the desktop shows them (#263):**
-  - Dialogs such as Separate Stems could open black until you clicked a
-    control. Wine now restores retained dialog content after the desktop
-    exposes the whole client area.
-  - The hardened implementation compiles on both sides of the Wine X11
-    boundary; GNOME, KDE Plasma and NVIDIA runtime confirmation is pending.
-  - Thanks @Sandai64 for the report.
+- Live no longer enters a half-old, half-new DPI session when automatic display
+  scaling changes. The launcher writes `LogPixels` and every applicable Live
+  awareness override as one fenced transaction, stops and waits for only that
+  owned Wine session, then runs `wineboot` before Live. A busy prefix is left
+  untouched. GNOME mixed-monitor detection now follows Xwayland's shared
+  highest scale, and automatic fractional setup requires confirmed native
+  Xwayland scaling. This restores stable window dimensions and the application
+  menu when moving Live across differently scaled monitors.
+- Live dialogs such as Separate Stems retain their content when the desktop
+  first displays them. This addresses the black-dialog report in issue 263;
+  confirmation on the original KDE/NVIDIA setup is still pending (#267).
+- Live 12 uses an automatic audio-worker count based on physical cores and
+  Live's own worker count. Existing user settings still take priority. The
+  troubleshooting guide provides a one-launch comparison with Live's own
+  setting (#278).
+- PipeASIO skips a redundant output publication after Live supplies an audio
+  block. Its fallback still publishes silence when the callback or buffer size
+  requires it (#269).
+- PipeASIO now identifies graph-quantum requests by the PipeWire node bound to
+  each request. It returns Live to the saved buffer size after the other request
+  ends (#274).
+- The NTSync check now proves that the running wineserver opens `/dev/ntsync`.
+  The audio report records the available CPU set, physical layout, and Linux
+  processor preferences (#272, #275).
 
-- installs and updates now finish after interrupted Link setup (#258):
-  - an active firewall makes Link setup ask for your password. The installer
-    now finishes after the prompt expires or you press Ctrl-C. It reports the
-    stopped Link setup. It gives you the command to resume setup. The previous
-    behaviour removed a new Live installation or restored the previous runtime
-  - Live offers Link when you use an ASIO driver. The README shows how to select
-    PipeASIO. The troubleshooting guide shows how to display the Link button
-  - thanks ΦNYX from Discord for the report
+### Experimental measurement tools
+
+- The new CPU and audio benchmark suite runs 5 fixed Live Sets and produces
+  comparable JSON, Markdown, and CSV reports (#271).
+- `PIPEASIO_TELEMETRY=on` records callback timing through a separate reporting
+  worker. The regular driver path keeps telemetry disabled (#273).
+- The PipeWire Pro Audio comparison tool measures one device in its current and
+  Pro Audio profiles, then restores the original profile (#276).
+- `WINE_APC_FASTPATH=1` selects an experimental NTSync wait path for controlled
+  tests. Wine's regular wait path remains the release default (#277).
+- The CPU optimisation research summary records the evidence, rejected ideas,
+  and test gates for future defaults (#270).
 
 ## 2026.08.26.1
 

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,16 @@ uninstall:                    ## remove installed Wine tree + launcher
 test:                         ## run installer and launcher lifecycle gates
 	./scripts/test-tsan-policy.sh
 	./scripts/test-release-policy.sh
+	./scripts/test-config-boundary.sh
 	./scripts/test-check-ntsync.sh
 	./scripts/test-shortcut-hold.sh
 	./scripts/test-cpu-topology.sh
 	./scripts/test-live-options.sh
 	./scripts/test-pipewire-pro-audio-ab.sh
 	./scripts/test-desktop-integration.sh
+	./scripts/test-launcher-transactions.sh
+	./scripts/test-link-boundary.sh
+	./scripts/test-uninstall-boundary.sh
 	./scripts/test-nix-packaging.sh
 	./scripts/test-installer-lifecycle.sh
 	./scripts/test-pipeasio-installer.sh

--- a/README.md
+++ b/README.md
@@ -49,8 +49,12 @@ performance with:
 - Dozens of nice-to-haves, quality-of-life fixes, and other polish
 - Auditable builds with pinned inputs, checksum verification, and public documentation
 
-We also have a separate, early AArch64 build for Apple Silicon computers that
-run Asahi Linux.
+Experimental AArch64 work for Apple Silicon computers that run Asahi Linux is
+tracked in [draft PR 259](https://github.com/shibco/ableton-linux/pull/259).
+PipeASIO and build auditing are not ready yet. Current test builds require
+clearing Live's saved application state before each launch and removing Demo
+Songs to avoid a crash; Ableton Index still crashes and shows error pop-ups.
+The draft PR tracks the required workarounds while those limits are being fixed.
 
 ## Installation
 
@@ -110,6 +114,11 @@ the installer will try to find one in the same directory.
 Once started, the install is mostly automatic.
 
 Near the end, the installer may name a program still running in the Wine prefix and ask whether to close it. Pressing Enter leaves it running, which is the safe answer if you also have Max or another Wine program open. Live is already installed by that point, so either answer keeps it.
+
+A final warning about desktop shortcuts, Link, saved settings, or old recovery
+files also keeps the installed runtime, Wine prefix, and Live. The final summary
+reports what still needs attention. The [installer warning guide](TROUBLESHOOTING.md#live-installs-and-the-final-summary-asks-for-a-retry)
+explains each result and when an update should be retried.
 
 ### Running Live
 
@@ -395,7 +404,7 @@ think that your problem is too small**.
 Start with the [common troubleshooting steps](TROUBLESHOOTING.md).
 
 If you're still stuck, file an issue [on GitHub](https://github.com/shibco/ableton-linux/issues/new/choose)
-or come visit us in the [Ableton on Linux Discord](https://discord.gg/SZ2cQgV7U). 
+or come visit us in the [Ableton on Linux Discord](https://discord.gg/VyUWk3f2j).
 When you post issues in our `#issues` Discord forum, we sync your posts to GitHub, 
 to keep our knowledge from being locked away inside a hidden Discord server.
 
@@ -409,6 +418,8 @@ Start with:
 - [Build from source](BUILDING.md)
 - [Implementation notes](notes/)
 - [CPU and audio benchmark guide](bench/README.md)
+- [CPU optimisation research summary in PR 270](https://github.com/shibco/ableton-linux/pull/270)
+- [Experimental PipeWire Pro Audio comparison](notes/PIPEWIRE-PRO-AUDIO-AB.md)
 
 Contributors must follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -16,6 +16,7 @@ have already fixed your issue.
 
 - [Installation and updates](#installation-and-updates)
   - [The installer does not finish after Live installs](#the-installer-does-not-finish-after-live-installs)
+  - [Live installs and the final summary asks for a retry](#live-installs-and-the-final-summary-asks-for-a-retry)
   - [The Ableton installer window never progresses or shows graphical corruption on Hyprland](#the-ableton-installer-window-never-progresses-or-shows-graphical-corruption-on-hyprland)
   - [The installer asks for an explicit display scale](#the-installer-asks-for-an-explicit-display-scale)
   - [The installer says PipeWire is too old](#the-installer-says-pipewire-is-too-old)
@@ -33,6 +34,7 @@ have already fixed your issue.
 - [Performance, visuals and the Live interface](#performance-visuals-and-the-live-interface)
   - [Live overloads after an update](#live-overloads-after-an-update)
   - [Live uses high CPU while idle](#live-uses-high-cpu-while-idle)
+  - [A dialog opens black until you click it](#a-dialog-opens-black-until-you-click-it)
   - [Live is the wrong size, or looks blurry](#live-is-the-wrong-size-or-looks-blurry)
 - [Plugins and Max for Live devices](#plugins-and-max-for-live-devices)
   - [A plugin's installer won't start](#a-plugins-installer-wont-start)
@@ -75,6 +77,36 @@ and run:
 ```bash
 sh ~/Downloads/install-ableton-latest.run update
 ```
+
+### Live installs and the final summary asks for a retry
+
+The installer keeps a working runtime, Wine prefix, and Live installation when
+a desktop shortcut, file association, Link setting, saved setting, or cleanup
+step needs another try. It also keeps every shortcut or support file that was
+updated successfully; one failed path does not undo the other repairs.
+
+Check the final `OK` summary. It shows which optional item needs repair:
+
+- `desktop shortcuts: retry needed` means the core installation is intact, but
+  the launchers and application-menu entries need another update
+- `Link: unchanged; setup can be retried` means Live remains installed with the
+  previous Link setting
+- `saved settings: retry needed` means the current install works and the next
+  command needs the same custom path options
+- `old recovery files: remain at ...` means the core install completed and the
+  installer kept files that it could not remove
+
+Follow the instruction printed with the warning. For desktop shortcuts, run:
+
+```bash
+sh ~/Downloads/install-ableton-latest.run update
+```
+
+Release `2026.08.26.1` could instead report that
+`install-manifest.tsv` changed after Live had installed. The current installer
+keeps that installed-file list outside runtime and prefix recovery. It rebuilds
+the list when required. This covers
+[issue 280](https://github.com/shibco/ableton-linux/issues/280).
 
 ### The Ableton installer window never progresses or shows graphical corruption on Hyprland
 
@@ -557,19 +589,37 @@ If the switch stays greyed out, or an empty Set still uses high CPU, open a
 your graphics card. If processor use rises only while the pointer moves, see
 [CPU spikes when moving your mouse](#cpu-spikes-when-moving-your-mouse).
 
+### A dialog opens black until you click it
+
+Older releases could lose the first frame of an offscreen dialog before the
+desktop displayed the window. Separate Stems was one affected dialog.
+
+Install the latest release and run an update:
+
+```bash
+sh ~/Downloads/install-ableton-latest.run update
+```
+
+The current Wine patch redraws the saved dialog content when the desktop shows
+the window. Report the desktop environment and graphics card if the problem
+continues. See [issue 263](https://github.com/shibco/ableton-linux/issues/263)
+for the original report.
+
 ### Live is the wrong size, or looks blurry
 
-If Live opens much bigger or smaller than everything else on your desktop, or
-if its text is blurry, Live is trying to display at a resolution that isn't
-aligned with your desktop.
+If Live opens much bigger or smaller than everything else on your desktop,
+resizes itself while you move it, loses its File/Edit/View menu, or has blurry
+text, Live is trying to display at a resolution that isn't aligned with your
+desktop.
 
 The launcher reads your display scale every time Live starts, so this normally
 takes care of itself. When it gets it wrong, tell Live your scale yourself:
 
 1. Close Live.
 2. Open your computer's Display settings and note the scale your screen is set
-   to, such as 125%. If your screens use different scales, use the monitor you
-   plan to use Live with.
+   to, such as 125%. On GNOME with differently scaled screens, use the highest
+   active scale because Xwayland shares that framebuffer across the screens.
+   On another desktop, use the monitor where you plan to use Live.
 3. Confirm your desktop type. In a terminal window, run this command:
 
    ```bash

--- a/notes/ABLETON-WINE-DPI-SCALE-100.md
+++ b/notes/ABLETON-WINE-DPI-SCALE-100.md
@@ -16,9 +16,31 @@ framebuffer. These values must describe the same mode:
 | Mutter `xwayland-native-scaling` | enabled | disabled |
 
 Stale values can magnify Live, double the cursor, or make the main window move
-by one or two pixels per configure cycle. `scripts/detect-scale.sh` detects
-GNOME, KDE, sway, Hyprland, COSMIC, and an Xft DPI fallback. The launcher
-updates the registry values but does not change the desktop setting.
+by one or two pixels per configure cycle. An incoherent live Wine session can
+also shrink the window in both dimensions while it is moved and remove Live's
+application menu. `scripts/detect-scale.sh` detects GNOME, KDE, sway,
+Hyprland, COSMIC, and an Xft DPI fallback. The launcher updates the registry
+values but does not change the desktop setting.
+
+On mixed-scale GNOME, Xwayland uses one shared framebuffer derived from the
+highest active logical monitor scale. The detector therefore chooses the
+highest scale, even when the 100% monitor is primary. Automatic fractional
+configuration is applied only when Mutter's `xwayland-native-scaling` feature
+can be confirmed.
+
+## Change the complete DPI block before booting Wine
+
+`reg.exe` itself starts Wine and caches the X11 monitor source from the current
+`LogPixels`. Writing a new `LogPixels` or Live IFEO value after `wineboot` can
+therefore combine an old volatile monitor scale with new persistent registry
+values. Both mismatch directions were observed to resize Live continuously.
+
+For a cold DPI change, the launcher now writes a pending-reseed marker, writes
+`LogPixels` and every installed Live IFEO key, stops and waits for the Wine
+session created by those writes, and only then runs `wineboot`. The marker is
+removed after that coherent boot. If another program is already using the
+prefix—or enters during the transaction—the launcher leaves it running and
+refuses Live until the prefix is idle.
 
 For one comparison launch:
 

--- a/scripts/ableton-linkctl
+++ b/scripts/ableton-linkctl
@@ -5,10 +5,23 @@ set -euo pipefail
 here="$(cd "$(dirname "$0")" && pwd)"
 for lib in "$here/lib/config.sh" "$here/config.sh" \
            "${XDG_DATA_HOME:-$HOME/.local/share}/ableton-wine/lib/config.sh"; do
+    # The first installed/repository helper wins.
+    # shellcheck disable=SC1090
     if [ -r "$lib" ]; then . "$lib"; break; fi
 done
-declare -F ableton_config_init >/dev/null 2>&1 || { echo "ableton-linkctl: config helper is missing" >&2; exit 1; }
-ableton_config_init
+declare -F ableton_config_init >/dev/null 2>&1 || {
+    echo "ableton-linkctl: support files are incomplete. Run the latest installer again." >&2
+    exit 1
+}
+if ! ableton_config_init 2>/dev/null; then
+    echo "ableton-linkctl: installer settings could not be read. Run the latest installer to repair them, then try again." >&2
+    exit 1
+fi
+for lib in "$here/lib/manifest.sh" \
+           "$ABLETON_DATA_HOME/lib/manifest.sh"; do
+    # shellcheck disable=SC1090
+    if [ -r "$lib" ]; then . "$lib"; break; fi
+done
 
 runtime_base="${XDG_RUNTIME_DIR:-$ABLETON_STATE_HOME/run}/ableton-wine"
 pid_file="$runtime_base/linkd.pid"
@@ -39,19 +52,54 @@ owned_pid()
     printf '%s\n' "$pid"
 }
 
+pid_matches_link_binary()
+{
+    local pid="$1" exe want
+    case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+    kill -0 "$pid" 2>/dev/null || return 1
+    exe="$(readlink -f "/proc/$pid/exe" 2>/dev/null || true)"
+    want="$(readlink -f "$ABLETON_LINKD" 2>/dev/null || true)"
+    [ -n "$want" ] && [ "$exe" = "$want" ]
+}
+
+write_pid_file()
+{
+    local pid="$1" tmp
+    tmp="$(mktemp "$runtime_base/.linkd.pid.XXXXXX" 2>/dev/null)" || return 1
+    if ! printf '%s\n' "$pid" > "$tmp" 2>/dev/null \
+       || ! chmod 600 "$tmp" 2>/dev/null \
+       || ! mv -T -f -- "$tmp" "$pid_file" 2>/dev/null; then
+        rm -f -- "$tmp" 2>/dev/null || true
+        return 1
+    fi
+}
+
+stop_spawned_link()
+{
+    local pid="$1"
+    kill -TERM "$pid" 2>/dev/null || true
+    for _ in {1..50}; do
+        kill -0 "$pid" 2>/dev/null || break
+        sleep 0.1
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -KILL "$pid" 2>/dev/null || true
+    fi
+    wait "$pid" 2>/dev/null || true
+}
+
 binary_is_project_owned()
 {
-    local manifest="$ABLETON_STATE_HOME/install-manifest.tsv" kind path digest current
-    if [ -r "$manifest" ]; then
-        while IFS=$'\t' read -r kind path digest; do
-            [ "$kind" = file ] && [ "$path" = "$ABLETON_LINKD" ] || continue
-            current="$(sha256sum -- "$ABLETON_LINKD" 2>/dev/null | awk '{print $1}')"
-            [ -n "$current" ] && [ "$current" = "$digest" ]
-            return
-        done < "$manifest"
+    local manifest="$ABLETON_STATE_HOME/install-manifest.tsv" strings_output
+    if declare -F ableton_validate_ownership_manifest >/dev/null 2>&1 \
+       && ableton_validate_ownership_manifest "$manifest" >/dev/null 2>&1 \
+       && ableton_manifest_path_matches "$ABLETON_LINKD"; then
+        return 0
     fi
     [ "$ABLETON_LINKD" = "$ABLETON_DATA_HOME/ableton-linkd" ] || return 1
-    strings "$ABLETON_LINKD" 2>/dev/null | grep -qF 'ableton-linkd: native Ableton Link session anchor and probe'
+    strings_output="$(strings "$ABLETON_LINKD" 2>/dev/null)" || return 1
+    grep -qF 'ableton-linkd: native Ableton Link session anchor and probe' \
+        <<< "$strings_output"
 }
 
 owned_pids()
@@ -74,52 +122,106 @@ owned_pids()
     return 0
 }
 
+first_owned_pid()
+{
+    local pids
+    pids="$(owned_pids)" || return 1
+    [ -n "$pids" ] || return 0
+    printf '%s\n' "${pids%%$'\n'*}"
+}
+
 start_link()
 {
     case "$ABLETON_LINK_MODE" in
         off|keep) return 0 ;;
         always)
             unit_is_project_owned || {
-                echo "ableton-linkctl: refusing to start missing, modified, or foreign unit $unit_file" >&2
+                echo "ableton-linkctl: Ableton Link was not started because its background-service file is missing or changed: $unit_file" >&2
+                echo "ableton-linkctl: Run Ableton Link setup again to repair it." >&2
                 return 1
             }
             ableton_run_bounded 20 systemctl --user start ableton-linkd.service
             return ;;
     esac
-    [ -x "$ABLETON_LINKD" ] || { echo "ableton-linkctl: Link binary not found at $ABLETON_LINKD" >&2; return 1; }
-    local linger="${ABLETON_LINKD_LINGER:-900}" pid
+    [ -x "$ABLETON_LINKD" ] || {
+        echo "ableton-linkctl: Ableton Link is missing at $ABLETON_LINKD. Run the latest installer again." >&2
+        return 1
+    }
+    local linger="${ABLETON_LINKD_LINGER:-900}" pid link_log=/dev/null
     linger="$(ableton_timeout_value "$linger" ABLETON_LINKD_LINGER 0 604800)" || return 2
-    ableton_mark_state_home
-    mkdir -p -- "$runtime_base" "$log_dir"
-    exec 9>"$lock_file"
-    flock -w 10 9 || { echo "ableton-linkctl: timed out waiting for the Link lifecycle lock" >&2; return 1; }
-    pid="$(owned_pids | head -n 1)"
+    # Logging is diagnostic only. Link can still start when optional persistent
+    # state is unavailable; the per-login directory below holds coordination.
+    if ableton_mark_state_home 2>/dev/null \
+       && mkdir -p -- "$log_dir" 2>/dev/null \
+       && { [ ! -L "$log_dir/ableton-linkd.log" ] \
+            && : >> "$log_dir/ableton-linkd.log" 2>/dev/null; }; then
+        link_log="$log_dir/ableton-linkd.log"
+    fi
+    mkdir -p -- "$runtime_base" || {
+        echo "ableton-linkctl: Ableton Link could not prepare its temporary files at $runtime_base. Check the directory permissions and try again." >&2
+        return 1
+    }
+    if ! exec 9>"$lock_file"; then
+        echo "ableton-linkctl: Ableton Link could not open its temporary lock at $lock_file. Check the directory permissions and try again." >&2
+        return 1
+    fi
+    flock -w 10 9 || {
+        echo "ableton-linkctl: Another Ableton Link start or stop is still running. Try again." >&2
+        return 1
+    }
+    pid="$(first_owned_pid)"
     if [ -n "$pid" ]; then
-        printf '%s\n' "$pid" > "$pid_file"
+        # A discovered exact process is already the requested outcome. Refresh
+        # its optional PID record atomically, but never turn a running Link into
+        # a failed start because that generated record could not be rewritten.
+        write_pid_file "$pid" || true
         return 0
     fi
-    rm -f -- "$pid_file"
     (
-        inherited_lock="${ABLETON_INSTALL_LOCK_FD:-}"
-        case "$inherited_lock" in
-            ''|*[!0-9]*) ;;
-            *) exec {inherited_lock}>&- ;;
-        esac
-        unset ABLETON_INSTALL_LOCK_FD ABLETON_RUNTIME_ONLY_LOCK
+        ableton_install_lock_close_in_child || exit 125
+        unset ABLETON_RUNTIME_ONLY_LOCK
         exec nohup "$ABLETON_LINKD" --linger "$linger"
-    ) >>"$log_dir/ableton-linkd.log" 2>&1 9>&- &
+    ) >>"$link_log" 2>&1 9>&- &
     pid=$!
-    printf '%s\n' "$pid" > "$pid_file"
     sleep 0.1
-    kill -0 "$pid" 2>/dev/null || { rm -f -- "$pid_file"; echo "ableton-linkctl: Link daemon failed to start" >&2; return 1; }
+    kill -0 "$pid" 2>/dev/null || {
+        rm -f -- "$pid_file" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+        if [ "$link_log" = /dev/null ]; then
+            echo "ableton-linkctl: Ableton Link did not start. Run the latest installer to repair its files, then try again." >&2
+        else
+            echo "ableton-linkctl: Ableton Link did not start. Check $link_log for details." >&2
+        fi
+        return 1
+    }
+    if ! write_pid_file "$pid"; then
+        # The canonical packaged helper can always be rediscovered by its exact
+        # executable. An external helper has no other safe ownership handle, so
+        # reap only the process just spawned instead of leaving it untracked.
+        if binary_is_project_owned && pid_matches_link_binary "$pid"; then
+            return 0
+        fi
+        stop_spawned_link "$pid"
+        echo "ableton-linkctl: Ableton Link was stopped because its process could not be tracked safely. Check the permissions on $runtime_base and try again." >&2
+        return 1
+    fi
 }
 
 stop_link()
 {
     local pid
-    mkdir -p -- "$runtime_base"
-    exec 9>"$lock_file"
-    flock -w 10 9 || { echo "ableton-linkctl: timed out waiting for the Link lifecycle lock" >&2; return 1; }
+    mkdir -p -- "$runtime_base" || {
+        echo "ableton-linkctl: Ableton Link could not prepare its temporary files at $runtime_base. Check the directory permissions and try again." >&2
+        return 1
+    }
+    if ! exec 9>"$lock_file"; then
+        echo "ableton-linkctl: Ableton Link could not open its temporary lock at $lock_file. Check the directory permissions and try again." >&2
+        return 1
+    fi
+    flock -w 10 9 || {
+        echo "ableton-linkctl: Another Ableton Link start or stop is still running. Try again." >&2
+        return 1
+    }
     while IFS= read -r pid; do
         [ -n "$pid" ] || continue
         kill -TERM "$pid" 2>/dev/null || true
@@ -130,24 +232,40 @@ stop_link()
                 && kill -KILL "$pid" 2>/dev/null || true
         fi
     done < <(owned_pids)
-    rm -f -- "$pid_file"
+    # The exact process outcome is authoritative. A stale generated PID record
+    # is harmless and can be replaced on the next start.
+    rm -f -- "$pid_file" 2>/dev/null || true
 }
 
 status_link()
 {
     local pid
-    printf 'policy: %s\n' "$ABLETON_LINK_MODE"
+    case "$ABLETON_LINK_MODE" in
+        off) echo 'mode: off' ;;
+        session) echo 'mode: session (while Ableton Live is running)' ;;
+        always) echo 'mode: always (background)' ;;
+        keep) echo 'mode: unchanged' ;;
+    esac
     if [ "$ABLETON_LINK_MODE" = always ] && unit_is_project_owned \
        && ableton_run_bounded 20 systemctl --user is-active --quiet ableton-linkd.service 2>/dev/null; then
-        echo 'state: running (systemd)'
-    elif pid="$(owned_pids | head -n 1)" && [ -n "$pid" ]; then
-        printf 'state: running (pid %s)\n' "$pid"
+        echo 'state: running in background'
+    elif pid="$(first_owned_pid)" && [ -n "$pid" ]; then
+        printf 'state: running (process %s)\n' "$pid"
     else
         echo 'state: stopped'
     fi
 }
 
-case "${1:-}" in
+link_action="${1:-}"
+case "$link_action" in
+    start|stop|restart)
+        ableton_install_lock_acquire || {
+            echo "ableton-linkctl: installation work is in progress; retry this command when it finishes" >&2
+            exit 1
+        } ;;
+esac
+
+case "$link_action" in
     start) start_link ;;
     stop) stop_link ;;
     restart) stop_link; start_link ;;

--- a/scripts/ableton-live
+++ b/scripts/ableton-live
@@ -94,7 +94,7 @@ ABLETON-LIVE VARIABLES:
     ABLETON_LINK_MODE=off|session|always
         whether the launcher starts the Ableton Link session anchor;
         new installations save session; otherwise the launcher follows
-        the saved policy, with off as the unconfigured compatibility fallback
+        the saved setting, with off as the unconfigured compatibility fallback
 
     ABLETON_LINKD=/path/to/ableton-linkd
         start this binary as the Ableton Link session anchor instead
@@ -259,12 +259,27 @@ for config_lib in "$launcher_here/lib/config.sh" \
                   "${XDG_DATA_HOME:-$HOME/.local/share}/ableton-wine/lib/config.sh"; do
     if [ -r "$config_lib" ]; then . "$config_lib"; break; fi
 done
-declare -F ableton_config_init >/dev/null 2>&1 || { echo "ableton-live: configuration helper is missing" >&2; exit 1; }
-ableton_config_init
+declare -F ableton_config_init >/dev/null 2>&1 || {
+    echo "ableton-live: support files are incomplete. Run the latest installer again." >&2
+    exit 1
+}
+if ! ableton_config_init 2>/dev/null; then
+    echo "ableton-live: installer settings could not be read. Run the latest installer to repair them, then try again." >&2
+    exit 1
+fi
 for lifecycle_lib in "$launcher_here/lib/lifecycle.sh" "$ABLETON_DATA_HOME/lib/lifecycle.sh"; do
     if [ -r "$lifecycle_lib" ]; then . "$lifecycle_lib"; break; fi
 done
-declare -F ableton_live_running >/dev/null 2>&1 || { echo "ableton-live: lifecycle helper is missing" >&2; exit 1; }
+for lifecycle_function in ableton_live_running ableton_prefix_wine_processes_any_runtime \
+                          ableton_prefix_wait; do
+    declare -F "$lifecycle_function" >/dev/null 2>&1 || {
+        echo "ableton-live: support files are incomplete. Run the latest installer again." >&2
+        exit 1
+    }
+done
+for manifest_lib in "$launcher_here/lib/manifest.sh" "$ABLETON_DATA_HOME/lib/manifest.sh"; do
+    if [ -r "$manifest_lib" ]; then . "$manifest_lib"; break; fi
+done
 for live_options_lib in "$launcher_here/lib/live-options.sh" "$ABLETON_DATA_HOME/lib/live-options.sh"; do
     if [ -r "$live_options_lib" ]; then . "$live_options_lib"; break; fi
 done
@@ -274,10 +289,14 @@ for live_options_function in ableton_available_physical_cores \
                              ableton_live_product_version \
                              ableton_seed_max_audio_threads; do
     declare -F "$live_options_function" >/dev/null 2>&1 || {
-        echo "ableton-live: live-options.sh helper is missing or incomplete" >&2
+        echo "ableton-live: support files are incomplete. Run the latest installer again." >&2
         exit 1
     }
 done
+declare -F ableton_install_state_has_active_transaction >/dev/null 2>&1 || {
+    echo "ableton-live: support files are incomplete. Run the latest installer again." >&2
+    exit 1
+}
 
 # Live exits cleanly; WebView2's updater does not, and one wedged agent keeps the
 # wineserver alive for the whole login session.
@@ -291,14 +310,24 @@ session_teardown()
 {
     local rc=$?
     [ -n "$session_started" ] || return "$rc"
-    ABLETON_SESSION_LABEL="Ableton Live" ableton_session_teardown || true
+    if ableton_install_lock_acquire; then
+        ABLETON_SESSION_LABEL="Ableton Live" ableton_session_teardown || true
+        # The descriptor closes automatically when this launcher exits. A
+        # failed explicit unlock here has no remaining user-visible effect.
+        ableton_install_lock_release || true
+    else
+        echo "ableton-live: Live closed, but its background Wine processes were left running because installation work started." >&2
+    fi
     return "$rc"
 }
 
 WINE_ROOT="$ABLETON_WINE_ROOT"
 export WINEPREFIX="$ABLETON_WINEPREFIX"
 [ -x "$WINE_ROOT/bin/wine" ] || { echo "ableton-live: Wine runtime is missing at $WINE_ROOT" >&2; exit 1; }
-[ -x "$WINE_ROOT/bin/wineserver" ] || { echo "ableton-live: wineserver is missing at $WINE_ROOT" >&2; exit 1; }
+[ -x "$WINE_ROOT/bin/wineserver" ] || {
+    echo "ableton-live: The Wine runtime is incomplete at $WINE_ROOT. Run the latest installer again." >&2
+    exit 1
+}
 [ -f "$WINEPREFIX/system.reg" ] || { echo "ableton-live: Wine prefix is missing or incomplete at $WINEPREFIX" >&2; exit 1; }
 case "${ABLETON_LIVE_VERSION:-}" in ''|11|12) ;;
     *) echo "ableton-live: ABLETON_LIVE_VERSION must be 11 or 12" >&2; exit 2 ;;
@@ -409,6 +438,25 @@ fi
 
 caller_winedlloverrides="${WINEDLLOVERRIDES:-}"
 
+# Host integration, diagnostics, and the selected prefix are installer-managed
+# state. Hold the same lifecycle lock before the first launcher-side write and
+# through cold bring-up, so a launch cannot invalidate an open installer
+# journal.
+ableton_install_lock_acquire || {
+    echo "ableton-live: installation work is in progress; retry this launch when it finishes" >&2
+    exit 1
+}
+if ableton_install_state_has_active_transaction; then
+    active_transaction_marker="$(find "$ABLETON_STATE_HOME/transactions" \
+        -mindepth 2 -maxdepth 3 -name active -print -quit 2>/dev/null || true)"
+    active_transaction="${active_transaction_marker%/active}"
+    [ -n "$active_transaction" ] || active_transaction="$ABLETON_STATE_HOME/transactions"
+    echo "ableton-live: an earlier install stopped before it restored the Wine runtime or prefix." >&2
+    echo "ableton-live: keep the recovery files at $active_transaction and report the problem before launching Live." >&2
+    ableton_install_lock_release || true
+    exit 1
+fi
+
 # Keep diagnostics from the current launch at one stable path. Tee preserves
 # terminal output while also covering desktop launchers whose stderr is
 # otherwise inherited from the desktop environment (and may be /dev/null).
@@ -422,8 +470,14 @@ if ableton_mark_state_home && mkdir -p -- "$diagnostic_dir" && : >> "$diagnostic
     # fallback warning that lands about two seconds into a faulted session. Same
     # already-running test as the single-instance guard below. Rotation preserves
     # the previous session when a later guard refuses this launch.
-    ableton_live_running || mv -f -- "$diagnostic_dir/live.log" "$diagnostic_dir/live.log.1"
-    exec 2> >(tee -a "$diagnostic_dir/live.log" >&2)
+    if ! ableton_live_running \
+       && ! mv -f -- "$diagnostic_dir/live.log" "$diagnostic_dir/live.log.1"; then
+        echo "ableton-live: could not rotate the previous diagnostic log" >&2
+    fi
+    # Process substitution is an asynchronous child. Close its duplicate of the
+    # lifecycle descriptor before exec, or tee can keep an otherwise released
+    # lock alive until the diagnostic pipe reaches EOF.
+    exec 2> >(ableton_install_lock_close_in_child || exit 1; exec tee -a "$diagnostic_dir/live.log" >&2)
 else
     echo "ableton-live: cannot write diagnostics to $diagnostic_dir/live.log" >&2
 fi
@@ -505,6 +559,7 @@ export WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS="${WEBVIEW2_ADDITIONAL_BROWSER_ARGU
 # empty, and the repair below copies the staged entry verbatim as it always
 # has.
 RUNTIME_LINK=""
+desktop_integration_ready=1
 runtime_lib="$WINE_ROOT/share/ableton-wine/scripts/runtime-link.sh"
 if [ -r "$runtime_lib" ]; then
     . "$runtime_lib"
@@ -517,32 +572,25 @@ fi
 # missing or changed entry can be repaired before the next browser round trip.
 repair_handler_entries() {
     local apps="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
-    local staged id type current want tmp rewrite wrote i repaired=0
+    local staged id want tmp rewrite wrote repaired=0
     local -a ids=("$ABLETON_PROTOCOL_DESKTOP_ID" "$ABLETON_AUZ_DESKTOP_ID")
-    local -a types=(x-scheme-handler/ableton application/x-wine-extension-auz)
     for id in "${ids[@]}"; do
         staged="$ABLETON_DATA_HOME/$id"
         # Packaged installs (nix) stage them under the runtime root instead of $HOME.
         [ -f "$staged" ] || staged="$WINE_ROOT/share/ableton-wine/$id"
         if [ ! -f "$staged" ]; then
-            echo "ableton-live: cannot repair $id: staged handler is missing at $staged" >&2
+            desktop_integration_ready=0
             continue
         fi
-        # An entry that is a symlink into the store is owned by nix or
-        # home-manager: it is read-only, rewriting it fails, and the declaration
-        # that produced it would put it back anyway. Repairing it every launch
-        # would only print two failures each time.
-        case "$(readlink -- "$apps/$id" 2>/dev/null)" in
-            /nix/store/*) continue ;;
-        esac
         # A packaged install's staged copy names the runtime root, which on Nix
         # is a store path; record the stable link instead, so neither an upgrade
         # nor a garbage collection can strand the entry. A tarball entry routes
         # through $ABLETON_BIN_HOME and contains no runtime root at all, so
-        # there is nothing to rewrite and the file is copied verbatim, as
-        # before - which keeps it byte-identical to the digest install.sh
-        # recorded for it.
-        want="$(cat -- "$staged")"
+        # there is nothing to rewrite and the file is copied verbatim.
+        if ! want="$(cat -- "$staged")"; then
+            desktop_integration_ready=0
+            continue
+        fi
         rewrite=0
         if [ -n "$RUNTIME_LINK" ] && [ "${want#*"$WINE_ROOT"/}" != "$want" ]; then
             want="${want//"$WINE_ROOT"\//$RUNTIME_LINK/}"
@@ -553,12 +601,14 @@ repair_handler_entries() {
         else
             cmp -s -- "$staged" "$apps/$id" && continue
         fi
-        echo "ableton-live: reinstating project handler $id" >&2
-        tmp="$apps/.$id.$$"
         if ! mkdir -p -- "$apps"; then
-            echo "ableton-live: failed to install $apps/$id" >&2
+            desktop_integration_ready=0
             continue
         fi
+        tmp="$(mktemp "$apps/.$id.XXXXXX")" || {
+            desktop_integration_ready=0
+            continue
+        }
         # wrote, not an emptied $tmp: clearing the variable loses the path and
         # leaves the partial file in place, once per launch with a new pid.
         wrote=1
@@ -567,38 +617,55 @@ repair_handler_entries() {
         else
             cp -- "$staged" "$tmp" || wrote=0
         fi
-        if [ "$wrote" -eq 0 ] || ! mv -f -- "$tmp" "$apps/$id"; then
-            rm -f -- "$tmp"
-            echo "ableton-live: failed to install $apps/$id" >&2
+        if [ "$wrote" -eq 0 ] || ! chmod 644 "$tmp" \
+           || ! mv -T -f -- "$tmp" "$apps/$id"; then
+            rm -f -- "$tmp" 2>/dev/null || true
+            desktop_integration_ready=0
             continue
         fi
         repaired=1
     done
     if [ "$repaired" -eq 1 ]; then
         if command -v update-desktop-database >/dev/null 2>&1; then
-            update-desktop-database "$apps" || \
-                echo "ableton-live: failed to refresh the desktop application database at $apps" >&2
+            update-desktop-database "$apps" || desktop_integration_ready=0
         else
-            echo "ableton-live: update-desktop-database is unavailable; repaired handlers may not be visible yet" >&2
+            desktop_integration_ready=0
         fi
     fi
+    return 0
+}
+repair_handler_entries
+
+# These reverse-DNS defaults belong to the generated callback entries above.
+# Querying avoids a needless mimeapps.list rewrite on every launch; a drifted
+# value is repaired directly while the global installation lock is held.
+# Association repair is ancillary: a failure warns but never blocks Live.
+repair_mime_defaults()
+{
+    local id type current i
+    local -a ids=("$ABLETON_PROTOCOL_DESKTOP_ID" "$ABLETON_AUZ_DESKTOP_ID")
+    local -a types=(x-scheme-handler/ableton application/x-wine-extension-auz)
     if ! command -v xdg-mime >/dev/null 2>&1; then
-        echo "ableton-live: xdg-mime is unavailable; cannot verify the Ableton callback defaults" >&2
+        desktop_integration_ready=0
         return 0
     fi
     for ((i=0; i<${#ids[@]}; i++)); do
-        id="${ids[i]}"; type="${types[i]}"
+        id="${ids[i]}"
+        type="${types[i]}"
+        current="$(xdg-mime query default "$type" 2>/dev/null || true)"
+        [ "$current" = "$id" ] && continue
         if ! xdg-mime default "$id" "$type"; then
-            echo "ableton-live: failed to set $type to $id" >&2
+            desktop_integration_ready=0
             continue
         fi
         current="$(xdg-mime query default "$type" 2>/dev/null || true)"
         if [ "$current" != "$id" ]; then
-            echo "ableton-live: $type still resolves to '${current:-no handler}', expected $id" >&2
+            desktop_integration_ready=0
         fi
     done
+    return 0
 }
-repair_handler_entries
+repair_mime_defaults
 
 # Live and Max share this coordinator.  It is acquired only for a cold Live
 # start and remains held until the selected prefix exposes the Live process.
@@ -606,16 +673,28 @@ cold_launch=0
 launch_lock_held=0
 if ! ableton_live_running; then
     cold_launch=1
-    coordinator_dir="$(ableton_lifecycle_runtime_dir)"
-    mkdir -p -- "$coordinator_dir"
+    coordinator_dir="$(ableton_lifecycle_runtime_dir)" || {
+        echo "ableton-live: Live was not started because its launch lock could not be prepared. Try again; if it repeats, report the problem." >&2
+        exit 1
+    }
+    mkdir -p -- "$coordinator_dir" || {
+        echo "ableton-live: Live was not started because its launch lock directory could not be created at $coordinator_dir. Check the directory permissions and try again." >&2
+        exit 1
+    }
     launch_lock="$coordinator_dir/bring-up.lock"
-    exec 9>"$launch_lock"
+    exec 9>"$launch_lock" || {
+        echo "ableton-live: Live was not started because its launch lock could not be opened at $launch_lock. Check the file permissions and try again." >&2
+        exit 1
+    }
     if ! flock -n 9; then
-        echo "ableton-live: another Live/Max launcher is bringing this prefix up" >&2
+        echo "ableton-live: another Live or Max launch is starting. Wait a few seconds and try again." >&2
         exit 1
     fi
     launch_lock_held=1
-    printf 'live %s\n' "$$" >&9
+    printf 'live %s\n' "$$" >&9 || {
+        echo "ableton-live: Live was not started because its launch lock could not be initialised. Try again; if it repeats, report the problem." >&2
+        exit 1
+    }
     # This launcher owns the session from here: every wine invocation is below.
     # launch_lock_held cannot serve as the gate - it is cleared once Live appears.
     session_started=1
@@ -667,44 +746,100 @@ if [ "$max_audio_threads_action" -eq 1 ]; then
     fi
 fi
 
-# Keep the menu entry tracking the installed edition: install.sh renders it
-# before Live exists in the prefix, so name, icon and window class heal here
-# on each start. An entry that does not route through this launcher is
-# hand-made and stays untouched.
-if [ -n "$exe_base" ]; then
-    apps_dir="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
-    live_entry="$apps_dir/ableton-live.desktop"
-    if [ -f "$live_entry" ] && grep -qF "$ABLETON_BIN_HOME/ableton-live" "$live_entry"; then
-        entry_name="${exe_base%.exe}"
-        entry_wmclass="$(printf '%s' "$exe_base" | tr '[:upper:]' '[:lower:]')"
-        entry_edition="$(printf '%s' "$entry_name" | awk '{print tolower($NF)}')"
-        entry_icon="live-suite"
-        [ -f "${XDG_DATA_HOME:-$HOME/.local/share}/icons/hicolor/scalable/apps/live-$entry_edition.svg" ] \
-            && entry_icon="live-$entry_edition"
-        if ! grep -qxF "Name=$entry_name" "$live_entry" \
-            || ! grep -qxF "Icon=$entry_icon" "$live_entry" \
-            || ! grep -qxF "StartupWMClass=$entry_wmclass" "$live_entry"; then
-            awk -v name="$entry_name" -v icon="$entry_icon" -v wmclass="$entry_wmclass" '
-                /^Name=/           { print "Name=" name; next }
-                /^Icon=/           { print "Icon=" icon; next }
-                /^StartupWMClass=/ { print "StartupWMClass=" wmclass; seen = 1; next }
-                { print }
-                END { if (!seen) print "StartupWMClass=" wmclass }
-            ' "$live_entry" > "$live_entry.tmp" && mv "$live_entry.tmp" "$live_entry"
-            update-desktop-database "$apps_dir" 2>/dev/null || true
-        fi
+# The menu entry is a generated artifact, not a user configuration surface.
+# Rebuild its complete canonical form from the selected edition while the
+# global lock is held. A failure only affects desktop integration, so warn and
+# continue to Live rather than turning optional self-heal into a launch gate.
+repair_live_desktop_entry()
+{
+    local apps_dir="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+    local live_entry="$apps_dir/ableton-live.desktop" live_entry_tmp=""
+    local entry_name entry_wmclass entry_edition entry_icon live_launcher
+    [ -n "$exe_base" ] || return 0
+    entry_name="${exe_base%.exe}"
+    entry_wmclass="$(printf '%s' "$exe_base" | tr '[:upper:]' '[:lower:]')"
+    entry_edition="$(printf '%s' "$entry_name" | awk '{print tolower($NF)}')"
+    entry_icon="live-suite"
+    [ -f "${XDG_DATA_HOME:-$HOME/.local/share}/icons/hicolor/scalable/apps/live-$entry_edition.svg" ] \
+        && entry_icon="live-$entry_edition"
+    live_launcher="$ABLETON_BIN_HOME/ableton-live"
+    if [ -x "$WINE_ROOT/bin/ableton-live" ]; then
+        live_launcher="$WINE_ROOT/bin/ableton-live"
+        [ -z "$RUNTIME_LINK" ] || live_launcher="$RUNTIME_LINK/bin/ableton-live"
     fi
+    if ! mkdir -p -- "$apps_dir"; then
+        desktop_integration_ready=0
+        return 0
+    fi
+    live_entry_tmp="$(mktemp "$apps_dir/.ableton-live.desktop.XXXXXX")" || {
+        desktop_integration_ready=0
+        return 0
+    }
+    if ! {
+        printf '[Desktop Entry]\n'
+        printf 'Name=%s\n' "$entry_name"
+        printf 'Comment=Music production and performance\n'
+        printf 'Exec=%s %%f\n' "$live_launcher"
+        printf 'Type=Application\n'
+        printf 'StartupNotify=true\n'
+        printf 'Path=%s\n' "$WINEPREFIX"
+        printf 'Icon=%s\n' "$entry_icon"
+        printf 'StartupWMClass=%s\n' "$entry_wmclass"
+        printf 'MimeType=application/x-ableton-live-set;application/x-ableton-live-clip;application/x-ableton-live-pack;\n'
+        printf 'Categories=AudioVideo;Audio;\n'
+    } > "$live_entry_tmp" || ! chmod 644 "$live_entry_tmp"; then
+        rm -f -- "$live_entry_tmp" 2>/dev/null || true
+        desktop_integration_ready=0
+    elif cmp -s -- "$live_entry_tmp" "$live_entry"; then
+        rm -f -- "$live_entry_tmp" 2>/dev/null || true
+    elif ! mv -T -f -- "$live_entry_tmp" "$live_entry"; then
+        rm -f -- "$live_entry_tmp" 2>/dev/null || true
+        desktop_integration_ready=0
+    elif command -v update-desktop-database >/dev/null 2>&1; then
+        update-desktop-database "$apps_dir" || desktop_integration_ready=0
+    else
+        desktop_integration_ready=0
+    fi
+    return 0
+}
+repair_live_desktop_entry
+if [ "$desktop_integration_ready" -eq 0 ]; then
+    echo "ableton-live: Live will start, but browser activation, file opening, or the application menu may need repair. Run the latest installer again." >&2
 fi
 
-# Never kill a prefix merely because Live is absent: standalone Max and other
-# clients intentionally share it.  Boot only an entirely idle prefix, under the
-# shared bring-up lock, and supervise the cold boot.
-if [ "$cold_launch" -eq 1 ] && ! ableton_prefix_busy; then
-    if ! ableton_run_bounded "${ABLETON_WINEBOOT_TIMEOUT:-60}" \
-        env WINEPREFIX="$WINEPREFIX" "$WINE_ROOT/bin/wineboot" -u >/dev/null 2>&1 9>&-; then
-        echo "ableton-live: bounded wineboot failed; refusing to launch into a partial boot" >&2
+# Record whether this launcher owns an idle prefix before its first Wine
+# command. A DPI registry write starts wineserver and seeds X11's monitor DPI
+# from the old LogPixels value, so a changed block must end that launcher-owned
+# session before wineboot. Never stop a prefix that Max or another client was
+# already using.
+dpi_prefix_was_idle=0
+dpi_changed=0
+dpi_write_failed=0
+dpi_transaction_token=""
+dpi_reseed_marker=""
+dpi_reseed_required=0
+ableton_prefix_idle_across_runtimes()
+{
+    local holders
+    holders="$(ableton_prefix_wine_processes_any_runtime "$WINEPREFIX" "$WINE_ROOT")"
+    [ -z "$holders" ]
+}
+if [ "$cold_launch" -eq 1 ]; then
+    # This fence belongs to the prefix, not the selected Wine generation. A
+    # runtime upgrade must not hide an interrupted DPI transaction while an
+    # older runtime still has the same prefix open.
+    dpi_reseed_marker="$WINEPREFIX/.ableton-linux-dpi-reseed-required"
+    if [ -L "$dpi_reseed_marker" ] \
+       || { [ -e "$dpi_reseed_marker" ] && [ ! -f "$dpi_reseed_marker" ]; }; then
+        session_started=""
+        echo "ableton-live: Live was not started because the DPI reseed marker is not a regular file: $dpi_reseed_marker" >&2
+        echo "ableton-live: move that unexpected path aside, then retry." >&2
         exit 1
     fi
+    [ ! -f "$dpi_reseed_marker" ] || dpi_reseed_required=1
+fi
+if [ "$cold_launch" -eq 1 ] && ableton_prefix_idle_across_runtimes; then
+    dpi_prefix_was_idle=1
 fi
 
 # Recalibrate prefix DPI to the detected scale before each launch. The block comes from
@@ -712,8 +847,9 @@ fi
 # other compositors -> LogPixels = round(96 x scale), no IFEO. Scales outside 100-250%
 # keep current values. ABLETON_DPI_MODE=100|fractional|dpi<N>|preserve overrides.
 if ! ableton_live_running; then
-    dpi_mode="${ABLETON_DPI_MODE:-auto}"
-    dpi_family=""; dpi_scale=""
+    dpi_mode_request="${ABLETON_DPI_MODE:-auto}"
+    dpi_mode="$dpi_mode_request"
+    dpi_family=""; dpi_scale=""; mutter_feats=""
     dpi_lib="$ABLETON_DATA_HOME/detect-scale.sh"
     # Packaged installs (nix) ship the libs under the runtime root instead of $HOME.
     [ -r "$dpi_lib" ] || dpi_lib="$WINE_ROOT/share/ableton-wine/scripts/detect-scale.sh"
@@ -751,12 +887,49 @@ if ! ableton_live_running; then
             esac
         fi
     fi
-    # The dpiAwareness IFEO is keyed on the exe name, so it follows the discovered install.
-    dpi_ifeo=""; cur_ifeo=""
-    if [ -n "$exe_base" ]; then
-        dpi_ifeo="HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\$exe_base"
-        cur_ifeo="$(awk '/^\[Software\\\\Microsoft\\\\Windows NT\\\\CurrentVersion\\\\Image File Execution Options\\\\'"$exe_base"'\]/{f=1;next} /^\[/{f=0} f&&/"dpiAwareness"=dword:/{gsub(/.*dword:/,""); gsub(/\r/,""); print; exit}' "$WINEPREFIX/system.reg" 2>/dev/null || true)"
+    if [ "$dpi_family" = gnome ] && [ "$dpi_mode_request" = auto ]; then
+        case "$dpi_mode" in
+            fractional*)
+                if command -v gsettings >/dev/null 2>&1; then
+                    mutter_feats="$(ableton_run_bounded 5 gsettings get \
+                        org.gnome.mutter experimental-features 9>&- 2>/dev/null || true)"
+                fi
+                case "$mutter_feats" in
+                    *xwayland-native-scaling*) ;;
+                    "")
+                        # Keeping an unknown existing block is not proof of
+                        # coherence. Refuse before Wine and require an explicit
+                        # policy instead of blessing a potentially bad tuple.
+                        session_started=""
+                        echo "ableton-live: GNOME xwayland-native-scaling could not be verified, so Live was not started." >&2
+                        echo "ableton-live: retry after gsettings works, or set ABLETON_DPI_MODE=100, fractional, or preserve explicitly." >&2
+                        exit 1 ;;
+                    *)
+                        echo "ableton-live: GNOME xwayland-native-scaling is OFF; selecting the coherent 100% DPI block." >&2
+                        dpi_mode=100 ;;
+                esac ;;
+        esac
     fi
+    # The dpiAwareness IFEO is keyed on the exe name. A direct launch updates
+    # its selected edition. A cold protocol/AUZ callback deliberately has no
+    # selected edition, so transact every installed Live target; the prefix
+    # association may choose any of them.
+    dpi_ifeo_keys=()
+    dpi_cur_ifeos=()
+    dpi_target_bases=()
+    if [ -n "$exe_base" ]; then
+        dpi_target_bases+=("$exe_base")
+    elif [ -n "$callback_kind" ]; then
+        while IFS= read -r dpi_target_exe; do
+            [ -n "$dpi_target_exe" ] || continue
+            dpi_target_bases+=("$(basename "$dpi_target_exe")")
+        done < <(ABLETON_LIVE_EXE='' find_live_exe "")
+    fi
+    for dpi_target_base in "${dpi_target_bases[@]}"; do
+        dpi_ifeo_key="HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\$dpi_target_base"
+        dpi_ifeo_keys+=("$dpi_ifeo_key")
+        dpi_cur_ifeos+=("$(awk '/^\[Software\\\\Microsoft\\\\Windows NT\\\\CurrentVersion\\\\Image File Execution Options\\\\'"$dpi_target_base"'\]/{f=1;next} /^\[/{f=0} f&&/"dpiAwareness"=dword:/{gsub(/.*dword:/,""); gsub(/\r/,""); print; exit}' "$WINEPREFIX/system.reg" 2>/dev/null || true)")
+    done
     # Read current values from the registry files directly (no wineserver spin-up).
     cur_lp="$(awk '/^\[Control Panel\\\\Desktop\]/{f=1;next} /^\[/{f=0} f&&/"LogPixels"=dword:/{gsub(/.*dword:/,""); gsub(/\r/,""); print; exit}' "$WINEPREFIX/user.reg" 2>/dev/null || true)"
     case "$dpi_mode" in
@@ -769,35 +942,176 @@ if ! ableton_live_running; then
                 want_lp="${lp_ifeo% *}"
                 want_ifeo="${lp_ifeo#* }"
                 want_lp_hex="$(printf '%08x' "$want_lp")"
-                if [ "$want_ifeo" = 2 ]; then
-                    if [ "${cur_lp:-}" != "$want_lp_hex" ] || { [ -n "$dpi_ifeo" ] && [ "${cur_ifeo:-}" != 00000002 ]; }; then
-                        echo "ableton-live: recalibrating prefix DPI to the '$dpi_mode' set (LogPixels $want_lp, IFEO=2)" >&2
-                        ableton_run_bounded 60 "$WINE_ROOT/bin/wine" reg add 'HKCU\Control Panel\Desktop' /v LogPixels /t REG_DWORD /d "$want_lp" /f >/dev/null 2>&1 9>&-
-                        [ -z "$dpi_ifeo" ] || ableton_run_bounded 60 "$WINE_ROOT/bin/wine" reg add "$dpi_ifeo" /v dpiAwareness /t REG_DWORD /d 2 /f >/dev/null 2>&1 9>&-
-                    fi
+                dpi_ifeo_mismatch=0
+                if [ "${#dpi_ifeo_keys[@]}" -eq 0 ]; then
+                    dpi_ifeo_mismatch=1
                 else
-                    if [ "${cur_lp:-00000060}" != "$want_lp_hex" ] || [ -n "$cur_ifeo" ]; then
-                        echo "ableton-live: recalibrating prefix DPI to the '$dpi_mode' set (LogPixels $want_lp, no IFEO)" >&2
-                        ableton_run_bounded 60 "$WINE_ROOT/bin/wine" reg add 'HKCU\Control Panel\Desktop' /v LogPixels /t REG_DWORD /d "$want_lp" /f >/dev/null 2>&1 9>&-
-                        [ -z "$dpi_ifeo" ] || ableton_run_bounded 60 "$WINE_ROOT/bin/wine" reg delete "$dpi_ifeo" /v dpiAwareness /f >/dev/null 2>&1 9>&- || true
+                    for cur_ifeo in "${dpi_cur_ifeos[@]}"; do
+                        if { [ "$want_ifeo" = 2 ] && [ "$cur_ifeo" != 00000002 ]; } \
+                           || { [ "$want_ifeo" != 2 ] && [ -n "$cur_ifeo" ]; }; then
+                            dpi_ifeo_mismatch=1
+                            break
+                        fi
+                    done
+                fi
+                dpi_change_required=0
+                if [ "$want_ifeo" = 2 ]; then
+                    [ "${cur_lp:-}" = "$want_lp_hex" ] && [ "$dpi_ifeo_mismatch" -eq 0 ] \
+                        || dpi_change_required=1
+                else
+                    [ "${cur_lp:-00000060}" = "$want_lp_hex" ] \
+                        && [ "$dpi_ifeo_mismatch" -eq 0 ] \
+                        || dpi_change_required=1
+                fi
+                if [ "$dpi_change_required" -eq 1 ]; then
+                    if [ "${#dpi_ifeo_keys[@]}" -eq 0 ]; then
+                        session_started=""
+                        echo "ableton-live: display scaling changed, but no installed Live executable was found for its DPI override." >&2
+                        echo "ableton-live: repair or install Live, then start it directly once before retrying the callback." >&2
+                        exit 1
                     fi
+                    if [ "$dpi_prefix_was_idle" -ne 1 ] \
+                       || ! ableton_prefix_idle_across_runtimes; then
+                        # This launcher has not started a Wine client. Do not let
+                        # the EXIT trap run session cleanup against the prefix
+                        # whose existing owner caused this refusal.
+                        session_started=""
+                        echo "ableton-live: display scaling changed, but another program is using the Wine prefix." >&2
+                        echo "ableton-live: close Max or the other prefix program, then start Live again so Wine can initialise the new DPI consistently." >&2
+                        exit 1
+                    fi
+                    echo "ableton-live: adjusting Wine display scaling for '$dpi_mode'" >&2
+                    dpi_transaction_token="${BASHPID:-$$}-${RANDOM:-0}-$SECONDS"
+                    # Keep an existing regular fence intact. For a new one,
+                    # noclobber prevents a path swapped to a symlink between
+                    # validation and creation from being followed.
+                    if [ ! -f "$dpi_reseed_marker" ] \
+                       && ! ( umask 077; set -o noclobber; : > "$dpi_reseed_marker" ) \
+                            2>/dev/null; then
+                        # No Wine process belongs to this launcher yet. Do not
+                        # let EXIT cleanup touch a client that may have entered
+                        # the prefix while marker publication was failing.
+                        session_started=""
+                        echo "ableton-live: display scaling changed, but its safe restart marker could not be written at $dpi_reseed_marker." >&2
+                        exit 1
+                    fi
+                    dpi_reseed_required=1
+                    dpi_changed=1
+                    if ! ableton_run_bounded 60 env WINEPREFIX="$WINEPREFIX" \
+                            ABLETON_DPI_TRANSACTION="$dpi_transaction_token" \
+                            "$WINE_ROOT/bin/wine" reg add \
+                            'HKCU\Control Panel\Desktop' /v LogPixels /t REG_DWORD \
+                            /d "$want_lp" /f >/dev/null 2>&1 9>&-; then
+                        dpi_write_failed=1
+                    fi
+                    for dpi_ifeo_index in "${!dpi_ifeo_keys[@]}"; do
+                        dpi_ifeo="${dpi_ifeo_keys[dpi_ifeo_index]}"
+                        cur_ifeo="${dpi_cur_ifeos[dpi_ifeo_index]}"
+                        if [ "$want_ifeo" = 2 ]; then
+                            if ! ableton_run_bounded 60 env WINEPREFIX="$WINEPREFIX" \
+                                    ABLETON_DPI_TRANSACTION="$dpi_transaction_token" \
+                                    "$WINE_ROOT/bin/wine" reg add \
+                                    "$dpi_ifeo" /v dpiAwareness /t REG_DWORD /d 2 /f \
+                                    >/dev/null 2>&1 9>&-; then
+                                dpi_write_failed=1
+                            fi
+                        elif [ -n "$cur_ifeo" ] && ! ableton_run_bounded 60 env \
+                                WINEPREFIX="$WINEPREFIX" \
+                                ABLETON_DPI_TRANSACTION="$dpi_transaction_token" \
+                                "$WINE_ROOT/bin/wine" reg delete "$dpi_ifeo" \
+                                /v dpiAwareness /f >/dev/null 2>&1 9>&-; then
+                            dpi_write_failed=1
+                        fi
+                    done
                 fi
             fi ;;
     esac
-    # Warn if mutter's xwayland-native-scaling disagrees with the DPI set; never change it.
-    # The knob only exists under mutter: skip when another compositor family was detected.
-    if [ -z "$dpi_family" ] || [ "$dpi_family" = gnome ]; then
-        if command -v gsettings >/dev/null 2>&1; then
-            mutter_feats="$(gsettings get org.gnome.mutter experimental-features 2>/dev/null || true)"
-            case "$dpi_mode" in
-                fractional*)   # upscaled-framebuffer sets expect the knob ON
-                    case "$mutter_feats" in *xwayland-native-scaling*) ;; *)
-                        [ -n "$mutter_feats" ] && echo "ableton-live: warn: mutter xwayland-native-scaling is OFF; the '$dpi_mode' set expects it ON" >&2 ;; esac ;;
-                100|dpi*)
-                    case "$mutter_feats" in *xwayland-native-scaling*)
-                        echo "ableton-live: warn: mutter xwayland-native-scaling is ON; the '$dpi_mode' set expects it OFF" >&2 ;; esac ;;
-            esac
+fi
+
+# A reg.exe process has already initialised Wine's X11 monitor source from the
+# pre-change LogPixels value. End only the session this cold launcher created,
+# wait for it to disappear, then let wineboot seed both system and monitor DPI
+# from the same registry block. Starting Live in the half-old/half-new state
+# causes the self-resize loop in opposite directions.
+if [ "$dpi_changed" -eq 1 ]; then
+    dpi_foreign_holder=""
+    while IFS="$(printf '\t')" read -r dpi_pid _; do
+        [ -n "$dpi_pid" ] || continue
+        if ! ableton_pid_has_env "$dpi_pid" \
+                "ABLETON_DPI_TRANSACTION=$dpi_transaction_token"; then
+            dpi_foreign_holder="$dpi_pid"
+            break
         fi
+    done < <(ableton_prefix_wine_processes_any_runtime "$WINEPREFIX" "$WINE_ROOT")
+    if [ -n "$dpi_foreign_holder" ]; then
+        # The runtime marker keeps the half-applied state from being treated as
+        # coherent on the next launch. Leave every existing process alone.
+        session_started=""
+        echo "ableton-live: another Wine process entered the prefix while display scaling was changing." >&2
+        echo "ableton-live: close it, then start Live again to finish the safe DPI restart." >&2
+        exit 1
+    fi
+    ableton_run_bounded 15 env WINEPREFIX="$WINEPREFIX" \
+        "$WINE_ROOT/bin/wineserver" -k >/dev/null 2>&1 9>&- || true
+    if ! ableton_prefix_wait "$WINE_ROOT" "$WINEPREFIX"; then
+        echo "ableton-live: Wine did not stop after its display scaling changed, so Live was not started." >&2
+        exit 1
+    fi
+    if [ "$dpi_write_failed" -eq 1 ]; then
+        echo "ableton-live: Wine display scaling could not be updated completely, so Live was not started." >&2
+        exit 1
+    fi
+fi
+
+# A previous launcher may have written the new registry block but refused to
+# stop after another client appeared. Matching registry values do not make that
+# live X11 source coherent; wait for a genuinely idle prefix and reseed it.
+if [ "$cold_launch" -eq 1 ] && [ "$dpi_reseed_required" -eq 1 ] \
+   && [ "$dpi_prefix_was_idle" -ne 1 ]; then
+    session_started=""
+    echo "ableton-live: Wine display scaling is waiting for a safe prefix restart." >&2
+    echo "ableton-live: close Max or the other prefix program, then start Live again." >&2
+    exit 1
+fi
+
+# Warn if mutter's xwayland-native-scaling disagrees with the DPI set; never change it.
+# The knob only exists under mutter: skip when another compositor family was detected.
+# This ancillary D-Bus query is deliberately after the mandatory DPI stop/wait.
+if [ -z "${dpi_family:-}" ] || [ "$dpi_family" = gnome ]; then
+    if command -v gsettings >/dev/null 2>&1; then
+        [ -n "${mutter_feats:-}" ] || mutter_feats="$(ableton_run_bounded 5 \
+            gsettings get org.gnome.mutter experimental-features 9>&- 2>/dev/null || true)"
+        case "${dpi_mode:-preserve}" in
+            fractional*)   # upscaled-framebuffer sets expect the knob ON
+                case "$mutter_feats" in *xwayland-native-scaling*) ;; *)
+                    [ -n "$mutter_feats" ] && echo "ableton-live: warn: mutter xwayland-native-scaling is OFF; the '$dpi_mode' set expects it ON" >&2 ;; esac ;;
+            100|dpi*)
+                case "$mutter_feats" in *xwayland-native-scaling*)
+                    echo "ableton-live: warn: mutter xwayland-native-scaling is ON; the '$dpi_mode' set expects it OFF" >&2 ;; esac ;;
+        esac
+    fi
+fi
+
+# Never boot merely because Live is absent: standalone Max and other clients
+# intentionally share this prefix. Boot only the prefix that was idle when this
+# launcher acquired the shared bring-up lock. This runs after DPI calibration
+# so X11 and Win32 initialise from one coherent scale.
+if [ "$cold_launch" -eq 1 ] && [ "$dpi_prefix_was_idle" -eq 1 ]; then
+    if ableton_prefix_idle_across_runtimes; then
+        if ! ableton_run_bounded "${ABLETON_WINEBOOT_TIMEOUT:-60}" \
+            env WINEPREFIX="$WINEPREFIX" "$WINE_ROOT/bin/wineboot" -u >/dev/null 2>&1 9>&-; then
+            echo "ableton-live: Wine could not finish preparing the prefix, so Live was not started. Run the installer's prefix update command, then try again." >&2
+            exit 1
+        fi
+        if [ "$dpi_reseed_required" -eq 1 ] \
+           && ! rm -f -- "$dpi_reseed_marker"; then
+            echo "ableton-live: Wine restarted with coherent display scaling, but the completed DPI marker could not be removed at $dpi_reseed_marker." >&2
+        fi
+    elif [ "$dpi_reseed_required" -eq 1 ]; then
+        session_started=""
+        echo "ableton-live: another Wine process entered the prefix before its required display restart." >&2
+        echo "ableton-live: close it, then start Live again to finish the safe DPI restart." >&2
+        exit 1
     fi
 fi
 
@@ -1022,8 +1336,26 @@ theme_watch_loop() {
         if [ "$*" = "$applied" ]; then
             continue
         fi
-        applied="$*"
-        ableton_run_bounded 30 "$WINE_ROOT/bin/wine" "$apply" "$@" >/dev/null 2>&1
+        # Live can exit between the liveness test and this Wine invocation. A
+        # lifecycle operation may then begin, so take the global lock for the
+        # exact prefix mutation and recheck Live after acquiring it.
+        if ableton_install_lock_acquire 2>/dev/null; then
+            if ableton_live_running; then
+                if ableton_run_bounded 30 "$WINE_ROOT/bin/wine" "$apply" "$@" 8>&- \
+                        >/dev/null 2>&1; then
+                    applied="$*"
+                else
+                    # Retry the same preference generation instead of treating a
+                    # failed Wine mutation as already applied.
+                    last=""
+                fi
+            fi
+            ableton_install_lock_release || return 1
+        else
+            # The installer owns the global lock. Keep this generation pending
+            # so the next watcher pass retries after it finishes.
+            last=""
+        fi
     done
 }
 
@@ -1134,7 +1466,7 @@ sync_font_fallback() {   # family -> register its SystemLink chain from what syn
                 # "Noto Sans CJK JP Regular" in ID 1, so the ID 16 name matched
                 # nothing and the entry was dropped at load with a silent
                 # "Unable to find file", dumping CJK text onto Unifont.
-                fc_fam="$(fc-scan -f '%{fullname}\n' "$f" 2>/dev/null | head -1)"
+                fc_fam="$(fc-scan -f '%{fullname}\n' "$f" 2>/dev/null | sed -n '1p')"
                 [ -n "$fc_fam" ] && pairs+=("$base,$fc_fam")
             done
         done
@@ -1334,7 +1666,9 @@ if [ -n "$shortcut_lib" ]; then
     if [ "$ableton_shortcuts_active" -eq 1 ]; then
         # The watcher can outlive a failed launch.  Do not let it keep the
         # single-launch guard open while it waits to restore the desktop.
-        ( exec 9>&-; ableton_shortcuts_watch_loop ) </dev/null >/dev/null 2>&1 &
+        ( exec 9>&- || exit 1
+          ableton_install_lock_close_in_child || exit 1
+          ableton_shortcuts_watch_loop ) </dev/null >/dev/null 2>&1 &
         disown
     fi
 elif [ "$shortcuts_mode" = take ] && [ -n "$EXE" ]; then
@@ -1394,14 +1728,16 @@ linkctl="$ABLETON_DATA_HOME/ableton-linkctl"
 # Packaged installs (nix) stage it under the runtime root instead of $HOME.
 [ -x "$linkctl" ] || linkctl="$WINE_ROOT/share/ableton-wine/scripts/ableton-linkctl"
 if [ "$ABLETON_LINK_MODE" != off ] && [ -x "$linkctl" ]; then
-    "$linkctl" start || echo "ableton-live: configured Link anchor failed to start" >&2
+    "$linkctl" start || echo "ableton-live: Ableton Link could not start; Live will continue without it." >&2
 fi
 
 # Follow Live-theme changes while it runs (see theme_watch_loop above). Spawned
 # after the launch lock is closed, fully detached; a no-op when the helper exe
 # is not installed or another watcher already holds the prefix's watch lock.
 if [ "${ABLETON_TOPBAR_MODE:-live}" = live ] && [ -n "$EXE" ] && [ -n "${want_light:-}" ]; then
-    ( exec 9>&-; theme_watch_loop ) </dev/null >/dev/null 2>&1 &
+    ( exec 9>&- || exit 1
+      ableton_install_lock_close_in_child || exit 1
+      theme_watch_loop ) </dev/null >/dev/null 2>&1 &
     disown
 fi
 
@@ -1414,22 +1750,76 @@ fi
 learnheal="$ABLETON_DATA_HOME/learnheal.exe"
 [ -f "$learnheal" ] || learnheal="$WINE_ROOT/share/ableton-wine/learnheal.exe"
 if [ -n "$EXE" ] && [ -f "$learnheal" ]; then
-    ( exec 9>&-; ableton_run_bounded 90 env WINEPREFIX="$WINEPREFIX" "$WINE_ROOT/bin/wine" "$learnheal" ) </dev/null >/dev/null 2>&1 &
+    ( exec 9>&- || exit 1
+      ableton_install_lock_close_in_child || exit 1
+      ableton_run_bounded 90 env WINEPREFIX="$WINEPREFIX" "$WINE_ROOT/bin/wine" "$learnheal" ) </dev/null >/dev/null 2>&1 &
     disown
 fi
 
 launch_command()
 {
-    if [ "$launch_lock_held" -ne 1 ]; then
-        exec "$@"
-    fi
     local child rc=0 timeout_secs i ready=0 process_group=0
     timeout_secs="$(ableton_timeout_value "${ABLETON_LAUNCH_TIMEOUT:-90}" ABLETON_LAUNCH_TIMEOUT 5 600)" || return 2
+    if [ "$launch_lock_held" -ne 1 ]; then
+        local after_pid handed_off=0 handoff_token="${BASHPID:-$$}-${RANDOM:-0}-$SECONDS"
+        if command -v setsid >/dev/null 2>&1; then
+            ( ableton_install_lock_close_in_child || exit 1
+              export ABLETON_LAUNCH_HANDOFF="$handoff_token"
+              exec setsid -- "$@" ) &
+            process_group=1
+        else
+            ( ableton_install_lock_close_in_child || exit 1
+              export ABLETON_LAUNCH_HANDOFF="$handoff_token"
+              exec "$@" ) &
+        fi
+        child=$!
+        # Do not create an unlock->exec window. Hand the lifecycle lock to a
+        # process that the installer's busy check can observe, or retain it until
+        # a short-lived callback has completed.
+        for ((i=0; i<timeout_secs*10; i++)); do
+            if ! kill -0 "$child" 2>/dev/null; then break; fi
+            while IFS= read -r after_pid; do
+                [ -n "$after_pid" ] || continue
+                if ableton_pid_has_env "$after_pid" "ABLETON_LAUNCH_HANDOFF=$handoff_token"; then
+                    handed_off=1
+                    break
+                fi
+            done < <(ableton_prefix_pids)
+            [ "$handed_off" -ne 1 ] || break
+            sleep 0.1
+        done
+        if [ "$handed_off" -eq 1 ]; then
+            ableton_install_lock_release || \
+                echo "ableton-live: Live started, but installer changes will remain blocked until this launch finishes." >&2
+            wait "$child"
+            return
+        fi
+        if kill -0 "$child" 2>/dev/null; then
+            if [ "$process_group" -eq 1 ] && kill -0 -- "-$child" 2>/dev/null; then
+                kill -TERM -- "-$child" 2>/dev/null || true
+                for _ in {1..50}; do kill -0 -- "-$child" 2>/dev/null || break; sleep 0.1; done
+                kill -0 -- "-$child" 2>/dev/null && kill -KILL -- "-$child" 2>/dev/null || true
+            else
+                kill -TERM "$child" 2>/dev/null || true
+                for _ in {1..50}; do kill -0 "$child" 2>/dev/null || break; sleep 0.1; done
+                kill -0 "$child" 2>/dev/null && kill -KILL "$child" 2>/dev/null || true
+            fi
+            wait "$child" || rc=$?
+            # This path returns immediately, so descriptor close completes any
+            # release that could not be done explicitly.
+            ableton_install_lock_release || true
+            echo "ableton-live: Live did not start within ${timeout_secs}s. Check $diagnostic_dir/live.log and try again." >&2
+            return 1
+        fi
+        wait "$child" || rc=$?
+        ableton_install_lock_release || true
+        return "$rc"
+    fi
     if command -v setsid >/dev/null 2>&1; then
-        setsid -- "$@" 9>&- &
+        ( ableton_install_lock_close_in_child || exit 1; exec setsid -- "$@" 9>&- ) &
         process_group=1
     else
-        "$@" 9>&- &
+        ( ableton_install_lock_close_in_child || exit 1; exec "$@" 9>&- ) &
     fi
     child=$!
     for ((i=0; i<timeout_secs*10; i++)); do
@@ -1437,9 +1827,6 @@ launch_command()
         if ! kill -0 "$child" 2>/dev/null; then break; fi
         sleep 0.1
     done
-    flock -u 9 2>/dev/null || true
-    exec 9>&-
-    launch_lock_held=0
     if [ "$ready" -ne 1 ]; then
         if [ "$process_group" -eq 1 ] && kill -0 -- "-$child" 2>/dev/null; then
             kill -TERM -- "-$child" 2>/dev/null || true
@@ -1451,9 +1838,17 @@ launch_command()
             kill -0 "$child" 2>/dev/null && kill -KILL "$child" 2>/dev/null || true
         fi
         wait "$child" || rc=$?
-        echo "ableton-live: Live did not become observable in the selected prefix within ${timeout_secs}s (launcher exit $rc)" >&2
+        flock -u 9 2>/dev/null || true
+        exec 9>&-
+        launch_lock_held=0
+        echo "ableton-live: Live did not start within ${timeout_secs}s (launcher exit $rc). Check $diagnostic_dir/live.log and try again." >&2
         return 1
     fi
+    flock -u 9 2>/dev/null || true
+    exec 9>&-
+    launch_lock_held=0
+    ableton_install_lock_release || \
+        echo "ableton-live: Live started, but installer changes will remain blocked until Live closes." >&2
     wait "$child"
 }
 

--- a/scripts/detect-scale.sh
+++ b/scripts/detect-scale.sh
@@ -1,8 +1,10 @@
-# Sourceable display-scale detection. ableton_detect_scale prints the primary monitor's scale
-# ("1", "1.25", ...) or returns 1 when no probe answers (probes: GNOME, KDE, sway, Hyprland,
-# COSMIC, Xft.dpi). ableton_detect_scale_ex also prints which probe answered (the compositor
-# family), and ableton_dpi_block_for_scale / ableton_dpi_block_values map a detected scale to
-# the calibrated DPI block for that family (see the mapping comment at the bottom).
+# Sourceable display-scale detection. ableton_detect_scale prints the compositor's X11-facing
+# scale ("1", "1.25", ...) or returns 1 when no probe answers (probes: GNOME, KDE, sway,
+# Hyprland, COSMIC, Xft.dpi). On mixed-scale GNOME, Mutter gives Xwayland one framebuffer at
+# the highest monitor's integer scale, so that probe returns the highest active logical scale.
+# ableton_detect_scale_ex also prints which probe answered (the compositor family), and
+# ableton_dpi_block_for_scale / ableton_dpi_block_values map a detected scale to the calibrated
+# DPI block for that family (see the mapping comment at the bottom).
 
 _ads_run() {
     if declare -F ableton_run_bounded >/dev/null 2>&1; then
@@ -13,22 +15,27 @@ _ads_run() {
 }
 
 _ads_gnome() {
-    local state rows all prim
+    local state rows all chosen
     state="$(_ads_run gdbus call --session \
         --dest org.gnome.Mutter.DisplayConfig \
         --object-path /org/gnome/Mutter/DisplayConfig \
         --method org.gnome.Mutter.DisplayConfig.GetCurrentState 2>/dev/null)" || return 1
-    # logical monitors serialise as "(x, y, scale, uint32 transform, primary, ..."
+    # GVariant may print the transform as either "uint32 0" or a bare "0"
+    # within the same state reply. Logical monitors otherwise serialise as
+    # "(x, y, scale, transform, primary, ...".
     rows="$(printf '%s\n' "$state" \
-        | grep -oE '\(-?[0-9]+, -?[0-9]+, [0-9]+(\.[0-9]+)?, uint32 [0-9]+, (true|false)')"
+        | grep -oE '\(-?[0-9]+, -?[0-9]+, [0-9]+(\.[0-9]+)?, (uint32 )?[0-9]+, (true|false)')"
     [ -n "$rows" ] || return 1
     all="$(printf '%s\n' "$rows" | awk -F', ' '{print $3}' | sort -u)"
-    prim="$(printf '%s\n' "$rows" | awk -F', ' '$5=="true"{print $3; exit}')"
-    [ -n "$prim" ] || prim="$(printf '%s\n' "$rows" | awk -F', ' 'NR==1{print $3}')"
+    chosen="$(printf '%s\n' "$rows" | awk -F', ' '
+        NR == 1 || $3 + 0 > highest + 0 { highest = $3 }
+        END { if (NR) print highest }
+    ')"
+    [ -n "$chosen" ] || return 1
     if [ "$(printf '%s\n' "$all" | wc -l)" -gt 1 ]; then
-        echo "note: monitors run mixed scales ($(printf '%s' "$all" | tr '\n' ' ' )): using the primary monitor's $prim" >&2
+        echo "note: monitors run mixed scales ($(printf '%s' "$all" | tr '\n' ' ' )): using GNOME/Xwayland's shared framebuffer scale from $chosen" >&2
     fi
-    printf '%s\n' "$prim"
+    printf '%s\n' "$chosen"
 }
 
 _ads_kde() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,7 +51,30 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-ableton_config_init
+if [ "$validate_only" -eq 1 ] || [ "$dry_run" -eq 1 ]; then
+    ABLETON_CONFIG_LAYOUT_ROOTS=none
+elif [ "$operation" != install ]; then
+    # Explicit transaction records carry their own target, marker, and
+    # allowlist checks. Unrelated configured roots must not veto a no-op domain
+    # preflight/commit when that transaction has no record for the domain.
+    ABLETON_CONFIG_LAYOUT_ROOTS=none
+elif [ "$want_runtime" -eq 1 ]; then
+    # Runtime promotion itself uses only the runtime root and private/external
+    # transaction data. Desktop, settings, and Link roots are checked only when
+    # their optional phase actually begins.
+    ABLETON_CONFIG_LAYOUT_ROOTS=runtime
+elif [ "$want_integration" -eq 1 ]; then
+    # Desktop integration writes generated files under data/state/bin.
+    # Runtime and prefix are referenced by launchers but are not destinations.
+    ABLETON_CONFIG_LAYOUT_ROOTS='data state bin'
+elif [ "$want_link" -eq 1 ]; then
+    # Link assets are generated only under the project data and state roots.
+    ABLETON_CONFIG_LAYOUT_ROOTS='data state'
+else
+    ABLETON_CONFIG_LAYOUT_ROOTS=none
+fi
+export ABLETON_CONFIG_LAYOUT_ROOTS
+ableton_config_init repair
 export WINEPREFIX="$ABLETON_WINEPREFIX"
 data="$ABLETON_DATA_HOME"
 bin="$ABLETON_BIN_HOME"
@@ -190,14 +213,13 @@ preflight_commit_transaction()
 
 rollback_transaction()
 {
-    local txn="$1" rc=0
+    local txn="$1" retire_active="${2:-1}" rc=0
     preflight_rollback_transaction "$txn" || return 1
     rollback_runtime "$txn" || rc=1
     ableton_txn_rollback_files "$txn" || rc=1
     update-mime-database "$mime_root" >/dev/null 2>&1 || true
     update-desktop-database "$apps" >/dev/null 2>&1 || true
-    gtk-update-icon-cache -q "$icons" >/dev/null 2>&1 || true
-    if [ "$rc" -eq 0 ]; then
+    if [ "$rc" -eq 0 ] && [ "$retire_active" -eq 1 ]; then
         rm -f -- "$txn/active" || rc=1
     fi
     return "$rc"
@@ -213,7 +235,8 @@ incomplete_rollback_marker_valid()
 
 commit_transaction()
 {
-    local txn="$1" metadata_pending="${2:-1}" target backup rollback marker marker_tmp=""
+    local txn="$1" metadata_pending="${2:-1}" retire_active="${3:-1}"
+    local target backup rollback marker marker_tmp=""
     local record="$1/runtime-rollback-path" record_tmp="" recorded=""
     preflight_commit_transaction "$txn" || return 1
     if [ -r "$txn/runtime.tsv" ]; then
@@ -311,31 +334,44 @@ commit_transaction()
         fi
     fi
     component_commit_started=1
-    rm -f -- "$txn/active" || return 1
+    [ "$retire_active" -eq 0 ] || rm -f -- "$txn/active" || return 1
 }
 
 case "$operation" in
     preflight-rollback) preflight_rollback_transaction "$transaction_arg"; exit ;;
     preflight-commit) preflight_commit_transaction "$transaction_arg"; exit ;;
-    rollback) rollback_transaction "$transaction_arg"; exit ;;
-    commit) commit_transaction "$transaction_arg"; exit ;;
+    # The public coordinator owns its top-level active marker. Domain helpers
+    # may validate and retire their own rollback material, but cannot make an
+    # incomplete later-domain recovery look inactive.
+    rollback) rollback_transaction "$transaction_arg" 0; exit ;;
+    commit) commit_transaction "$transaction_arg" 1 0; exit ;;
 esac
 
 [ "$want_runtime$want_integration$want_link" != 000 ] || {
     echo "!! select at least one component" >&2; exit 2; }
 
+runtime_core_only=0
+if [ "$want_runtime" -eq 1 ] && [ "$want_integration" -eq 0 ] \
+   && [ "$want_link" -eq 0 ]; then
+    runtime_core_only=1
+fi
+
 own_transaction=0
 if [ -n "$transaction_arg" ]; then
     ABLETON_TRANSACTION_DIR="$transaction_arg"
-elif [ "$validate_only" -eq 1 ] || [ "$dry_run" -eq 1 ] \
-     || { [ "$want_runtime" -eq 1 ] && [ "$want_integration" -eq 0 ] && [ "$want_link" -eq 0 ]; }; then
-    ABLETON_TRANSACTION_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ableton-install-plan.XXXXXX")"
-    own_transaction=1
 else
-    ableton_mark_state_home
-    mkdir -p -- "$ABLETON_STATE_HOME/transactions"
-    ABLETON_TRANSACTION_DIR="$(mktemp -d "$ABLETON_STATE_HOME/transactions/install.XXXXXX")"
-    own_transaction=1
+    # Only the public coordinator keeps recovery state under XDG_STATE_HOME.
+    # A direct component call is private scratch work; if its cleanup is
+    # interrupted, launchers must never mistake it for an unfinished core run.
+    if ABLETON_TRANSACTION_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ableton-install-plan.XXXXXX")"; then
+        own_transaction=1
+    elif [ "$want_runtime" -eq 1 ]; then
+        exit 1
+    else
+        ABLETON_TRANSACTION_DIR=""
+        echo "!! Temporary recovery files are unavailable. Continuing with repairable shortcuts and support files." >&2 \
+            || true
+    fi
 fi
 export ABLETON_TRANSACTION_DIR
 # ShellCheck does not follow function names stored in traps.
@@ -346,32 +382,105 @@ cleanup_unstarted_component_transaction()
     trap - EXIT
     if [ "$rc" -ne 0 ] && [ "$own_transaction" -eq 1 ] \
        && ! rm -rf -- "$ABLETON_TRANSACTION_DIR"; then
-        echo "!! failed to remove unstarted component transaction: $ABLETON_TRANSACTION_DIR" >&2
+        echo "!! Temporary installer files could not be removed: $ABLETON_TRANSACTION_DIR" >&2
     fi
     exit "$rc"
 }
 trap cleanup_unstarted_component_transaction EXIT
-ableton_txn_init
-ableton_validate_install_state_journals
+if ! ableton_txn_init; then
+    if [ "$want_runtime" -eq 1 ] || [ -n "$transaction_arg" ]; then
+        exit 1
+    fi
+    [ "$own_transaction" -eq 0 ] || rm -rf -- "$ABLETON_TRANSACTION_DIR" 2>/dev/null || true
+    own_transaction=0
+    ABLETON_TRANSACTION_DIR=""
+    export ABLETON_TRANSACTION_DIR
+    echo "!! Temporary recovery files are unavailable. Continuing with repairable shortcuts and support files." >&2 \
+        || true
+fi
+ableton_validate_install_state_journals repair
 stage=""
 component_commit_started=0
+runtime_core_ready=0
+runtime_core_committed=0
+optional_files_ready=0
+direct_optional_transaction=0
+cleanup_preview_scratch()
+{
+    local stage_name=""
+    if [ -n "$stage" ]; then
+        stage_name="$(basename "$stage" 2>/dev/null || true)"
+        case "$stage_name" in
+            ableton-runtime-validate.*)
+                if [ -d "$stage" ] && [ ! -L "$stage" ]; then
+                    rm -rf -- "$stage" 2>/dev/null || true
+                fi ;;
+        esac
+        if [ -e "$stage" ] || [ -L "$stage" ]; then
+            echo "!! Checks finished, but temporary files remain at $stage" >&2 || true
+        fi
+        stage=""
+    fi
+    if [ "$own_transaction" -eq 1 ]; then
+        rm -f -- "$ABLETON_TRANSACTION_DIR/active" 2>/dev/null || true
+        rm -rf -- "$ABLETON_TRANSACTION_DIR" 2>/dev/null || true
+        if [ -e "$ABLETON_TRANSACTION_DIR" ] || [ -L "$ABLETON_TRANSACTION_DIR" ]; then
+            echo "!! Checks finished, but temporary files remain at $ABLETON_TRANSACTION_DIR" >&2 \
+                || true
+        fi
+        own_transaction=0
+    fi
+    return 0
+}
 cleanup()
 {
     local rc=$? restore_error="" restoration_complete=yes
     trap - EXIT
+    # Recovery must not depend on whether a diagnostic stream is writable.
+    # Every mutation/recovery status below is handled explicitly.
+    set +e
+    if [ "$validate_only" -eq 1 ] || [ "$dry_run" -eq 1 ]; then
+        # Preview work never mutates installation state. Preserve the real
+        # validation/planning result and dispose only its private scratch;
+        # there is nothing to roll back or record as failed recovery.
+        cleanup_preview_scratch
+        exit "$rc"
+    fi
     if [ -n "$stage" ] && ! rm -rf -- "$stage"; then
         restore_error="temporary runtime cleanup failed"
         rc=1
     fi
-    if [ "$rc" -ne 0 ] && [ "$component_commit_started" -eq 1 ]; then
+    if [ "$rc" -ne 0 ] \
+       && { [ "$runtime_core_committed" -eq 1 ] || [ "$optional_files_ready" -eq 1 ]; }; then
+        if [ "$runtime_core_committed" -eq 1 ]; then
+            if [ "$direct_optional_transaction" -eq 1 ] \
+               && { [ -e "$ABLETON_TRANSACTION_DIR/active" ] \
+                    || [ -L "$ABLETON_TRANSACTION_DIR/active" ]; }; then
+                if ! rollback_transaction "$ABLETON_TRANSACTION_DIR"; then
+                    restore_error="optional files could not be fully restored"
+                elif ! rm -rf -- "$ABLETON_TRANSACTION_DIR"; then
+                    restore_error="temporary optional-file recovery data could not be removed"
+                fi
+            fi
+            echo "!! Wine is ready. Run the installer again to retry shortcuts or Ableton Link files." >&2 || true
+            [ -z "$restore_error" ] \
+                || echo "!! Some shortcut or Link files from this attempt could not be restored: $restore_error" >&2 || true
+            if [ -z "$transaction_arg" ]; then
+                echo "OK: Installation complete." || true
+            fi
+        else
+            echo "!! Ableton is ready. Run the installer again to retry shortcuts or Ableton Link files." >&2 || true
+        fi
+        rc=0
+    elif [ "$rc" -ne 0 ] && [ "$component_commit_started" -eq 1 ]; then
         printf 'component=install.sh\nstatus=committed-cleanup-incomplete\nexit=%s\ncleanup_error=%s\n' \
             "$rc" "$restore_error" > "$ABLETON_TRANSACTION_DIR/COMMITTED_CLEANUP_FAILURE" 2>/dev/null || true
-        echo "!! component installation is committed, but cleanup is incomplete" >&2
-        echo "!! inspect $ABLETON_TRANSACTION_DIR/COMMITTED_CLEANUP_FAILURE before retrying" >&2
+        echo "!! Installation finished, but temporary recovery files could not be removed." >&2
+        echo "!! Details were saved at $ABLETON_TRANSACTION_DIR/COMMITTED_CLEANUP_FAILURE." >&2
     elif [ "$rc" -ne 0 ] && [ -e "$ABLETON_TRANSACTION_DIR/active" ]; then
-        echo "!! component installation failed; rolling its recorded mutations back" >&2
+        echo "!! Installation did not finish. Restoring the files from before this attempt." >&2
         if ! rollback_transaction "$ABLETON_TRANSACTION_DIR"; then
-            restore_error="${restore_error}${restore_error:+; }component rollback failed"
+            restore_error="${restore_error}${restore_error:+; }earlier files could not be fully restored"
         fi
         [ -z "$restore_error" ] || restoration_complete=no
         if [ "$own_transaction" -eq 1 ]; then
@@ -379,14 +488,14 @@ cleanup()
                 "$rc" "$restoration_complete" "$restore_error" \
                 > "$ABLETON_TRANSACTION_DIR/FAILURE" || true
             if [ "$restoration_complete" = yes ]; then
-                echo "!! rollback complete; failure record: $ABLETON_TRANSACTION_DIR/FAILURE" >&2
+                echo "!! Earlier files were restored. Details: $ABLETON_TRANSACTION_DIR/FAILURE" >&2
             else
-                echo "!! component rollback is incomplete: $restore_error" >&2
-                echo "!! inspect $ABLETON_TRANSACTION_DIR/FAILURE before retrying" >&2
+                echo "!! Automatic restoration did not finish: $restore_error" >&2
+                echo "!! Keep $ABLETON_TRANSACTION_DIR/FAILURE for troubleshooting before retrying." >&2
             fi
         fi
     elif [ "$rc" -ne 0 ] && [ -n "$restore_error" ]; then
-        echo "!! component cleanup is incomplete: $restore_error" >&2
+        echo "!! Temporary installer cleanup did not finish: $restore_error" >&2
     fi
     exit "$rc"
 }
@@ -405,8 +514,8 @@ validate_runtime_payload()
 {
     local version version_lines checksum expected_sha checksum_name checksum_extra actual_sha
     [ -r "$root/VERSION" ] || { echo "!! installer kit has no VERSION" >&2; return 1; }
-    version_lines="$(wc -l < "$root/VERSION")"
-    version="$(sed -n '1p' "$root/VERSION")"
+    version_lines="$(wc -l < "$root/VERSION")" || return 1
+    version="$(sed -n '1p' "$root/VERSION")" || return 1
     [ "$version_lines" -eq 1 ] && [[ "$version" =~ ^20[0-9]{2}\.[0-9]{2}\.[0-9]{2}\.[0-9]+$ ]] || {
         echo "!! installer kit has an invalid VERSION" >&2; return 1; }
     tarball="$root/dist/$ABLETON_RUNTIME_NAME-$version.tar.zst"
@@ -420,7 +529,7 @@ validate_runtime_payload()
     checksum_name="${checksum_name#\*}"
     [ "$checksum_name" = "$(basename "$tarball")" ] || {
         echo "!! runtime checksum names a different payload" >&2; return 1; }
-    actual_sha="$(sha256sum -- "$tarball" | awk '{print $1}')"
+    actual_sha="$(sha256sum -- "$tarball" | awk '{print $1}')" || return 1
     [ "$actual_sha" = "$expected_sha" ] || { echo "!! runtime checksum does not match" >&2; return 1; }
     runtime_info="$root/BUILD-INFO-$version.txt"
     [ -s "$runtime_info" ] || runtime_info="$root/dist/BUILD-INFO-$version.txt"
@@ -428,26 +537,22 @@ validate_runtime_payload()
     bundle_probe="$root/bin/pipewire-version-probe"
     [ -x "$bundle_probe" ] || bundle_probe="$root/dist/pipewire-version-probe"
     [ -x "$bundle_probe" ] || { echo "!! installer kit is missing its PipeWire compatibility check" >&2; return 1; }
-    echo "== validate runtime payload: $(basename "$tarball") =="
-    echo "$(basename "$tarball"): OK"
+    echo "== Check the Wine package: $(basename "$tarball") ==" || true
+    echo "$(basename "$tarball"): OK" || true
     local parent
-    parent="$(dirname "$ABLETON_WINE_ROOT")"
+    parent="$(dirname "$ABLETON_WINE_ROOT")" || return 1
     if [ "$validate_only" -eq 1 ] || [ "$dry_run" -eq 1 ]; then
-        stage="$(mktemp -d "${TMPDIR:-/tmp}/ableton-runtime-validate.XXXXXX")"
+        stage="$(mktemp -d "${TMPDIR:-/tmp}/ableton-runtime-validate.XXXXXX")" || return 1
     else
-        mkdir -p -- "$parent"
-        stage="$(mktemp -d "$parent/.ableton-runtime-stage.XXXXXX")"
+        mkdir -p -- "$parent" || return 1
+        stage="$(mktemp -d "$parent/.ableton-runtime-stage.XXXXXX")" || return 1
     fi
     local extract_timeout
-    extract_timeout="$(ableton_timeout_value "${ABLETON_RUNTIME_EXTRACT_TIMEOUT:-1800}" ABLETON_RUNTIME_EXTRACT_TIMEOUT 60 7200)"
-    echo "   extracting and checking the staged runtime (bounded to ${extract_timeout}s)"
-    if tar --help 2>&1 | grep -q -- '--checkpoint'; then
-        ableton_run_bounded "$extract_timeout" tar --checkpoint=500 --checkpoint-action=dot \
-            -C "$stage" -I zstd -xf "$tarball"
-        printf '\n' >&2
-    else
-        ableton_run_bounded "$extract_timeout" tar -C "$stage" -I zstd -xf "$tarball"
-    fi
+    extract_timeout="$(ableton_timeout_value "${ABLETON_RUNTIME_EXTRACT_TIMEOUT:-1800}" ABLETON_RUNTIME_EXTRACT_TIMEOUT 60 7200)" \
+        || return 1
+    echo "   Unpacking and checking Wine (up to ${extract_timeout}s)" || true
+    ableton_run_bounded "$extract_timeout" tar -C "$stage" -I zstd -xf "$tarball" \
+        >/dev/null || return 1
     candidate="$stage/$ABLETON_RUNTIME_NAME"
     local required
     for required in \
@@ -468,15 +573,30 @@ validate_runtime_payload()
     [ ! -e "$candidate/lib/wine/i386-windows/libusb-1.0.dll" ] || {
         echo "!! runtime unexpectedly contains a 32-bit Push bridge" >&2; return 1; }
     if command -v readelf >/dev/null 2>&1 && command -v strings >/dev/null 2>&1; then
-        readelf -d "$candidate/lib/wine/x86_64-unix/libusb-1.0.so" | grep -F 'Shared library: [libusb-1.0.so.0]' >/dev/null
-        strings "$candidate/lib/wine/x86_64-unix/comdlg32.so" | grep -F 'org.freedesktop.portal.FileChooser' >/dev/null
-        readelf -d "$candidate/lib/wine/x86_64-unix/pipeasio64.dll.so" | grep -F 'Shared library: [libpipewire-0.3.so.0]' >/dev/null
-        readelf -d "$candidate/lib/wine/x86_64-unix/winegstreamer.so" | grep -F 'Shared library: [libgstreamer-1.0.so.0]' >/dev/null
+        readelf -d "$candidate/lib/wine/x86_64-unix/libusb-1.0.so" \
+            | grep -F 'Shared library: [libusb-1.0.so.0]' >/dev/null || {
+            echo "!! runtime Push bridge dependency validation failed" >&2; return 1; }
+        strings "$candidate/lib/wine/x86_64-unix/comdlg32.so" \
+            | grep -F 'org.freedesktop.portal.FileChooser' >/dev/null || {
+            echo "!! runtime portal integration validation failed" >&2; return 1; }
+        readelf -d "$candidate/lib/wine/x86_64-unix/pipeasio64.dll.so" \
+            | grep -F 'Shared library: [libpipewire-0.3.so.0]' >/dev/null || {
+            echo "!! runtime PipeASIO dependency validation failed" >&2; return 1; }
+        readelf -d "$candidate/lib/wine/x86_64-unix/winegstreamer.so" \
+            | grep -F 'Shared library: [libgstreamer-1.0.so.0]' >/dev/null || {
+            echo "!! runtime GStreamer dependency validation failed" >&2; return 1; }
     fi
-    ableton_pipeasio_validate_runtime "$candidate" "$runtime_info" "$version"
+    ableton_pipeasio_validate_runtime "$candidate" "$runtime_info" "$version" || return 1
+    if ! ableton_pipeasio_validate_panel "$candidate" "$runtime_info" >/dev/null 2>&1; then
+        echo "!! Wine and PipeASIO passed their checks, but PipeASIO Settings is incomplete. Its desktop shortcut will be left unchanged." >&2 \
+            || true
+    fi
     cmp -s -- "$bundle_probe" "$candidate/bin/pipewire-version-probe" || {
         echo "!! installer and runtime compatibility checks do not match" >&2; return 1; }
-    ableton_run_bounded 30 "$candidate/bin/wine" --version
+    ableton_run_bounded 30 "$candidate/bin/wine" --version >/dev/null || {
+        echo "!! staged runtime Wine executable did not pass its bounded version check" >&2
+        return 1
+    }
 }
 
 validate_integration_sources()
@@ -516,112 +636,114 @@ validate_integration_sources()
         [ -f "$root/desktop/$required" ] || {
             echo "!! installer kit is missing desktop/$required" >&2; return 1; }
     done
-    for required in xdg-mime update-desktop-database update-mime-database; do
-        command -v "$required" >/dev/null 2>&1 || {
-            echo "!! $required is required for desktop and MIME integration" >&2; return 1; }
-    done
 }
 
 validate_link_sources()
 {
-    local file needed
+    local file needed managed_linkd="$ABLETON_DATA_HOME/ableton-linkd"
     for file in "$here/../bin/ableton-linkd" "$root/dist/ableton-linkd"; do
         [ -f "$file" ] && { linkd_source="$file"; break; }
     done
-    [ -n "$linkd_source" ] || { echo "!! installer kit is missing bin/ableton-linkd" >&2; return 1; }
+    if [ "$ABLETON_LINKD" = "$managed_linkd" ] && [ -z "$linkd_source" ]; then
+        echo "!! installer kit is missing bin/ableton-linkd" >&2
+        return 1
+    fi
     unit_source="$here/ableton-linkd.service"
     [ -f "$unit_source" ] || unit_source="$root/scripts/ableton-linkd.service"
     [ -f "$unit_source" ] || { echo "!! installer kit is missing ableton-linkd.service" >&2; return 1; }
     [ -f "$here/ableton-linkctl" ] || { echo "!! installer kit is missing ableton-linkctl" >&2; return 1; }
-    if command -v readelf >/dev/null 2>&1; then
-        needed="$(readelf -d "$linkd_source" | sed -n 's/.*Shared library: \[\(.*\)\]/\1/p')"
+    if [ -n "$linkd_source" ] && command -v readelf >/dev/null 2>&1; then
+        needed="$(readelf -d "$linkd_source" \
+            | sed -n 's/.*Shared library: \[\(.*\)\]/\1/p')" || {
+            echo "!! could not inspect ableton-linkd dependencies" >&2
+            return 1
+        }
         for file in $needed; do
             case "$file" in linux-vdso.so*|libm.so*|libc.so*|libpthread.so*|libatomic.so*|ld-linux*.so*) ;;
                 *) echo "!! ableton-linkd links unexpected library $file" >&2; return 1 ;;
             esac
         done
     fi
-    ableton_run_bounded 10 "$linkd_source" --help >/dev/null
+    if [ -n "$linkd_source" ]; then
+        ableton_run_bounded 10 "$linkd_source" --help >/dev/null || {
+            echo "!! ableton-linkd did not pass its bounded startup check" >&2
+            return 1
+        }
+    fi
 }
 
-[ "$want_runtime" -eq 0 ] || validate_runtime_payload
-[ "$want_integration" -eq 0 ] || validate_integration_sources
-[ "$want_link" -eq 0 ] || validate_link_sources
+if [ "$want_runtime" -eq 1 ]; then
+    validate_runtime_payload
+fi
+if [ "$want_integration" -eq 1 ]; then
+    if ! validate_integration_sources; then
+        if [ "$validate_only" -eq 1 ] || [ "$dry_run" -eq 1 ]; then
+            exit 1
+        fi
+        echo "!! Some shortcut or support files are missing from this installer. Available files will still be updated." >&2 \
+            || true
+    fi
+fi
+if [ "$want_link" -eq 1 ]; then
+    if ! validate_link_sources; then
+        if [ "$validate_only" -eq 1 ] || [ "$dry_run" -eq 1 ]; then
+            exit 1
+        fi
+        echo "!! Some Ableton Link files are missing from this installer. Available files will still be updated." >&2 \
+            || true
+    fi
+fi
+if [ "$want_runtime" -eq 1 ] \
+   && { [ "$want_integration" -eq 1 ] || [ "$want_link" -eq 1 ]; } \
+   && ! ableton_config_validate_layout 'runtime prefix data config state bin'; then
+    echo "!! Wine can still be installed, but shortcuts and Link support were skipped because one of their locations cannot be used safely." >&2 \
+        || true
+    want_integration=0
+    want_link=0
+fi
+if [ "$want_runtime" -eq 1 ] && [ "$want_integration" -eq 0 ] \
+   && [ "$want_link" -eq 0 ]; then
+    runtime_core_only=1
+fi
 
 if [ "$validate_only" -eq 1 ]; then
-    echo "OK: selected component payloads are valid"
-    if [ -n "$stage" ]; then
-        case "$(basename "$stage")" in ableton-runtime-validate.*) ;; *)
-            echo "!! refusing unexpected validation staging path: $stage" >&2; exit 1 ;; esac
-        [ -d "$stage" ] && [ ! -L "$stage" ] \
-            && rm -rf -- "$stage" && [ ! -e "$stage" ] || exit 1
-        stage=""
-    fi
-    rm -f -- "$ABLETON_TRANSACTION_DIR/active"
-    if [ "$own_transaction" -eq 1 ]; then
-        rm -rf -- "$ABLETON_TRANSACTION_DIR"
-    fi
+    # Validation has already succeeded. Reporting and disposal of private
+    # scratch files cannot turn that result into a failure.
+    set +e
+    echo "OK: The selected files passed all checks."
+    cleanup_preview_scratch
     trap - EXIT
     exit 0
 fi
 
 if [ "$dry_run" -eq 1 ]; then
+    # Planning mutates no installation state. Its report and scratch cleanup
+    # are presentation/housekeeping only.
+    set +e
     echo "PLAN: resolved configuration"
     [ "$want_runtime" -eq 0 ] || {
-        printf '  replace runtime tree atomically: %s\n' "$ABLETON_WINE_ROOT"
-        printf '  write runtime ownership marker: %s/.ableton-linux-runtime\n' "$ABLETON_WINE_ROOT"
+        printf '  install or update Wine: %s\n' "$ABLETON_WINE_ROOT"
+        echo "  update PipeASIO Settings shortcuts to match this Wine build"
     }
-    if [ "$want_runtime" -eq 1 ] && [ "$want_integration" -eq 0 ]; then
-        printf '  apply the runtime PipeASIO panel record to existing launchers\n'
-        printf '  save each replaced PipeASIO launcher beside it as: <name>.bak\n'
-        printf '  record ownership for each replaced PipeASIO launcher in: %s/install-manifest.tsv\n' \
-            "$ABLETON_STATE_HOME"
-    fi
     if [ "$want_integration" -eq 1 ]; then
-        printf '  back up each displaced launcher beside it as: <name>.bak\n'
-        printf '  write launcher: %s/ableton-live\n' "$bin"
-        printf '  write launcher support and recovery tools below: %s\n' "$data"
-        printf '  write NTSync diagnostic: %s/{check-ntsync.sh,ntsyncprobe.exe}\n' "$data"
-        printf '  write helper assets when packaged: %s/{setsyscolors.exe,learnheal.exe}\n' "$data"
-        printf '  write desktop entries: %s/{ableton-live,%s,%s}\n' \
-            "$apps" "$ABLETON_PROTOCOL_DESKTOP_ID" "$ABLETON_AUZ_DESKTOP_ID"
-        printf '  write staged callback entries: %s/{%s,%s}\n' \
-            "$data" "$ABLETON_PROTOCOL_DESKTOP_ID" "$ABLETON_AUZ_DESKTOP_ID"
-        printf '  write icon files below: %s/{scalable,symbolic}\n' "$icons"
-        printf '  write MIME packages below: %s/packages\n' "$mime_root"
-        printf '  record/modify MIME defaults: %s/mime-prestate.tsv and %s\n' \
-            "$ABLETON_STATE_HOME" "${XDG_CONFIG_HOME:-$HOME/.config}/mimeapps.list"
+        echo "  install or update launchers, desktop shortcuts, file-opening support, and icons"
+        echo "  install diagnostic and recovery tools"
         if [ -f "$ABLETON_WINEPREFIX/drive_c/Program Files/Cycling '74/Max 9/Max.exe" ]; then
-            printf '  write Max launcher and desktop/protocol entries: %s/max9, %s/{max9,wine-protocol-c74max}.desktop\n' "$bin" "$apps"
+            echo "  install or update the Max 9 launcher and file-opening support"
         fi
     fi
     if [ "$want_link" -eq 1 ]; then
         if [ "$ABLETON_LINKD" = "$ABLETON_DATA_HOME/ableton-linkd" ]; then
-            printf '  write Link binary: %s\n' "$ABLETON_LINKD"
+            echo "  install or update Ableton Link support"
         else
-            printf '  use external Link binary without taking ownership: %s\n' "$ABLETON_LINKD"
+            printf '  use the configured Ableton Link helper and leave it unchanged: %s\n' "$ABLETON_LINKD"
         fi
-        printf '  write Link controller/setup/unit assets: %s/{ableton-linkctl,setup-link.sh,ableton-linkd.service}\n' "$data"
-        printf '  write Link support libraries: %s/lib/{config.sh,lifecycle.sh,manifest.sh}\n' "$data"
-    fi
-    if [ "$want_integration" -eq 1 ] || [ "$want_link" -eq 1 ]; then
-        printf '  write component version: %s/VERSION\n' "$data"
     fi
     if [ "$want_integration" -eq 1 ] || [ "$want_link" -eq 1 ] \
        || { [ "$want_runtime" -eq 1 ] && [ "$ownership_manifest_was_present" -eq 1 ]; }; then
-        printf '  update ownership manifest: %s/install-manifest.tsv\n' "$ABLETON_STATE_HOME"
+        echo "  record the installed release and files for later repair or removal"
     fi
-    if [ -n "$stage" ]; then
-        case "$(basename "$stage")" in ableton-runtime-validate.*) ;; *)
-            echo "!! refusing unexpected validation staging path: $stage" >&2; exit 1 ;; esac
-        [ -d "$stage" ] && [ ! -L "$stage" ] \
-            && rm -rf -- "$stage" && [ ! -e "$stage" ] || exit 1
-        stage=""
-    fi
-    rm -f -- "$ABLETON_TRANSACTION_DIR/active"
-    if [ "$own_transaction" -eq 1 ]; then
-        rm -rf -- "$ABLETON_TRANSACTION_DIR"
-    fi
+    cleanup_preview_scratch
     trap - EXIT
     exit 0
 fi
@@ -674,21 +796,32 @@ stop_runtime_clients()
 promote_runtime()
 {
     local target="$ABLETON_WINE_ROOT" parent backup safe marker marker_tmp record
-    parent="$(dirname "$target")"
-    mkdir -p -- "$parent"
+    parent="$(dirname "$target")" || return 1
+    mkdir -p -- "$parent" || return 1
     safe="$(ableton_path_is_safe_delete_target "$target")" || { echo "!! unsafe runtime target: $target" >&2; return 1; }
     backup=absent
     if [ -e "$safe" ]; then
         [ ! -L "$safe" ] || { echo "!! refusing to replace symlink runtime $safe" >&2; return 1; }
-        ableton_adopt_runtime_marker "$safe" "$ABLETON_RUNTIME_NAME" || {
-            echo "!! refusing to replace an unrecognised runtime directory: $safe" >&2
-            return 1
-        }
+        if [ "$runtime_core_only" -eq 1 ]; then
+            # The directory-level runtime record is the complete rollback unit.
+            # Marking a recognised legacy runtime must not add a host-file row
+            # to that core record.
+            ABLETON_TRANSACTION_DIR="" \
+                ableton_adopt_runtime_marker "$safe" "$ABLETON_RUNTIME_NAME" || {
+                echo "!! refusing to replace an unrecognised runtime directory: $safe" >&2
+                return 1
+            }
+        else
+            ableton_adopt_runtime_marker "$safe" "$ABLETON_RUNTIME_NAME" || {
+                echo "!! refusing to replace an unrecognised runtime directory: $safe" >&2
+                return 1
+            }
+        fi
         backup="$safe.transaction-${ABLETON_TRANSACTION_DIR##*/}"
         [ ! -e "$backup" ] && [ ! -L "$backup" ] \
             || { echo "!! transaction backup already exists: $backup" >&2; return 1; }
     fi
-    stop_runtime_clients
+    stop_runtime_clients || return 1
     # Mark and verify the staged tree before it can become the live runtime.
     marker="$candidate/.ableton-linux-runtime"
     [ ! -e "$marker" ] && [ ! -L "$marker" ] || {
@@ -704,12 +837,70 @@ promote_runtime()
         return 1
     fi
     record="$ABLETON_TRANSACTION_DIR/runtime.tsv"
-    ableton_promote_directory "$candidate" "$safe" "$backup" "$record"
+    ableton_promote_directory "$candidate" "$safe" "$backup" "$record" || return 1
     ableton_runtime_marker_valid "$safe" "$ABLETON_RUNTIME_NAME" || {
         echo "!! promoted runtime lost its ownership marker" >&2; return 1; }
     ABLETON_RUNTIME_INSTALLED=1
     export ABLETON_RUNTIME_INSTALLED
-    ableton_run_bounded 30 "$safe/bin/wine" --version
+    ableton_run_bounded 30 "$safe/bin/wine" --version >/dev/null || return 1
+}
+
+# A direct runtime call owns no larger prefix/Live transaction. Once the live
+# tree has been promoted and revalidated, retire its private rollback journal
+# before touching generated desktop or Link files. Failure to name the saved
+# old runtime or remove private scratch state is advisory from this boundary;
+# neither may restore or invalidate the new Wine tree.
+finish_direct_runtime_transaction()
+{
+    local txn="$ABLETON_TRANSACTION_DIR" cleanup_failed=0
+    runtime_core_committed=1
+    if ! commit_transaction "$txn" 0 1 >/dev/null 2>&1; then
+        echo "!! Wine is ready, but the installer may not be able to restore the previous Wine version automatically. Temporary recovery files may remain." >&2 \
+            || true
+        cleanup_failed=1
+    fi
+    if { [ -e "$txn/active" ] || [ -L "$txn/active" ]; } \
+       && ! rm -f -- "$txn/active"; then
+        cleanup_failed=1
+    fi
+    if ! rm -rf -- "$txn" || [ -e "$txn" ] || [ -L "$txn" ]; then
+        cleanup_failed=1
+    fi
+    if [ "$cleanup_failed" -ne 0 ] \
+       && { [ -e "$txn" ] || [ -L "$txn" ]; }; then
+        echo "!! Wine is ready, but temporary installer data remains at $txn" >&2 \
+            || true
+    fi
+    ABLETON_TRANSACTION_DIR=""
+    export ABLETON_TRANSACTION_DIR
+    own_transaction=0
+}
+
+start_direct_optional_transaction()
+{
+    if ! ABLETON_TRANSACTION_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ableton-install-files.XXXXXX")"; then
+        ABLETON_TRANSACTION_DIR=""
+        export ABLETON_TRANSACTION_DIR
+        own_transaction=0
+        direct_optional_transaction=0
+        echo "!! Temporary recovery files are unavailable. Continuing with repairable shortcuts and support files." >&2 \
+            || true
+        return 0
+    fi
+    export ABLETON_TRANSACTION_DIR
+    own_transaction=1
+    direct_optional_transaction=1
+    ABLETON_PUBLICATION_JOURNAL_BROKEN=0
+    if ! ableton_txn_init; then
+        rm -rf -- "$ABLETON_TRANSACTION_DIR" 2>/dev/null || true
+        ABLETON_TRANSACTION_DIR=""
+        export ABLETON_TRANSACTION_DIR
+        own_transaction=0
+        direct_optional_transaction=0
+        echo "!! Temporary recovery files are unavailable. Continuing with repairable shortcuts and support files." >&2 \
+            || true
+    fi
+    return 0
 }
 
 sed_escape()
@@ -717,48 +908,25 @@ sed_escape()
     printf '%s' "$1" | sed 's/[\\&#]/\\&/g'
 }
 
-record_mime_prestate()
-{
-    local state="$ABLETON_STATE_HOME/mime-prestate.tsv" type old tmp
-    ableton_validate_mime_prestate "$state" || return 1
-    [ -e "$state" ] && return 0
-    ableton_txn_snapshot "$state"
-    ableton_mark_state_home
-    tmp="$(mktemp "$ABLETON_STATE_HOME/.mime-prestate.XXXXXX")" || return 1
-    if command -v xdg-mime >/dev/null 2>&1; then
-        for type in x-scheme-handler/ableton application/x-wine-extension-auz \
-                    application/x-ableton-live-set application/x-ableton-live-clip \
-                    application/x-ableton-live-pack application/x-ableton-live-max-device \
-                    x-scheme-handler/c74max; do
-            old="$(xdg-mime query default "$type" 2>/dev/null || true)"
-            printf '%s\t%s\n' "$type" "$old" >> "$tmp"
-        done
-    fi
-    if ! chmod 600 "$tmp" \
-       || ! ableton_txn_expect "$state" "$(ableton_regular_source_token "$tmp")" \
-       || ! mv -f -- "$tmp" "$state"; then
-        rm -f -- "$tmp"
-        return 1
-    fi
-}
-
 install_integration()
 {
     local tool source target tmp newest="" exe live_name="Ableton Live" live_icon=live-suite live_wmclass="" edition d i
     local probe_source="" ntsync_probe_source="" mime_stage="" mimeapps_file="${XDG_CONFIG_HOME:-$HOME/.config}/mimeapps.list"
+    local mime_setup_ok=1
+    local failures_before="$ABLETON_OPTIONAL_FILE_FAILURES"
     local max_unix="$ABLETON_WINEPREFIX/drive_c/Program Files/Cycling '74/Max 9/Max.exe"
     local -a handler_ids=("$ABLETON_PROTOCOL_DESKTOP_ID" "$ABLETON_AUZ_DESKTOP_ID")
     local -a handler_templates=(ableton-linux-protocol ableton-linux-auz)
-    echo "== install launchers and host integration =="
+    echo "== Set up Ableton launchers and desktop shortcuts ==" || true
     for tool in config.sh lifecycle.sh live-options.sh manifest.sh pipeasio.sh; do
-        ableton_install_file 644 "$here/lib/$tool" "$data/lib/$tool"
+        ableton_try_publish_file 644 "$here/lib/$tool" "$data/lib/$tool" file replace-generated
     done
-    ableton_install_launcher_file 755 "$here/ableton-live" "$bin/ableton-live"
+    ableton_try_publish_launcher_file 755 "$here/ableton-live" "$bin/ableton-live"
     for tool in detect-scale.sh detect-theme.sh shortcut-hold.sh; do
-        ableton_install_file 644 "$here/$tool" "$data/$tool"
+        ableton_try_publish_file 644 "$here/$tool" "$data/$tool" file replace-generated
     done
     for tool in setup-realtime.sh audio-report.sh check-ntsync.sh rollback.sh; do
-        ableton_install_file 755 "$here/$tool" "$data/$tool"
+        ableton_try_publish_file 755 "$here/$tool" "$data/$tool" file replace-generated
     done
     for source in "$here/ntsyncprobe.exe" \
                   "$root/beta/tester-kit/probes/windows/ntsyncprobe.exe"; do
@@ -766,26 +934,28 @@ install_integration()
         ntsync_probe_source="$source"
         break
     done
-    [ -n "$ntsync_probe_source" ] || {
-        echo "!! installer kit is missing its NTSync semantics probe" >&2
-        return 1
-    }
-    ableton_install_file 644 "$ntsync_probe_source" "$data/ntsyncprobe.exe"
+    if [ -z "$ntsync_probe_source" ]; then
+        echo "!! installer kit is missing its NTSync semantics probe" >&2 || true
+        ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
+    else
+        ableton_try_publish_file 644 "$ntsync_probe_source" "$data/ntsyncprobe.exe" file replace-generated
+    fi
     for source in "$ABLETON_WINE_ROOT/bin/pipewire-version-probe" \
                   "$root/bin/pipewire-version-probe" "$root/dist/pipewire-version-probe"; do
         [ -x "$source" ] || continue
         probe_source="$source"
         break
     done
-    [ -n "$probe_source" ] || {
-        echo "!! installer kit is missing its PipeWire compatibility check" >&2
-        return 1
-    }
-    ableton_install_file 755 "$probe_source" "$data/pipewire-version-probe"
+    if [ -z "$probe_source" ]; then
+        echo "!! installer kit is missing its PipeWire compatibility check" >&2 || true
+        ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
+    else
+        ableton_try_publish_file 755 "$probe_source" "$data/pipewire-version-probe" file replace-generated
+    fi
     for tool in setsyscolors.exe learnheal.exe; do
         for source in "$here/$tool" "$root/tools/$tool"; do
             [ -f "$source" ] || continue
-            ableton_install_file 644 "$source" "$data/$tool"
+            ableton_try_publish_file 644 "$source" "$data/$tool" file replace-generated
             break
         done
     done
@@ -801,26 +971,35 @@ install_integration()
         edition="$(printf '%s' "$live_name" | awk '{print tolower($NF)}')"
         [ ! -f "$root/desktop/icons/scalable/apps/live-$edition.svg" ] || live_icon="live-$edition"
     fi
-    tmp="$(mktemp)"
-    sed -e "s#@HOME@#$(sed_escape "$HOME")#g" \
-        -e "s#@BIN@#$(sed_escape "$bin")#g" \
-        -e "s#@PREFIX@#$(sed_escape "$ABLETON_WINEPREFIX")#g" \
-        -e "s#@NAME@#$(sed_escape "$live_name")#g" \
-        -e "s#@ICON@#$(sed_escape "$live_icon")#g" \
-        -e "s#@WMCLASS@#$(sed_escape "$live_wmclass")#g" \
-        "$root/desktop/ableton-live.desktop.in" > "$tmp"
-    [ -n "$live_wmclass" ] || sed -i '/^StartupWMClass=/d' "$tmp"
-    ableton_install_launcher_file 644 "$tmp" "$apps/ableton-live.desktop"
-    rm -f -- "$tmp"
+    tmp=""
+    if tmp="$(mktemp)" \
+       && sed -e "s#@HOME@#$(sed_escape "$HOME")#g" \
+            -e "s#@BIN@#$(sed_escape "$bin")#g" \
+            -e "s#@PREFIX@#$(sed_escape "$ABLETON_WINEPREFIX")#g" \
+            -e "s#@NAME@#$(sed_escape "$live_name")#g" \
+            -e "s#@ICON@#$(sed_escape "$live_icon")#g" \
+            -e "s#@WMCLASS@#$(sed_escape "$live_wmclass")#g" \
+            "$root/desktop/ableton-live.desktop.in" > "$tmp" \
+       && { [ -n "$live_wmclass" ] || sed -i '/^StartupWMClass=/d' "$tmp"; }; then
+        ableton_try_publish_launcher_file 644 "$tmp" "$apps/ableton-live.desktop"
+    else
+        ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
+    fi
+    [ -z "$tmp" ] || rm -f -- "$tmp" 2>/dev/null || true
 
     for ((i=0; i<${#handler_ids[@]}; i++)); do
         d="${handler_ids[i]}"
-        tmp="$(mktemp)"
-        sed -e "s#@HOME@#$(sed_escape "$HOME")#g" -e "s#@BIN@#$(sed_escape "$bin")#g" \
-            "$root/desktop/${handler_templates[i]}.desktop.in" > "$tmp"
-        ableton_install_launcher_file 644 "$tmp" "$data/$d"
-        ableton_install_launcher_file 644 "$tmp" "$apps/$d"
-        rm -f -- "$tmp"
+        tmp=""
+        if tmp="$(mktemp)" \
+           && sed -e "s#@HOME@#$(sed_escape "$HOME")#g" \
+                -e "s#@BIN@#$(sed_escape "$bin")#g" \
+                "$root/desktop/${handler_templates[i]}.desktop.in" > "$tmp"; then
+            ableton_try_publish_launcher_file 644 "$tmp" "$data/$d"
+            ableton_try_publish_launcher_file 644 "$tmp" "$apps/$d"
+        else
+            ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
+        fi
+        [ -z "$tmp" ] || rm -f -- "$tmp" 2>/dev/null || true
     done
 
     # Retire only the legacy handlers written by this project.  Wine may still
@@ -831,129 +1010,133 @@ install_integration()
         "$data/wine-protocol-ableton.desktop" "$data/wine-extension-auz.desktop" \
         "$apps/wine-protocol-ableton.desktop" "$apps/wine-extension-auz.desktop"; do
         [ -e "$target" ] || continue
-        if grep -Eq '^Exec=.*/ableton-live (%u|%f)$' "$target"; then
-            echo "   removing legacy project handler $target"
-            ableton_remove_managed_file "$target"
+        if ableton_legacy_owned_path "$target"; then
+            # Exact legacy launchers are obsolete generated output. Removing
+            # them must not consult stale uninstall inventory or prestate.
+            rm -f -- "$target" 2>/dev/null || true
+            if [ -e "$target" ] || [ -L "$target" ]; then
+                echo "!! Ableton was installed, but an old shortcut could not be removed: $target" >&2 \
+                    || true
+            else
+                ableton_record_deowned "$target" >/dev/null 2>&1 || true
+            fi
         else
-            echo "   preserving foreign legacy handler $target"
+            echo "   kept an existing shortcut at $target" || true
         fi
     done
 
     for source in "$root"/desktop/icons/scalable/apps/*.svg; do
-        ableton_install_file 644 "$source" "$icons/scalable/apps/$(basename "$source")"
+        ableton_try_publish_file 644 "$source" "$icons/scalable/apps/$(basename "$source")"
     done
     for source in "$root"/desktop/icons/scalable/mimetypes/*.svg; do
-        ableton_install_file 644 "$source" "$icons/scalable/mimetypes/$(basename "$source")"
+        ableton_try_publish_file 644 "$source" "$icons/scalable/mimetypes/$(basename "$source")"
     done
     for source in "$root"/desktop/icons/symbolic/apps/*.svg; do
-        ableton_install_file 644 "$source" "$icons/symbolic/apps/$(basename "$source")"
+        ableton_try_publish_file 644 "$source" "$icons/symbolic/apps/$(basename "$source")"
     done
-    ableton_install_file 644 "$root/desktop/x-wine-extension-auz.xml" "$mime_root/packages/x-wine-extension-auz.xml"
-    ableton_install_file 644 "$root/desktop/icons/application-ableton-live.xml" "$mime_root/packages/application-ableton-live.xml"
+    ableton_try_publish_file 644 "$root/desktop/x-wine-extension-auz.xml" "$mime_root/packages/x-wine-extension-auz.xml"
+    ableton_try_publish_file 644 "$root/desktop/icons/application-ableton-live.xml" "$mime_root/packages/application-ableton-live.xml"
 
-    record_mime_prestate
     if command -v xdg-mime >/dev/null 2>&1; then
         if [ -e "$mimeapps_file" ] || [ -L "$mimeapps_file" ]; then
-            [ -f "$mimeapps_file" ] && [ ! -L "$mimeapps_file" ] || {
-                echo "!! refusing unsafe MIME association file $mimeapps_file" >&2; return 1; }
+            if [ ! -f "$mimeapps_file" ] || [ -L "$mimeapps_file" ]; then
+                mime_setup_ok=0
+                mimeapps_file=""
+            fi
         fi
-        mime_stage="$(mktemp -d "${TMPDIR:-/tmp}/ableton-mimeapps.XXXXXX")" || return 1
-        [ ! -e "$mimeapps_file" ] || cp -- "$mimeapps_file" "$mime_stage/mimeapps.list"
-        if ! env XDG_CONFIG_HOME="$mime_stage" xdg-mime default \
+        if [ -n "$mimeapps_file" ]; then
+            mime_stage="$(mktemp -d "${TMPDIR:-/tmp}/ableton-mimeapps.XXXXXX")" || true
+            [ -n "$mime_stage" ] || mime_setup_ok=0
+        fi
+        if [ -n "$mime_stage" ] && [ -e "$mimeapps_file" ] \
+           && ! cp -- "$mimeapps_file" "$mime_stage/mimeapps.list"; then
+            rm -rf -- "$mime_stage" 2>/dev/null || true
+            mime_stage=""
+            mime_setup_ok=0
+        fi
+        if [ -n "$mime_stage" ] \
+           && { ! env XDG_CONFIG_HOME="$mime_stage" xdg-mime default \
                 "$ABLETON_PROTOCOL_DESKTOP_ID" x-scheme-handler/ableton \
-           || ! env XDG_CONFIG_HOME="$mime_stage" xdg-mime default \
+                || ! env XDG_CONFIG_HOME="$mime_stage" xdg-mime default \
                 "$ABLETON_AUZ_DESKTOP_ID" application/x-wine-extension-auz \
-           || ! env XDG_CONFIG_HOME="$mime_stage" xdg-mime default \
+                || ! env XDG_CONFIG_HOME="$mime_stage" xdg-mime default \
                 ableton-live.desktop application/x-ableton-live-set \
-                application/x-ableton-live-clip application/x-ableton-live-pack; then
-            rm -rf -- "$mime_stage"
-            echo "!! MIME association staging failed; existing associations were unchanged" >&2
-            return 1
+                    application/x-ableton-live-clip application/x-ableton-live-pack; }; then
+            rm -rf -- "$mime_stage" 2>/dev/null || true
+            mime_stage=""
+            mime_setup_ok=0
         fi
-        if [ -f "$max_unix" ] \
+        if [ -n "$mime_stage" ] && [ -f "$max_unix" ] \
            && { ! env XDG_CONFIG_HOME="$mime_stage" xdg-mime default \
                     max9.desktop application/x-ableton-live-max-device \
                 || ! env XDG_CONFIG_HOME="$mime_stage" xdg-mime default \
                     wine-protocol-c74max.desktop x-scheme-handler/c74max; }; then
-            rm -rf -- "$mime_stage"
-            echo "!! MIME association staging failed; existing associations were unchanged" >&2
-            return 1
+            rm -rf -- "$mime_stage" 2>/dev/null || true
+            mime_stage=""
+            mime_setup_ok=0
         fi
-        if [ -e "$mime_stage/mimeapps.list" ]; then
-            ableton_txn_replace_unowned_file "$mime_stage/mimeapps.list" "$mimeapps_file"
+        if [ -n "$mime_stage" ] && [ -f "$mime_stage/mimeapps.list" ]; then
+            if ! ableton_atomic_restore_object "$mime_stage/mimeapps.list" "$mimeapps_file"; then
+                mime_setup_ok=0
+            fi
         fi
-        rm -rf -- "$mime_stage"
+        [ -z "$mime_stage" ] || rm -rf -- "$mime_stage" 2>/dev/null || true
+    else
+        mime_setup_ok=0
+    fi
+    if [ "$mime_setup_ok" -ne 1 ]; then
+        ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
+        echo "!! Could not set Ableton as the default app for Live files. Ableton itself can still be used normally." >&2 \
+            || true
     fi
 
     if [ -f "$max_unix" ]; then
-        ableton_install_launcher_file 755 "$here/max9" "$bin/max9"
+        ableton_try_publish_launcher_file 755 "$here/max9" "$bin/max9"
         for d in max9 wine-protocol-c74max; do
-            tmp="$(mktemp)"
-            sed -e "s#@HOME@#$(sed_escape "$HOME")#g" -e "s#@BIN@#$(sed_escape "$bin")#g" \
-                -e "s#@PREFIX@#$(sed_escape "$ABLETON_WINEPREFIX")#g" \
-                "$root/desktop/$d.desktop.in" > "$tmp"
-            target="$apps/$d.desktop"
-            ableton_install_launcher_file 644 "$tmp" "$target"
-            rm -f -- "$tmp"
+            tmp=""
+            if tmp="$(mktemp)" \
+               && sed -e "s#@HOME@#$(sed_escape "$HOME")#g" \
+                    -e "s#@BIN@#$(sed_escape "$bin")#g" \
+                    -e "s#@PREFIX@#$(sed_escape "$ABLETON_WINEPREFIX")#g" \
+                    "$root/desktop/$d.desktop.in" > "$tmp"; then
+                target="$apps/$d.desktop"
+                ableton_try_publish_launcher_file 644 "$tmp" "$target"
+            else
+                ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
+            fi
+            [ -z "$tmp" ] || rm -f -- "$tmp" 2>/dev/null || true
         done
     fi
 
-    echo "== register desktop and MIME integration =="
-    update-mime-database "$mime_root" || {
-        echo "!! failed to update the MIME database at $mime_root" >&2; return 1; }
-    update-desktop-database "$apps" || {
-        echo "!! failed to update the desktop application database at $apps" >&2; return 1; }
+    echo "== Refresh desktop menus and file associations ==" || true
+    if command -v update-mime-database >/dev/null 2>&1; then
+        update-mime-database "$mime_root" >/dev/null 2>&1 || true
+    fi
+    if command -v update-desktop-database >/dev/null 2>&1; then
+        update-desktop-database "$apps" >/dev/null 2>&1 || true
+    fi
 
-    pin_mime_default()
-    {
-        local id="$1" type="$2" current
-        xdg-mime default "$id" "$type" || {
-            echo "!! failed to set $type to $id" >&2; return 1; }
-        current="$(xdg-mime query default "$type")" || {
-            echo "!! failed to query the active handler for $type" >&2; return 1; }
-        [ "$current" = "$id" ] || {
-            echo "!! $type resolves to '${current:-no handler}' after registration; expected $id" >&2
-            return 1
-        }
-    }
-    pin_mime_default "$ABLETON_PROTOCOL_DESKTOP_ID" x-scheme-handler/ableton
-    pin_mime_default "$ABLETON_AUZ_DESKTOP_ID" application/x-wine-extension-auz
-    for d in application/x-ableton-live-set application/x-ableton-live-clip application/x-ableton-live-pack; do
-        pin_mime_default ableton-live.desktop "$d"
-    done
-    if [ -f "$max_unix" ]; then
-        pin_mime_default max9.desktop application/x-ableton-live-max-device
-        pin_mime_default wine-protocol-c74max.desktop x-scheme-handler/c74max
+    if [ "$ABLETON_OPTIONAL_FILE_FAILURES" -gt "$failures_before" ]; then
+        echo "!! Some shortcuts or support files could not be updated. Run the installer again to retry them." >&2 \
+            || true
     fi
-    if command -v gtk-update-icon-cache >/dev/null 2>&1; then
-        gtk-update-icon-cache -q "$icons" || \
-            echo "!! warning: failed to refresh the icon cache at $icons" >&2
-    fi
+    return 0
 }
 
 install_link_assets()
 {
-    echo "== install Link assets (not enabled or started) =="
-    local tool restart_always=0 fragment="" expected_unit
+    echo "== Install Ableton Link support files ==" || true
+    local tool failures_before="$ABLETON_OPTIONAL_FILE_FAILURES"
     local managed_linkd="$ABLETON_DATA_HOME/ableton-linkd"
     local legacy_custom="${ABLETON_PR182_CUSTOM_LINKD:-}"
-    if [ -x "$ABLETON_LINKD" ]; then
-        [ "$ABLETON_LINK_MODE" != always ] || restart_always=1
-        if command -v systemctl >/dev/null 2>&1; then
-            fragment="$(ableton_run_bounded 20 systemctl --user show -p FragmentPath --value ableton-linkd.service 2>/dev/null || true)"
-            expected_unit="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/ableton-linkd.service"
-            if [ -n "$fragment" ] \
-               && [ "$(ableton_realpath_m "$fragment")" = "$(ableton_realpath_m "$expected_unit")" ] \
-               && grep -qxF 'X-AbletonLinuxOwned=true' "$expected_unit" 2>/dev/null; then
-                ableton_run_bounded 20 systemctl --user stop ableton-linkd.service >/dev/null 2>&1 || return 1
-            fi
-        fi
-        "$here/ableton-linkctl" stop || return 1
-    fi
+    # Support files are published atomically, so a currently running Link
+    # process may keep using its old executable until the policy step restarts
+    # it. Lifecycle and firewall changes belong to setup-link.sh; they must not
+    # become prerequisites for replacing files that this installer owns.
     # setup-link.sh sources manifest.sh and stops without it, so a Link-only
     # install ships it too.
     for tool in config.sh lifecycle.sh manifest.sh; do
-        ableton_install_file 644 "$here/lib/$tool" "$data/lib/$tool"
+        ableton_try_publish_file 644 "$here/lib/$tool" "$data/lib/$tool" file replace-generated
     done
     if [ -n "$legacy_custom" ]; then
         # Seal the proof first and keep it: the VERSION write below stops the live
@@ -962,99 +1145,253 @@ install_link_assets()
         # relinquished managed file is disposed of.  An unmodified object is removed
         # and any pre-install file it displaced comes back; a changed one is left
         # exactly where it is and only the ownership claim is dropped.
-        ableton_txn_authorize_pr182_custom_link "$legacy_custom" || {
-            echo "!! legacy custom Link ownership could not be verified" >&2
-            return 1
-        }
-        if ableton_pr182_custom_link_owned "$legacy_custom"; then
-            ableton_remove_managed_file "$legacy_custom" || return 1
-            echo "   retired the PR #182 custom Link binary ownership"
+        if ! ableton_txn_authorize_pr182_custom_link "$legacy_custom"; then
+            echo "!! Kept an older custom Link helper because the installer could not confirm that it created the file." >&2 \
+                || true
+        elif ableton_pr182_custom_link_owned "$legacy_custom"; then
+            if ableton_remove_managed_file "$legacy_custom"; then
+                echo "   removed the old custom Link helper" || true
+            else
+                ableton_record_deowned "$legacy_custom" >/dev/null 2>&1 || true
+                echo "!! Kept the older custom Link helper because its saved recovery data could not be used safely." >&2 \
+                    || true
+            fi
         else
-            ableton_abandon_managed_file "$legacy_custom" || return 1
-            echo "   kept and de-owned the modified former PR #182 Link binary"
+            ableton_abandon_managed_file "$legacy_custom" >/dev/null 2>&1 \
+                || ableton_record_deowned "$legacy_custom" >/dev/null 2>&1 \
+                || true
+            echo "   kept the modified custom Link helper" || true
         fi
     fi
     # A configured external Link daemon may be executed by the controller, but
     # it is never installed, claimed, restored, or removed by this project.
     if [ "$ABLETON_LINKD" = "$managed_linkd" ]; then
-        ableton_install_file 755 "$linkd_source" "$managed_linkd"
+        if [ -n "$linkd_source" ]; then
+            ableton_try_publish_file 755 "$linkd_source" "$managed_linkd" file replace-generated
+        else
+            ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
+        fi
     else
-        [ -x "$ABLETON_LINKD" ] || {
-            echo "!! configured external Link daemon is not executable: $ABLETON_LINKD" >&2
-            return 1
-        }
-        printf '   using external Link daemon without taking ownership: %s\n' "$ABLETON_LINKD"
+        if [ ! -x "$ABLETON_LINKD" ]; then
+            echo "!! The configured Ableton Link helper cannot be run: $ABLETON_LINKD" >&2 \
+                || true
+            ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
+        else
+            printf '   using the configured Ableton Link helper and leaving it unchanged: %s\n' "$ABLETON_LINKD" \
+                || true
+        fi
     fi
-    ableton_install_file 755 "$here/ableton-linkctl" "$data/ableton-linkctl"
-    ableton_install_file 755 "$here/setup-link.sh" "$data/setup-link.sh"
-    ableton_install_file 644 "$unit_source" "$data/ableton-linkd.service"
-    if [ "$restart_always" -eq 1 ]; then
-        ableton_run_bounded 20 systemctl --user start ableton-linkd.service
+    ableton_try_publish_file 755 "$here/ableton-linkctl" "$data/ableton-linkctl" file replace-generated
+    ableton_try_publish_file 755 "$here/setup-link.sh" "$data/setup-link.sh" file replace-generated
+    if [ -n "$unit_source" ] && [ -f "$unit_source" ]; then
+        ableton_try_publish_file 644 "$unit_source" "$data/ableton-linkd.service" file replace-generated
+    else
+        ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
     fi
+    if [ "$ABLETON_OPTIONAL_FILE_FAILURES" -gt "$failures_before" ]; then
+        echo "!! Some Ableton Link files could not be updated. Run the installer again to retry them." >&2 \
+            || true
+    fi
+    return 0
 }
 
-[ "$want_runtime" -eq 0 ] || promote_runtime
+if [ "$want_runtime" -eq 1 ]; then
+    promote_runtime
+    ableton_pipeasio_validate_runtime "$ABLETON_WINE_ROOT"
+    # Promotion and final core validation are the runtime boundary in every
+    # component combination. A direct call closes its private transaction now;
+    # a coordinator-owned transaction stays open for the prefix/Live parent.
+    runtime_core_ready=1
+    if [ "$own_transaction" -eq 1 ]; then
+        finish_direct_runtime_transaction
+        if [ "$want_integration" -eq 1 ] || [ "$want_link" -eq 1 ]; then
+            start_direct_optional_transaction
+        fi
+    fi
+fi
 if [ "$want_integration" -eq 1 ]; then
     install_integration
     ableton_pipeasio_optional_tools_advice
 fi
-[ "$want_link" -eq 0 ] || install_link_assets
+if [ "$want_link" -eq 1 ]; then
+    install_link_assets
+fi
+
+if [ "$want_runtime" -eq 0 ]; then
+    # Every selected generated-file phase returned successfully. From here on,
+    # auxiliary records and cache refreshes may report a warning but cannot make
+    # working launchers or Link files disappear again.
+    optional_files_ready=1
+fi
 
 # Runtime updates use the selected runtime's panel record. Integration-only
 # installs use the current runtime's compatible panel record when available.
+postcommit_runtime_panel=0
 if [ "$want_runtime" -eq 1 ]; then
-    ableton_pipeasio_validate_runtime "$ABLETON_WINE_ROOT"
     if [ "$want_integration" -eq 1 ]; then
-        ableton_pipeasio_sync_panel "$ABLETON_WINE_ROOT" install
+        if ! ableton_pipeasio_sync_panel "$ABLETON_WINE_ROOT" install; then
+            ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
+            echo "!! Ableton was installed, but the PipeASIO settings shortcut could not be updated." >&2 \
+                || true
+        fi
+    elif [ "$runtime_core_only" -eq 1 ]; then
+        # A parent-owned core phase leaves all desktop work to the later repair
+        # phase. A direct runtime update performs the same repair only after the
+        # runtime has committed, so launcher drift cannot undo valid Wine files.
+        [ -n "$transaction_arg" ] || postcommit_runtime_panel=1
     else
-        ableton_pipeasio_sync_panel "$ABLETON_WINE_ROOT" reconcile
+        if ! ableton_pipeasio_sync_panel "$ABLETON_WINE_ROOT" reconcile; then
+            ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
+            echo "!! The runtime was installed, but the PipeASIO settings shortcut could not be updated." >&2 \
+                || true
+        fi
     fi
 elif [ "$want_integration" -eq 1 ]; then
     if grep -qxF 'pipeasio-panel: built' "$ABLETON_WINE_ROOT/ABLETON-WINE-BUILD-INFO.txt" 2>/dev/null \
        || grep -qxF 'pipeasio-panel: skipped' "$ABLETON_WINE_ROOT/ABLETON-WINE-BUILD-INFO.txt" 2>/dev/null; then
         if ableton_pipeasio_validate_runtime "$ABLETON_WINE_ROOT" >/dev/null 2>&1; then
-            ableton_pipeasio_sync_panel "$ABLETON_WINE_ROOT" install
+            if ! ableton_pipeasio_sync_panel "$ABLETON_WINE_ROOT" install; then
+                ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
+                echo "!! Ableton was installed, but the PipeASIO settings shortcut could not be updated." >&2 \
+                    || true
+            fi
         else
-            echo "   kept existing PipeASIO panel links because this runtime uses another panel format"
+            echo "   kept existing PipeASIO panel links because this runtime uses another panel format" \
+                || true
         fi
     else
-        echo "   launcher integration continues with the available PipeASIO files"
+        echo "   launcher integration continues with the available PipeASIO files" || true
     fi
 fi
 
 if [ "$want_integration" -eq 1 ] || [ "$want_link" -eq 1 ]; then
     version_tmp=""
-    mkdir -p -- "$data"
-    version_tmp="$(mktemp "$data/.VERSION.XXXXXX")" || exit 1
-    if ! printf '%s\n' "$(cat "$root/VERSION" 2>/dev/null || echo unknown)" > "$version_tmp" \
-       || ! ableton_install_file 644 "$version_tmp" "$data/VERSION"; then
-        rm -f -- "$version_tmp"
-        exit 1
+    version_ready=0
+    if mkdir -p -- "$data" \
+       && version_tmp="$(mktemp "$data/.VERSION.XXXXXX")" \
+       && printf '%s\n' "$(cat "$root/VERSION" 2>/dev/null || echo unknown)" > "$version_tmp"; then
+        if [ "$want_runtime" -eq 0 ]; then
+            # This label is repairable metadata. Publish it atomically without
+            # adding it to a parent-owned core journal, then include it in the
+            # best-effort installed-file list below.
+            if chmod 644 "$version_tmp" \
+               && ableton_atomic_restore_object "$version_tmp" "$data/VERSION" \
+               && ableton_record_owned "$data/VERSION"; then
+                version_ready=1
+            fi
+        elif ableton_publish_file 644 "$version_tmp" "$data/VERSION" file replace-generated; then
+            version_ready=1
+        fi
     fi
-    rm -f -- "$version_tmp"
+    if [ "$version_ready" -eq 1 ]; then
+        :
+    else
+        ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
+        echo "!! Ableton was installed, but its support files could not be fully updated." >&2 \
+            || true
+    fi
+    [ -z "$version_tmp" ] || rm -f -- "$version_tmp" 2>/dev/null || true
 fi
-if [ "$want_integration" -eq 1 ] || [ "$want_link" -eq 1 ] \
-   || { [ "$want_runtime" -eq 1 ] && [ "$ownership_manifest_was_present" -eq 1 ]; } \
-   || [ "${#ABLETON_OWNED_PATHS[@]}" -gt 0 ]; then
-    ableton_write_ownership_manifest
+if [ "$runtime_core_only" -eq 0 ] \
+   && { [ "$want_integration" -eq 1 ] || [ "$want_link" -eq 1 ] \
+        || { [ "$want_runtime" -eq 1 ] && [ "$ownership_manifest_was_present" -eq 1 ]; } \
+        || [ "${#ABLETON_OWNED_PATHS[@]}" -gt 0 ]; }; then
+    if ! ableton_write_ownership_manifest "$ABLETON_STATE_HOME/install-manifest.tsv"; then
+        ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
+        echo "!! Ableton was installed, but the installed-file list could not be updated." >&2 \
+            || true
+    fi
 fi
 
-[ -z "$stage" ] || rm -rf -- "$stage"
-stage=""
-if [ "$own_transaction" -eq 1 ]; then
-    commit_transaction "$ABLETON_TRANSACTION_DIR" 0
-    if ! rm -rf -- "$ABLETON_TRANSACTION_DIR"; then
-        echo "!! committed component transaction could not be retired" >&2
-        exit 1
+if [ -n "$stage" ]; then
+    # The validated runtime has already moved out of this private scratch tree.
+    # Failure to remove that scratch directory does not invalidate the promoted
+    # runtime or any journalled integration changes, so it must not trigger an
+    # otherwise unnecessary rollback.
+    if ! rm -rf -- "$stage" || [ -e "$stage" ] || [ -L "$stage" ]; then
+        echo "!! Wine was installed, but temporary files remain at $stage" >&2 || true
     fi
-else
-    rm -f -- "$ABLETON_TRANSACTION_DIR/active"
+    stage=""
 fi
-trap - EXIT
-echo "OK: selected components installed transactionally"
+if [ "$own_transaction" -eq 1 ]; then
+    if [ "$optional_files_ready" -eq 1 ] || [ "$runtime_core_ready" -eq 1 ]; then
+        if ! commit_transaction "$ABLETON_TRANSACTION_DIR" 0 1 >/dev/null 2>&1; then
+            if [ "$direct_optional_transaction" -eq 1 ]; then
+                echo "!! Ableton's files are ready, but the installer could not finish its final housekeeping." >&2 \
+                    || true
+            elif [ "$runtime_core_ready" -eq 1 ]; then
+                echo "!! Wine is ready, but the installer may not be able to restore the previous Wine version automatically. Temporary recovery files may remain." >&2 \
+                    || true
+            else
+                echo "!! Ableton's files are ready, but the installer could not finish its final housekeeping." >&2 \
+                    || true
+            fi
+        fi
+    else
+        commit_transaction "$ABLETON_TRANSACTION_DIR" 0 1
+    fi
+    if ! rm -rf -- "$ABLETON_TRANSACTION_DIR"; then
+        if [ "$direct_optional_transaction" -eq 1 ]; then
+                echo "!! Installed files are ready, but temporary installer data remains at $ABLETON_TRANSACTION_DIR" >&2 \
+                    || true
+        elif [ "$runtime_core_ready" -eq 1 ]; then
+                echo "!! Wine is ready, but temporary installer data remains at $ABLETON_TRANSACTION_DIR" >&2 \
+                    || true
+        else
+                echo "!! Installed files are ready, but temporary installer data remains at $ABLETON_TRANSACTION_DIR" >&2 \
+                    || true
+        fi
+    fi
+    if [ "$direct_optional_transaction" -eq 1 ]; then
+        direct_optional_transaction=0
+        own_transaction=0
+        ABLETON_TRANSACTION_DIR=""
+        export ABLETON_TRANSACTION_DIR
+    fi
+fi
+if [ "$postcommit_runtime_panel" -eq 1 ]; then
+    # The runtime is committed and its private records are gone. Panel repair is
+    # deliberately unjournalled and warning-only from this point forward.
+    unset ABLETON_TRANSACTION_DIR
+    panel_repair_status=0
+    set +e
+    if ! ableton_config_validate_layout 'runtime prefix data config state bin'; then
+        panel_repair_status=126
+    else
+        (
+            set -e
+            ableton_pipeasio_sync_panel "$ABLETON_WINE_ROOT" reconcile
+            ableton_write_ownership_manifest "$ABLETON_STATE_HOME/install-manifest.tsv" || exit 125
+        )
+        panel_repair_status=$?
+    fi
+    set -e
+    case "$panel_repair_status" in
+        0) ;;
+        125)
+            echo "!! Wine was installed, but the installed-file list could not be updated." >&2 \
+                || true ;;
+        126)
+            echo "!! Wine was installed, but the PipeASIO settings shortcut was skipped because one of its locations cannot be used safely." >&2 \
+                || true ;;
+        *)
+            echo "!! Wine was installed, but the PipeASIO settings shortcut could not be updated." >&2 \
+                || true ;;
+    esac
+fi
+if [ "${ABLETON_INTERNAL_OPTIONAL_STATUS:-0}" = 1 ] \
+   && [ "$ABLETON_OPTIONAL_FILE_FAILURES" -gt 0 ]; then
+    # Internal advisory status for the public installer summary. All selected
+    # repair work and transaction cleanup above has already finished.
+    trap - EXIT
+    exit 3
+fi
+if [ -z "$transaction_arg" ]; then
+    echo "OK: Installation complete." || true
+fi
 if [ "$want_integration" -eq 1 ]; then
-    printf '   Audio report: %s/audio-report.sh\n' "$data"
-    printf '   NTSync check: %s/check-ntsync.sh\n' "$data"
-    printf '   Realtime setup: %s/setup-realtime.sh\n' "$data"
-    printf '   Runtime rollback: %s/rollback.sh\n' "$data"
+    printf '   Audio report: %s/audio-report.sh\n' "$data" || true
+    printf '   NTSync check: %s/check-ntsync.sh\n' "$data" || true
+    printf '   Realtime setup: %s/setup-realtime.sh\n' "$data" || true
+    printf '   Restore previous Wine version: %s/rollback.sh\n' "$data" || true
 fi

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -43,7 +43,8 @@ EOF
 
 warn_compat()
 {
-    printf 'WARNING: %s is deprecated; use %s\n' "$1" "$2" >&2
+    printf 'WARNING: %s is deprecated; use %s\n' "$1" "$2" >&2 || true
+    return 0
 }
 
 command_name=""
@@ -124,7 +125,7 @@ while [ $# -gt 0 ]; do
             [ "$major_seen" -eq 0 ] || { echo "!! --live-major was specified more than once" >&2; exit 2; }
             major_seen=1; cli_major="${1#*=}" ;;
         --link=*)
-            [ "$link_seen" -eq 0 ] || { echo "!! Link policy was specified more than once" >&2; exit 2; }
+            [ "$link_seen" -eq 0 ] || { echo "!! The Ableton Link setting was specified more than once" >&2; exit 2; }
             link_seen=1
             cli_link="${1#*=}" ;;
         --mode=*)
@@ -209,7 +210,7 @@ esac
 [ "$major_seen" -eq 0 ] || [ -n "$cli_major" ] || {
     echo "!! --live-major needs 11 or 12" >&2; exit 2; }
 [ "$link_seen" -eq 0 ] || [ -n "$cli_link" ] || {
-    echo "!! --link needs a policy" >&2; exit 2; }
+    echo "!! --link needs off, session, always, or keep" >&2; exit 2; }
 [ "$mode_seen" -eq 0 ] || [ -n "$link_mode_option" ] || {
     echo "!! --mode needs session or always" >&2; exit 2; }
 [ "$delete_prefix" -eq 0 ] || [ "$keep_prefix" -eq 0 ] || { echo "!! --keep-prefix and --delete-prefix conflict" >&2; exit 2; }
@@ -266,7 +267,22 @@ esac
 if [ -n "$cli_prefix" ]; then ABLETON_WINEPREFIX="$cli_prefix"; export ABLETON_WINEPREFIX; fi
 if [ -n "$cli_runtime" ]; then ABLETON_WINE_ROOT="$cli_runtime"; export ABLETON_WINE_ROOT; fi
 if [ -n "$cli_major" ]; then ABLETON_LIVE_VERSION="$cli_major"; export ABLETON_LIVE_VERSION; fi
-ableton_config_init
+if [ "$dry_run" -eq 1 ]; then
+    ABLETON_CONFIG_LAYOUT_ROOTS=none
+else
+    case "$command_name:$subcommand" in
+        runtime:install) ABLETON_CONFIG_LAYOUT_ROOTS=runtime ;;
+        install:|update:|prefix:create|prefix:update)
+            ABLETON_CONFIG_LAYOUT_ROOTS='runtime prefix state' ;;
+        prefix:repair-live11) ABLETON_CONFIG_LAYOUT_ROOTS='prefix state' ;;
+        link:enable|link:disable) ABLETON_CONFIG_LAYOUT_ROOTS='data config state' ;;
+        link:status) ABLETON_CONFIG_LAYOUT_ROOTS=none ;;
+        uninstall:) ABLETON_CONFIG_LAYOUT_ROOTS='runtime prefix' ;;
+        *) ABLETON_CONFIG_LAYOUT_ROOTS='runtime prefix state' ;;
+    esac
+fi
+export ABLETON_CONFIG_LAYOUT_ROOTS
+ableton_config_init repair
 
 # PR #182 briefly owned a configured custom Link binary.  Only a narrowly
 # proven install of that release is migrated to the canonical managed path.
@@ -292,7 +308,7 @@ case "$command_name" in
 esac
 [ "$desired_link" != keep ] || desired_link="$prior_link"
 [ -n "$desired_link" ] || desired_link="$prior_link"
-case "$desired_link" in off|session|always|'') ;; *) echo "!! no persistent Link policy is available; choose --link=off|session|always" >&2; exit 2 ;; esac
+case "$desired_link" in off|session|always|'') ;; *) echo "!! No saved Ableton Link setting is available; choose --link=off|session|always" >&2; exit 2 ;; esac
 
 resolve_payload()
 {
@@ -335,28 +351,53 @@ resolve_payload()
 
 payload_major()
 {
-    local payload="$1" names lower majors
+    local payload="$1" lower majors scan prefix=""
     lower="$(basename "$payload" | tr '[:upper:]' '[:lower:]')"
     majors=""
     case "$lower" in *live*11*) majors=11 ;; esac
     case "$lower" in *live*12*) majors="${majors:+$majors }12" ;; esac
+    scan="$(mktemp "${TMPDIR:-/tmp}/ableton-payload-scan.XXXXXX")" || return 1
     case "$lower" in
         *.zip)
-            if command -v unzip >/dev/null 2>&1; then names="$(unzip -Z1 "$payload" 2>/dev/null | head -n 200 || true)"
-            elif command -v bsdtar >/dev/null 2>&1; then names="$(bsdtar -tf "$payload" 2>/dev/null | head -n 200 || true)"
-            else names=""; fi ;;
-        *) names="$(head -c 8388608 -- "$payload" 2>/dev/null | strings 2>/dev/null | head -n 20000 || true)" ;;
+            if command -v unzip >/dev/null 2>&1; then
+                unzip -Z1 "$payload" > "$scan" 2>/dev/null || { rm -f -- "$scan"; return 1; }
+            elif command -v bsdtar >/dev/null 2>&1; then
+                bsdtar -tf "$payload" > "$scan" 2>/dev/null || { rm -f -- "$scan"; return 1; }
+            elif command -v python3 >/dev/null 2>&1; then
+                python3 -m zipfile -l "$payload" > "$scan" 2>/dev/null \
+                    || { rm -f -- "$scan"; return 1; }
+            else
+                rm -f -- "$scan"
+                return 1
+            fi ;;
+        *)
+            prefix="$(mktemp "${TMPDIR:-/tmp}/ableton-payload-prefix.XXXXXX")" \
+                || { rm -f -- "$scan"; return 1; }
+            if ! head -c 8388608 -- "$payload" > "$prefix" 2>/dev/null \
+               || ! strings "$prefix" > "$scan" 2>/dev/null; then
+                rm -f -- "$prefix" "$scan"
+                return 1
+            fi
+            rm -f -- "$prefix" 2>/dev/null || true ;;
     esac
-    printf '%s\n' "$names" | grep -Eqi 'Ableton[ _-]*Live[ _-]*11' && majors="${majors:+$majors }11"
-    printf '%s\n' "$names" | grep -Eqi 'Ableton[ _-]*Live[ _-]*12' && majors="${majors:+$majors }12"
-    tr ' ' '\n' <<< "$majors" | sed '/^$/d' | sort -u | paste -sd' ' -
+    if grep -Eqi 'Ableton[ _-]*Live[ _-]*11' "$scan"; then
+        case " $majors " in *' 11 '*) ;; *) majors="${majors:+$majors }11" ;; esac
+    fi
+    if grep -Eqi 'Ableton[ _-]*Live[ _-]*12' "$scan"; then
+        case " $majors " in *' 12 '*) ;; *) majors="${majors:+$majors }12" ;; esac
+    fi
+    rm -f -- "$scan" 2>/dev/null || true
+    printf '%s\n' "$majors"
 }
 
 validate_payload_major()
 {
     [ -n "$live_payload" ] || return 0
     local detected
-    detected="$(payload_major "$live_payload")"
+    if ! detected="$(payload_major "$live_payload")"; then
+        echo "!! cannot read $(basename "$live_payload") well enough to verify its Live version" >&2
+        return 2
+    fi
     if [ -n "${ABLETON_LIVE_VERSION:-}" ]; then
         case " $detected " in *" $ABLETON_LIVE_VERSION "*) ;;
             "  ") echo "!! cannot prove that $(basename "$live_payload") matches Live $ABLETON_LIVE_VERSION" >&2; return 2 ;;
@@ -386,16 +427,12 @@ host_preflight()
     case "$command_name:$subcommand" in
         prefix:repair-live11) ;;
         *) command -v timeout >/dev/null \
-            || { echo "!! GNU timeout is required" >&2; return 1; } ;;
+            || { echo "!! Install GNU coreutils (the timeout command), then run the installer again." >&2; return 1; } ;;
     esac
     case "$command_name" in
         install|update|runtime)
-            command -v tar >/dev/null || { echo "!! tar is required" >&2; return 1; }
-            command -v zstd >/dev/null || { echo "!! zstd is required" >&2; return 1; } ;;
-    esac
-    case "$command_name:$subcommand" in
-        install:|update:|prefix:create|prefix:update)
-            command -v cabextract >/dev/null || { echo "!! cabextract is required" >&2; return 1; } ;;
+            command -v tar >/dev/null || { echo "!! Install tar, then run the installer again." >&2; return 1; }
+            command -v zstd >/dev/null || { echo "!! Install zstd, then run the installer again." >&2; return 1; } ;;
     esac
 }
 host_preflight
@@ -447,10 +484,9 @@ install_args=()
 [ "$dry_run" -eq 0 ] || install_args+=(--dry-run)
 components=()
 if [ "$command_name" = install ] || [ "$command_name" = update ]; then
-    components=(--runtime-only --integration-only)
-    if [ "$desired_link" != off ] || [ -n "${ABLETON_PR182_CUSTOM_LINKD:-}" ]; then
-        components+=(--link-assets-only)
-    fi
+    # Runtime and prefix/registry state are the core transaction. Desktop and
+    # Link integration are repaired only after that core has committed.
+    components=(--runtime-only)
 fi
 
 case "$command_name:$subcommand" in
@@ -473,7 +509,7 @@ case "$command_name:$subcommand" in
         fi ;;
     prefix:update)
         "$here/setup-prefix.sh" --refresh --validate
-        if [ "$dry_run" -eq 1 ]; then printf 'PLAN: transactionally update prefix %s\n' "$ABLETON_WINEPREFIX"; exit; fi ;;
+        if [ "$dry_run" -eq 1 ]; then printf 'PLAN: update the Ableton Wine prefix at %s\n' "$ABLETON_WINEPREFIX"; exit; fi ;;
     prefix:repair-live11)
         if [ "$dry_run" -eq 1 ]; then
             printf 'PLAN: move aside stale Live 11 Max preferences in %s\n' "$ABLETON_WINEPREFIX"
@@ -496,17 +532,20 @@ case "$command_name:$subcommand" in
         ABLETON_RUNTIME_PENDING=1 "$here/setup-prefix.sh" "${prefix_validate[@]}" --validate
         if [ "$dry_run" -eq 1 ]; then
             "$here/install.sh" "${components[@]}" --dry-run
-            printf '  transactionally %s prefix: %s\n' "$([ "$command_name" = update ] && echo update || echo create)" "$ABLETON_WINEPREFIX"
-            printf '  stage prefix as a sibling, promote only after all checks, then write: %s/pipeasio/config.ini\n' \
-                "${XDG_CONFIG_HOME:-$HOME/.config}"
-            [ -z "$live_payload" ] || printf '  run bounded Live %s installer: %s\n' "$ABLETON_LIVE_VERSION" "$live_payload"
-            printf '  write persistent resolved configuration: %s\n' "$ABLETON_CONFIG_FILE"
+            "$here/install.sh" --integration-only --dry-run
+            if [ "$desired_link" != off ]; then
+                "$here/install.sh" --link-assets-only --dry-run
+            fi
+            printf '  %s the Ableton Wine prefix: %s\n' "$([ "$command_name" = update ] && echo Update || echo Create)" "$ABLETON_WINEPREFIX"
+            printf '  configure PipeASIO: %s/pipeasio/config.ini\n' "${XDG_CONFIG_HOME:-$HOME/.config}"
+            [ -z "$live_payload" ] || printf '  run the Live %s installer: %s\n' "$ABLETON_LIVE_VERSION" "$live_payload"
+            printf '  save installer settings: %s\n' "$ABLETON_CONFIG_FILE"
             if [ "$desired_link" = off ]; then
                 "$here/setup-link.sh" plan-disable
             else
                 "$here/setup-link.sh" plan-enable "--mode=$desired_link"
             fi
-            printf '  final Link policy: %s\n' "$desired_link"
+            printf '  set Ableton Link mode: %s\n' "$desired_link"
             exit
         fi ;;
 esac
@@ -518,8 +557,7 @@ ableton_install_lock_acquire
 if [ "$command_name:$subcommand" = runtime:install ]; then
     transaction="$(mktemp -d "${TMPDIR:-/tmp}/ableton-runtime-install.XXXXXX")"
 else
-    ableton_mark_state_home
-    mkdir -p -- "$ABLETON_STATE_HOME/transactions"
+    ableton_prepare_transactions_dir
     transaction="$(mktemp -d "$ABLETON_STATE_HOME/transactions/installer.XXXXXX")"
 fi
 # ShellCheck does not follow function names stored in traps.
@@ -529,7 +567,7 @@ cleanup_unstarted_transaction()
     local rc=$?
     trap - EXIT
     if [ "$rc" -ne 0 ] && ! rm -rf -- "$transaction"; then
-        echo "!! failed to remove unstarted installer transaction: $transaction" >&2
+        echo "!! The installer stopped before making changes, and temporary files remain at $transaction." >&2
     fi
     exit "$rc"
 }
@@ -538,33 +576,39 @@ ABLETON_TRANSACTION_DIR="$transaction"
 export ABLETON_TRANSACTION_DIR
 config_backup="$transaction/config.before"
 config_existed=0
+config_rollback_state=absent
 if [ -e "$ABLETON_CONFIG_FILE" ] || [ -L "$ABLETON_CONFIG_FILE" ]; then
-    { [ -f "$ABLETON_CONFIG_FILE" ] || [ -L "$ABLETON_CONFIG_FILE" ]; } \
-        && [ ! -d "$ABLETON_CONFIG_FILE" ] \
-        && [ -n "$(ableton_manifest_digest "$ABLETON_CONFIG_FILE" 2>/dev/null || true)" ] || {
-        echo "!! current installer configuration is unsafe" >&2
-        exit 1
-    }
-    mkdir -p -- "$(dirname "$config_backup")"
-    cp -a -- "$ABLETON_CONFIG_FILE" "$config_backup"
-    config_existed=1
+    config_rollback_state=unchanged
+    if [ -f "$ABLETON_CONFIG_FILE" ] && [ ! -L "$ABLETON_CONFIG_FILE" ] \
+       && [ -n "$(ableton_manifest_digest "$ABLETON_CONFIG_FILE" 2>/dev/null || true)" ] \
+       && cp -a -- "$ABLETON_CONFIG_FILE" "$config_backup"; then
+        config_existed=1
+        config_rollback_state=present
+    fi
 fi
-pipeasio_config_parent="$(ableton_realpath_m "${XDG_CONFIG_HOME:-$HOME/.config}/pipeasio")"
-pipeasio_config="$pipeasio_config_parent/config.ini"
-case "$pipeasio_config" in *$'\n'*|*$'\r'*|*$'\t'*)
-    echo "!! PipeASIO configuration path contains a newline or tab" >&2; exit 2 ;;
-esac
+pipeasio_config_parent="$(ableton_realpath_m \
+    "${XDG_CONFIG_HOME:-$HOME/.config}/pipeasio" 2>/dev/null || true)"
+pipeasio_config="${XDG_CONFIG_HOME:-$HOME/.config}/pipeasio/config.ini"
+pipeasio_config_resolved=0
+if [ -n "$pipeasio_config_parent" ]; then
+    pipeasio_config="$pipeasio_config_parent/config.ini"
+    pipeasio_config_resolved=1
+fi
 pipeasio_config_backup="$transaction/pipeasio-config.before"
 pipeasio_config_existed=0
-if [ -e "$pipeasio_config" ] || [ -L "$pipeasio_config" ]; then
-    { [ -f "$pipeasio_config" ] || [ -L "$pipeasio_config" ]; } \
-        && [ ! -d "$pipeasio_config" ] \
-        && [ -n "$(ableton_manifest_digest "$pipeasio_config" 2>/dev/null || true)" ] || {
-        echo "!! current PipeASIO configuration is unsafe" >&2
-        exit 1
-    }
-    cp -a -- "$pipeasio_config" "$pipeasio_config_backup"
-    pipeasio_config_existed=1
+pipeasio_rollback_state=absent
+if [ "$pipeasio_config_resolved" -ne 1 ]; then
+    # Saved settings are an optional rollback convenience. A path that cannot
+    # be resolved leaves the current PipeASIO settings untouched.
+    pipeasio_rollback_state=unchanged
+elif [ -e "$pipeasio_config" ] || [ -L "$pipeasio_config" ]; then
+    pipeasio_rollback_state=unchanged
+    if [ -f "$pipeasio_config" ] && [ ! -L "$pipeasio_config" ] \
+       && [ -n "$(ableton_manifest_digest "$pipeasio_config" 2>/dev/null || true)" ] \
+       && cp -a -- "$pipeasio_config" "$pipeasio_config_backup"; then
+        pipeasio_config_existed=1
+        pipeasio_rollback_state=present
+    fi
 fi
 panel_integration_existed=0
 ownership_manifest="$ABLETON_STATE_HOME/install-manifest.tsv"
@@ -577,11 +621,26 @@ fi
 transaction_complete=0
 rollback_log="$transaction/rollback.log"
 rollback_sink="$rollback_log"
-committed_cleanup_step=""
+cleanup_log="$transaction/cleanup.log"
 link_transaction=0
-link_setup_failed=0
+integration_ready=1
+link_ready=1
+settings_ready=1
+cleanup_ready=1
+link_resume_command=""
 live_unpack=""
-config_post_token=""
+
+format_link_resume_command()
+{
+    local installer_path
+    if [ -n "${ABLETON_INSTALLER_PATH:-}" ]; then
+        printf -v installer_path '%q' "$ABLETON_INSTALLER_PATH"
+        printf 'sh %s link enable --mode=%q' "$installer_path" "$1"
+    else
+        printf -v installer_path '%q' "$here/installer.sh"
+        printf 'bash %s link enable --mode=%q' "$installer_path" "$1"
+    fi
+}
 
 cleanup_live_unpack()
 {
@@ -590,7 +649,8 @@ cleanup_live_unpack()
     safe="$(ableton_path_is_safe_delete_target "$live_unpack")" || return 1
     case "$(basename "$safe")" in ableton-live-installer.*) ;; *) return 1 ;; esac
     [ ! -L "$safe" ] || return 1
-    rm -rf -- "$safe"
+    rm -rf -- "$safe" || return 1
+    [ ! -e "$safe" ] && [ ! -L "$safe" ] || return 1
     live_unpack=""
 }
 
@@ -604,10 +664,13 @@ rollback_log_step()
 rollback_all()
 {
     local rc=$? restore_error="" restoration_complete=yes failure_record="$transaction/FAILURE"
-    local rollback_preflight_ok=1 config_current_token="" config_prior_token=""
+    local rollback_preflight_ok=1 failure_record_written=0
     trap - EXIT
+    # A closed terminal must not stop recovery from running. From this point
+    # every recovery command and status write is checked explicitly.
+    set +e
     if [ "$transaction_complete" -ne 1 ]; then
-        echo "!! installer transaction failed; restoring the previous component and prefix state" >&2
+        echo "!! Installation did not finish. Restoring the changes from this attempt." >&2
         # A log the installer cannot open must not stop the restoration: a
         # child redirected to an unopenable path never runs at all.
         if ! : 2>/dev/null >> "$rollback_sink"; then
@@ -615,92 +678,70 @@ rollback_all()
             rollback_sink=/dev/null
             rollback_log=""
         fi
-        rollback_log_step "rollback started for $command_name${subcommand:+ $subcommand} (exit $rc)"
-        rollback_log_step "prefix rollback preflight"
+        rollback_log_step "Recovery started for $command_name${subcommand:+ $subcommand} (exit $rc)"
+        rollback_log_step "Checking Wine prefix recovery"
         if ! "$here/setup-prefix.sh" --preflight-rollback "$transaction" >> "$rollback_sink" 2>&1; then
-            restore_error="prefix rollback preflight failed"
+            restore_error="Wine prefix recovery could not be checked"
             rollback_preflight_ok=0
         fi
-        rollback_log_step "component rollback preflight"
+        rollback_log_step "Checking Wine runtime recovery"
         if ! "$here/install.sh" --preflight-rollback "$transaction" >> "$rollback_sink" 2>&1; then
-            restore_error="${restore_error}${restore_error:+; }component rollback preflight failed"
+            restore_error="${restore_error}${restore_error:+; }Wine runtime recovery could not be checked"
             rollback_preflight_ok=0
         fi
-        [ "$link_transaction" -ne 1 ] || rollback_log_step "Link rollback preflight"
+        [ "$link_transaction" -ne 1 ] || rollback_log_step "Checking Link recovery"
         if [ "$link_transaction" -eq 1 ] \
            && ! "$here/setup-link.sh" preflight-rollback "$transaction" >> "$rollback_sink" 2>&1; then
-            restore_error="${restore_error}${restore_error:+; }Link rollback preflight failed"
+            restore_error="${restore_error}${restore_error:+; }Link recovery could not be checked"
             rollback_preflight_ok=0
         fi
-        if [ "$config_existed" -eq 1 ] \
-           && { [ ! -f "$config_backup" ] || [ -L "$config_backup" ]; }; then
-            restore_error="${restore_error}${restore_error:+; }installer configuration snapshot is unsafe"
-            rollback_preflight_ok=0
-        fi
-        if [ -e "$ABLETON_CONFIG_FILE" ] || [ -L "$ABLETON_CONFIG_FILE" ]; then
-            if [ -d "$ABLETON_CONFIG_FILE" ] \
-               || { [ ! -f "$ABLETON_CONFIG_FILE" ] && [ ! -L "$ABLETON_CONFIG_FILE" ]; }; then
-                restore_error="${restore_error}${restore_error:+; }installer configuration destination is unsafe"
-                rollback_preflight_ok=0
-            fi
-        fi
-        if [ "$rollback_preflight_ok" -eq 1 ] && [ -n "$config_post_token" ]; then
-            config_current_token="$(ableton_object_token "$ABLETON_CONFIG_FILE" 2>/dev/null || true)"
-            if [ "$config_existed" -eq 1 ]; then
-                config_prior_token="$(ableton_object_token "$config_backup" 2>/dev/null || true)"
-            else
-                config_prior_token=absent
-            fi
-            if [ -z "$config_current_token" ] \
-               || { [ "$config_current_token" != "$config_post_token" ] \
-                    && [ "$config_current_token" != "$config_prior_token" ]; }; then
-                restore_error="${restore_error}${restore_error:+; }installer configuration changed while the transaction was open"
-                rollback_preflight_ok=0
-            fi
-        fi
-        [ "$rollback_preflight_ok" -ne 1 ] || rollback_log_step "prefix rollback"
+        [ "$rollback_preflight_ok" -ne 1 ] || rollback_log_step "Restoring Wine prefix"
         if [ "$rollback_preflight_ok" -eq 1 ] \
            && ! "$here/setup-prefix.sh" --rollback "$transaction" >> "$rollback_sink" 2>&1; then
-            restore_error="prefix rollback failed"
+            restore_error="Wine prefix could not be restored"
         fi
-        [ "$rollback_preflight_ok" -ne 1 ] || rollback_log_step "component rollback"
+        [ "$rollback_preflight_ok" -ne 1 ] || rollback_log_step "Restoring Wine runtime"
         if [ "$rollback_preflight_ok" -eq 1 ] \
            && ! "$here/install.sh" --rollback "$transaction" >> "$rollback_sink" 2>&1; then
-            restore_error="${restore_error}${restore_error:+; }component rollback failed"
-        fi
-        if [ "$rollback_preflight_ok" -eq 1 ] && [ "$config_existed" -eq 1 ]; then
-            if ! ableton_atomic_restore_object "$config_backup" "$ABLETON_CONFIG_FILE"; then
-                restore_error="${restore_error}${restore_error:+; }installer configuration restoration failed"
-            fi
-        elif [ "$rollback_preflight_ok" -eq 1 ] \
-             && [ "$config_existed" -eq 0 ] \
-             && ! rm -f -- "$ABLETON_CONFIG_FILE"; then
-            restore_error="${restore_error}${restore_error:+; }installer configuration cleanup failed"
+            restore_error="${restore_error}${restore_error:+; }Wine runtime could not be restored"
         fi
         if [ "$rollback_preflight_ok" -eq 1 ] && [ "$link_transaction" -eq 1 ]; then
-            rollback_log_step "Link rollback"
+            rollback_log_step "Restoring Link settings"
             if ! "$here/setup-link.sh" rollback "$transaction" >> "$rollback_sink" 2>&1; then
-                restore_error="${restore_error}${restore_error:+; }Link rollback failed"
+                restore_error="${restore_error}${restore_error:+; }Link settings could not be restored"
             fi
         fi
         if [ "$rollback_preflight_ok" -eq 1 ] && ! cleanup_live_unpack; then
-            restore_error="${restore_error}${restore_error:+; }temporary Live payload cleanup failed"
+            rollback_log_step "temporary Live installer files were retained at $live_unpack"
+        fi
+        # Domain helpers deliberately leave the coordinator marker alone.  It
+        # is retired only after every rollback domain and temporary payload has
+        # been restored.  If any recovery is incomplete, keep it so launchers
+        # cannot self-heal managed files inside the retained evidence.
+        if [ "$rollback_preflight_ok" -eq 1 ] && [ -z "$restore_error" ] \
+           && ! rm -f -- "$transaction/active"; then
+            restore_error="recovery status cleanup failed"
         fi
         [ -z "$restore_error" ] || restoration_complete=no
-        printf 'command=%s %s\nexit=%s\nrestoration_complete=%s\nrestoration_error=%s\nrollback_log=%s\n' \
+        if printf 'command=%s %s\nexit=%s\nrestoration_complete=%s\nrestoration_error=%s\nrollback_log=%s\n' \
             "$command_name" "$subcommand" "$rc" "$restoration_complete" "$restore_error" "$rollback_log" \
-            > "$failure_record" || true
+            > "$failure_record"; then
+            failure_record_written=1
+        fi
         if [ "$restoration_complete" = yes ]; then
-            echo "!! rollback complete; failure record: $failure_record" >&2
+            echo "!! Installation did not finish. The earlier installation state was restored." >&2
+            [ "$failure_record_written" -eq 0 ] || echo "!! Details: $failure_record" >&2
         else
-            echo "!! installer rollback is incomplete: $restore_error" >&2
-            echo "!! inspect $failure_record${rollback_log:+ and $rollback_log} before retrying" >&2
+            echo "!! Installation failed, and recovery still needs attention: $restore_error" >&2
+            if [ "$failure_record_written" -eq 1 ]; then
+                echo "!! Save these recovery details before retrying: $failure_record${rollback_log:+ and $rollback_log}" >&2
+            elif [ -n "$rollback_log" ]; then
+                echo "!! Save this recovery log before retrying: $rollback_log" >&2
+            fi
         fi
     elif [ "$rc" -ne 0 ]; then
-        printf 'command=%s %s\nstatus=committed-cleanup-incomplete\nstep=%s\nexit=%s\n' \
-            "$command_name" "$subcommand" "${committed_cleanup_step:-unknown}" "$rc" \
-            > "$transaction/COMMITTED_CLEANUP_FAILURE"
-        echo "!! installation committed, but rollback metadata or cleanup was incomplete: $transaction/COMMITTED_CLEANUP_FAILURE" >&2
+        echo "!! Ableton is ready. Run the installer again to retry shortcuts, Link, or saved settings." >&2 || true
+        rc=0
     fi
     exit "$rc"
 }
@@ -709,16 +750,17 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 case "$command_name:$subcommand" in
-    install:|update:|link:enable|link:disable)
+    link:enable|link:disable)
         "$here/setup-link.sh" snapshot "$transaction"
         link_transaction=1 ;;
 esac
 
 ABLETON_LINK_MODE="$desired_link"
 export ABLETON_LINK_MODE
-if [ "$command_name:$subcommand" != runtime:install ]; then
-    config_post_token="$(ableton_expected_config_token)"
-fi
+# Child lifecycle helpers inherit both the lock and this snapshot. Refresh the
+# resolved-value half after applying the requested policy; the file itself has
+# not changed, so its original token remains the concurrency boundary.
+ableton_config_snapshot_capture
 
 case "$command_name:$subcommand" in
     runtime:install)
@@ -729,12 +771,9 @@ case "$command_name:$subcommand" in
         "$here/setup-prefix.sh" --refresh --transaction-dir "$transaction" ;;
     link:enable)
         "$here/install.sh" --link-assets-only --transaction-dir "$transaction" "${install_args[@]}"
-        "$here/setup-link.sh" enable "--mode=$desired_link" ;;
+        ABLETON_LINK_COORDINATED=1 "$here/setup-link.sh" enable "--mode=$desired_link" ;;
     link:disable)
-        if [ -n "${ABLETON_PR182_CUSTOM_LINKD:-}" ]; then
-            "$here/install.sh" --link-assets-only --transaction-dir "$transaction" "${install_args[@]}"
-        fi
-        "$here/setup-link.sh" disable ;;
+        ABLETON_LINK_COORDINATED=1 "$here/setup-link.sh" disable ;;
     install:|update:)
         "$here/install.sh" "${components[@]}" --transaction-dir "$transaction" "${install_args[@]}"
         if [ "$command_name" = update ]; then
@@ -744,12 +783,87 @@ case "$command_name:$subcommand" in
         fi ;;
 esac
 
+# Direct Link commands save their selected mode themselves. Drop the parent's
+# now-stale view of that generated file so later cleanup cannot mistake the
+# child's successful write for an installation failure.
+case "$command_name:$subcommand" in
+    link:enable|link:disable)
+        unset ABLETON_CONFIG_SNAPSHOT_PATH ABLETON_CONFIG_SNAPSHOT_TOKEN \
+            ABLETON_CONFIG_SNAPSHOT_VALUES ;;
+esac
+
+live11_registry_ready()
+{
+    ableton_run_bounded 30 env WINEPREFIX="$ABLETON_WINEPREFIX" \
+        "$ABLETON_WINE_ROOT/bin/wine" reg query 'HKLM\Software' >/dev/null 2>&1
+}
+
+live11_placeholder_present()
+{
+    local key
+    for key in \
+        'HKLM\Software\Microsoft\Windows\CurrentVersion\Installer\UpgradeCodes\86C5CFEA462003E469588217A219FCE4' \
+        'HKLM\Software\Classes\Installer\UpgradeCodes\86C5CFEA462003E469588217A219FCE4'; do
+        ableton_run_bounded 30 env WINEPREFIX="$ABLETON_WINEPREFIX" \
+            "$ABLETON_WINE_ROOT/bin/wine" reg query "$key" \
+            /v 16A75B0B0E11E2A4A911BAE107021162 >/dev/null 2>&1 || return 1
+    done
+    for key in \
+        'HKLM\Software\Classes\Installer\Products\16A75B0B0E11E2A4A911BAE107021162' \
+        'HKLM\Software\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products\16A75B0B0E11E2A4A911BAE107021162'; do
+        ableton_run_bounded 30 env WINEPREFIX="$ABLETON_WINEPREFIX" \
+            "$ABLETON_WINE_ROOT/bin/wine" reg query "$key" >/dev/null 2>&1 || return 1
+    done
+}
+
+live11_placeholder_absent()
+{
+    local key status
+    live11_registry_ready || return 1
+    for key in \
+        'HKLM\Software\Microsoft\Windows\CurrentVersion\Installer\UpgradeCodes\86C5CFEA462003E469588217A219FCE4' \
+        'HKLM\Software\Classes\Installer\UpgradeCodes\86C5CFEA462003E469588217A219FCE4'; do
+        status=0
+        ableton_run_bounded 30 env WINEPREFIX="$ABLETON_WINEPREFIX" \
+            "$ABLETON_WINE_ROOT/bin/wine" reg query "$key" \
+            /v 16A75B0B0E11E2A4A911BAE107021162 >/dev/null 2>&1 || status=$?
+        [ "$status" -eq 1 ] || return 1
+    done
+    for key in \
+        'HKLM\Software\Classes\Installer\Products\16A75B0B0E11E2A4A911BAE107021162' \
+        'HKLM\Software\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products\16A75B0B0E11E2A4A911BAE107021162'; do
+        status=0
+        ableton_run_bounded 30 env WINEPREFIX="$ABLETON_WINEPREFIX" \
+            "$ABLETON_WINE_ROOT/bin/wine" reg query "$key" >/dev/null 2>&1 || status=$?
+        [ "$status" -eq 1 ] || return 1
+    done
+}
+
+live_install_result_valid()
+{
+    local major="$1" exe live_found=0 base="$ABLETON_WINEPREFIX/drive_c/ProgramData/Ableton"
+    for exe in "$base"/"Live $major"*/Program/"Ableton Live $major"*.exe; do
+        [ -e "$exe" ] || [ -L "$exe" ] || continue
+        if [ ! -f "$exe" ] || [ -L "$exe" ]; then
+            echo "!! Live created an unsafe executable path: $exe" >&2
+            return 1
+        fi
+        live_found=1
+    done
+    [ "$live_found" -eq 1 ] || {
+        echo "!! The Live installer exited without installing Ableton Live $major in the selected prefix." >&2
+        return 1
+    }
+}
+
 install_live_payload()
 {
     [ -n "$live_payload" ] || return 0
-    local installer="$live_payload" unpack="" lower flags=() timeout_secs extract_timeout status=0 seed_reg=""
+    local installer="$live_payload" unpack="" stale_unpack="" lower flags=() timeout_secs extract_timeout status=0 seed_reg=""
     local zip_name zip_bytes zip_fingerprint zip_kb need_kb avail_kb
-    local stop_answer="" holders="" unknown="" holder holder_image
+    local stop_answer="" holders="" unknown="" holder holder_image wait_status=0
+    local exe_inventory="" exe_inventory_sorted="" signature="" key
+    local -a payload_exes=()
     lower="$(basename "$installer" | tr '[:upper:]' '[:lower:]')"
     if [[ "$lower" = *.zip ]]; then
         unpack="${ABLETON_PAYLOAD_UNPACK_DIR:-$(dirname "$installer")}/ableton-live-installer.d"
@@ -760,10 +874,20 @@ install_live_payload()
         zip_bytes="$(stat -c %s -- "$installer" 2>/dev/null || wc -c < "$installer" 2>/dev/null || echo 0)"
         zip_fingerprint="$zip_name $zip_bytes"
         if [ -f "$unpack/.extracted" ] && [ "$(cat "$unpack/.extracted" 2>/dev/null)" = "$zip_fingerprint" ]; then
-            echo "-- reusing the Live installer payload already extracted at $unpack"
+            echo "-- Reusing the extracted Live installer at $unpack" || true
         else
-            live_unpack="$unpack"; cleanup_live_unpack || return 1
-            mkdir -p -- "$unpack" || { echo "!! cannot create $unpack" >&2; return 1; }
+            live_unpack="$unpack"
+            if cleanup_live_unpack; then
+                mkdir -p -- "$unpack" || { echo "!! cannot create $unpack" >&2; return 1; }
+            else
+                # Old extraction data is disposable. If its permissions or
+                # shape prevent removal, use a new private directory rather
+                # than turning our own cache into an installation gate.
+                stale_unpack="$unpack"
+                unpack="$(mktemp -d "${TMPDIR:-/tmp}/ableton-live-installer.XXXXXX")" \
+                    || { echo "!! cannot create a temporary directory for the Live installer" >&2; return 1; }
+                live_unpack="$unpack"
+            fi
             if [ ! -w "$unpack" ]; then
                 echo "!! $unpack is not writable; set ABLETON_PAYLOAD_UNPACK_DIR to a writable location" >&2
                 return 1
@@ -771,7 +895,9 @@ install_live_payload()
             # Need headroom: the unpacked payload can exceed the zip's own size.
             if command -v df >/dev/null 2>&1; then
                 zip_kb=$(( zip_bytes / 1024 )); need_kb=$(( zip_kb * 3 / 2 ))
-                avail_kb="$(df -Pk -- "$unpack" 2>/dev/null | awk 'NR==2{print $4}')"
+                if ! avail_kb="$(df -Pk -- "$unpack" 2>/dev/null | awk 'NR==2{print $4}')"; then
+                    avail_kb=""
+                fi
                 case "$avail_kb" in
                     ''|*[!0-9]*) ;; # no usable df figure; skip the guard
                     *) [ "$avail_kb" -ge "$need_kb" ] || {
@@ -780,23 +906,36 @@ install_live_payload()
                 esac
             fi
             extract_timeout="$(ableton_timeout_value "${ABLETON_PAYLOAD_EXTRACT_TIMEOUT:-900}" ABLETON_PAYLOAD_EXTRACT_TIMEOUT 60 7200)"
-            echo "-- extracting Live installer payload (bounded to ${extract_timeout}s; extracted filenames show progress)"
+            echo "-- Extracting the Live installer (up to ${extract_timeout}s)" || true
             # -o + </dev/null stop unzip hanging on a "replace? (y/n)" prompt.
-            if command -v unzip >/dev/null 2>&1; then ableton_run_bounded "$extract_timeout" unzip -o "$installer" -d "$unpack" </dev/null
-            elif command -v bsdtar >/dev/null 2>&1; then ableton_run_bounded "$extract_timeout" bsdtar -xvf "$installer" -C "$unpack" </dev/null
+            if command -v unzip >/dev/null 2>&1; then ableton_run_bounded "$extract_timeout" unzip -oq "$installer" -d "$unpack" </dev/null
+            elif command -v bsdtar >/dev/null 2>&1; then ableton_run_bounded "$extract_timeout" bsdtar -xf "$installer" -C "$unpack" </dev/null
             elif command -v python3 >/dev/null 2>&1; then ableton_run_bounded "$extract_timeout" python3 -m zipfile -e "$installer" "$unpack" </dev/null
             else echo "!! unzip, bsdtar, or python3 is required for a ZIP payload" >&2; return 1; fi
-            printf '%s\n' "$zip_fingerprint" > "$unpack/.extracted"
+            printf '%s\n' "$zip_fingerprint" > "$unpack/.extracted" 2>/dev/null || true
         fi
         live_unpack="$unpack"
-        mapfile -t payload_exes < <(find "$unpack" -type f -iname '*.exe' -print | sort -V)
+        exe_inventory="$(mktemp "$transaction/live-exes.XXXXXX")" || return 1
+        exe_inventory_sorted="$(mktemp "$transaction/live-exes-sorted.XXXXXX")" || return 1
+        if ! find "$unpack" -type f -iname '*.exe' -print0 > "$exe_inventory" \
+           || ! sort -zV "$exe_inventory" > "$exe_inventory_sorted"; then
+            echo "!! The extracted Live installer could not be checked completely." >&2
+            return 1
+        fi
+        mapfile -d '' -t payload_exes < "$exe_inventory_sorted"
+        rm -f -- "$exe_inventory" "$exe_inventory_sorted" 2>/dev/null || true
         [ "${#payload_exes[@]}" -eq 1 ] || {
             echo "!! expected exactly one installer executable in the ZIP, found ${#payload_exes[@]}" >&2; return 1; }
         installer="${payload_exes[0]}"
     fi
-    if grep -qaF '.wixburn' < <(head -c 4096 -- "$installer"); then
+    signature="$(mktemp "$transaction/live-installer-signature.XXXXXX")" || return 1
+    if ! head -c 4194304 -- "$installer" > "$signature" 2>/dev/null; then
+        echo "!! The Live installer could not be read completely." >&2
+        return 1
+    fi
+    if grep -qaF '.wixburn' "$signature"; then
         flags=(/passive /norestart)
-        if grep -qa 'wixtoolset' < <(head -c 4194304 -- "$installer"); then
+        if grep -qa 'wixtoolset' "$signature"; then
             # WiX 4 Live 11 bundles expose no command-line switch for the
             # Windows-only Push USB audio driver. Register a high-version
             # placeholder so the bundle's own plan excludes that package.
@@ -819,16 +958,28 @@ Windows Registry Editor Version 5.00
 "DisplayVersion"="99.0.0"
 "WindowsInstaller"=dword:00000001
 EOF
+            if ! live11_registry_ready; then
+                echo "!! The Wine registry could not be checked before installing Live." >&2
+                return 1
+            fi
             ableton_run_bounded 60 env WINEPREFIX="$ABLETON_WINEPREFIX" \
                 "$ABLETON_WINE_ROOT/bin/wine" regedit /S "$seed_reg"
+            if ! live11_placeholder_present; then
+                echo "!! The temporary Live 11 driver block was not written to the Wine registry." >&2
+                return 1
+            fi
         fi
-    elif grep -qa 'Inno Setup' < <(head -c 4194304 -- "$installer"); then
+    elif grep -qa 'Inno Setup' "$signature"; then
         flags=(/SILENT /SUPPRESSMSGBOXES /NORESTART '/MERGETASKS=!audiodriver')
     fi
+    rm -f -- "$signature" 2>/dev/null || true
     timeout_secs="$(ableton_timeout_value "${ABLETON_LIVE_INSTALL_TIMEOUT:-3600}" ABLETON_LIVE_INSTALL_TIMEOUT 60 14400)"
-    echo "-- running the Live installer under a ${timeout_secs}s TERM→KILL watchdog"
+    echo "-- Running the Live installer (up to ${timeout_secs}s)" || true
     (
-        cd "$(dirname "$installer")"
+        if ! cd "$(dirname "$installer")"; then
+            echo "!! The Live installer directory is no longer available." >&2
+            exit 1
+        fi
         ableton_run_bounded "$timeout_secs" env WINEPREFIX="$ABLETON_WINEPREFIX" \
             "$ABLETON_WINE_ROOT/bin/wine" "./$(basename "$installer")" "${flags[@]}"
     ) || status=$?
@@ -849,11 +1000,16 @@ EOF
             ableton_run_bounded 30 env WINEPREFIX="$ABLETON_WINEPREFIX" \
                 "$ABLETON_WINE_ROOT/bin/wine" reg delete "$key" /f >/dev/null 2>&1 || true
         done
-        rm -f -- "$seed_reg"
+        if ! live11_placeholder_absent; then
+            echo "!! The temporary Live 11 driver block is still present in the Wine registry." >&2
+            return 1
+        fi
+        rm -f -- "$seed_reg" 2>/dev/null \
+            || echo "!! Live is installed, but a temporary installer file could not be removed: $seed_reg" >&2 \
+            || true
     fi
-    # The prefix is promoted and nothing below opens it again, so the install is
-    # complete from here and this step never fails it.
-    #
+    live_install_result_valid "$ABLETON_LIVE_VERSION" || return 1
+
     # The agents an install leaves behind are ended by name first, because that is
     # what removes the cause: Live 12's WebView2 updater cannot validate its COM
     # registration under Wine, so it parks in Core::DoRun and holds the wineserver
@@ -861,23 +1017,29 @@ EOF
     # applet from a Startup shortcut.  Wine resolves a process to its long image
     # name, so the list matches the applet through its 8.3 path too.  Wine's own
     # processes exit once the last client goes, so the server needs no signal.
-    ableton_stop_leftover_agents
-    if ! ableton_prefix_wait_progress; then
+    ableton_stop_leftover_agents \
+        || echo "!! Live is installed, but one of its background helpers could not be stopped." >&2 \
+        || true
+    ableton_prefix_wait_progress || wait_status=$?
+    if [ "$wait_status" -eq 124 ] || [ "$wait_status" -eq 137 ]; then
         # Named before anything is decided: once the prefix is ended there is no
         # process left to read an image name from, and the image name is the only
         # part of this a bug report can carry.
-        holders="$(ableton_prefix_holders)"
-        unknown="$(printf '%s\n' "$holders" | ableton_unknown_holders)"
+        holders="$(ableton_prefix_holders 2>/dev/null)" || holders=""
+        unknown="$(printf '%s\n' "$holders" | ableton_unknown_holders 2>/dev/null)" \
+            || unknown=""
         # The unknown set, not every holder: naming an agent the step just ended
         # and then saying nothing needs to be done reads as a contradiction.
         if [ -n "$unknown" ]; then
-            echo "-- the install is complete. A program in the prefix is still running:"
+            echo "-- The Live installer finished, but a program is still using its Wine prefix:" \
+                || true
             while IFS="$(printf '\t')" read -r holder holder_image; do
                 [ -n "$holder" ] || continue
-                printf '   %s (pid %s)\n' "$holder_image" "$holder"
+                printf '   %s (pid %s)\n' "$holder_image" "$holder" || true
             done <<< "$unknown"
         else
-            echo "-- the install is complete; a background program is still finishing."
+            echo "-- The Live installer finished; a background program is still using its Wine prefix." \
+                || true
         fi
         # The question is asked only when a program this project did not install is
         # holding the prefix.  A helper this project installed exits once the prefix
@@ -887,63 +1049,53 @@ EOF
         # one of those.  A prefix a Max may be sharing is not ended without an
         # answer, so with nobody to ask the install completes and prints the command.
         if [ -z "$unknown" ] || [ "$assume_yes" -eq 1 ] || [ ! -t 0 ]; then
-            echo "-- nothing needs to be done. To end it anyway, close it or run:"
+            echo "-- You can leave it running. To stop every program in the prefix instead, run:" \
+                || true
             printf '   WINEPREFIX=%s %s/bin/wineserver -k\n' \
-                "$ABLETON_WINEPREFIX" "$ABLETON_WINE_ROOT"
+                "$ABLETON_WINEPREFIX" "$ABLETON_WINE_ROOT" || true
         else
             # Default no, and a timed read that falls back to it: pressing return or
             # walking away leaves the prefix as it is.
-            printf 'End every program in the prefix now? [y/N] ' >&2
+            printf 'End every program in the prefix now? [y/N] ' >&2 || true
             read -r -t 60 stop_answer || stop_answer=""
             case "$stop_answer" in
                 [yY]*)
-                    ableton_run_bounded 20 env WINEPREFIX="$ABLETON_WINEPREFIX" \
-                        "$ABLETON_WINE_ROOT/bin/wineserver" -k >/dev/null 2>&1 || true
-                    echo "-- ended the programs in the prefix" ;;
+                    if ableton_run_bounded 20 env WINEPREFIX="$ABLETON_WINEPREFIX" \
+                        "$ABLETON_WINE_ROOT/bin/wineserver" -k >/dev/null 2>&1; then
+                        echo "-- stopped the programs in the prefix" || true
+                    else
+                        echo "!! Live is installed, but the programs in its Wine prefix could not be stopped." >&2 \
+                            || true
+                    fi ;;
                 *)
-                    echo "-- left them running; the next update may ask you to close them" ;;
+                    echo "-- left them running; the next update may ask you to close them" \
+                        || true ;;
             esac
         fi
+    elif [ "$wait_status" -ne 0 ]; then
+        echo "!! Live is installed, but Wine could not be checked afterward (exit $wait_status)." >&2 \
+            || true
     fi
-    [ -z "$unpack" ] || cleanup_live_unpack
+    if [ -n "$unpack" ] && ! cleanup_live_unpack; then
+        echo "!! Live is installed, but its extracted installer files could not be removed: $unpack" >&2 \
+            || true
+    fi
+    if [ -n "$stale_unpack" ] \
+       && { [ -e "$stale_unpack" ] || [ -L "$stale_unpack" ]; }; then
+        echo "!! Live is installed. Older extracted installer files remain at $stale_unpack." >&2 \
+            || true
+    fi
 }
 
 if [ "$command_name" = install ]; then
     install_live_payload
 fi
 
-case "$command_name" in
-    install|update)
-        if [ "$desired_link" = off ]; then
-            "$here/setup-link.sh" disable
-        else
-            # Link setup asks for a sudo password when a firewall is active.
-            # Preserve the completed Live changes when the prompt expires or
-            # receives Ctrl-C. Report the stopped Link step. Show the command that
-            # resumes it. The stored Link choice makes later updates repeat the
-            # setup.
-            trap 'link_setup_failed=1' INT
-            "$here/setup-link.sh" enable "--mode=$desired_link" || link_setup_failed=1
-            trap 'exit 130' INT
-            if [ "$link_setup_failed" -eq 1 ]; then
-                echo "!! Link setup stopped; the $command_name continues" >&2
-                echo "   Run this command to complete Link setup: installer link enable --mode=$desired_link" >&2
-            fi
-        fi ;;
-esac
-
-if [ "$command_name:$subcommand" != runtime:install ]; then
-    ableton_write_config
-    [ "$(ableton_object_token "$ABLETON_CONFIG_FILE")" = "$config_post_token" ] || {
-        echo "!! installed configuration does not match the resolved transaction" >&2
-        exit 1
-    }
-fi
-
 persist_runtime_rollback_metadata()
 {
     local record="$transaction/runtime-rollback-path" rollback_path meta new_meta old_meta
-    local marker marker_tmp parent base target installer_state=absent pipeasio_state=absent
+    local marker marker_tmp parent base target installer_state="$config_rollback_state"
+    local pipeasio_state="$pipeasio_rollback_state"
     local old_moved=0
     [ -r "$record" ] || return 0
     rollback_path="$(sed -n '1p' "$record")" || return 1
@@ -1054,59 +1206,186 @@ persist_runtime_rollback_metadata()
     rm -f -- "$marker" || return 1
 }
 
-# Validate every cleanup domain before any one of them retires its rollback
-# material.  A corrupt or concurrently changed later journal must leave all
-# component, prefix, and Link snapshots available for the ordinary rollback.
-if [ -n "$config_post_token" ] \
-   && [ "$(ableton_object_token "$ABLETON_CONFIG_FILE" 2>/dev/null || true)" != "$config_post_token" ]; then
-    echo "!! installer configuration changed while the transaction was open" >&2
-    exit 1
-fi
+# Validate the core rollback records before discarding any of them.  These
+# records cover only the runtime and prefix; generated desktop and Link files
+# are repaired after this point and cannot invalidate the core install.
 "$here/install.sh" --preflight-commit "$transaction"
 "$here/setup-prefix.sh" --preflight-commit "$transaction"
 if [ "$link_transaction" -eq 1 ]; then
     "$here/setup-link.sh" preflight-commit "$transaction"
 fi
 
-# Every requested component is valid and the persistent configuration is now
-# coherent.  This is the transaction commit point.  The calls below only retire
-# rollback snapshots/backups; a cleanup failure must not attempt restoration
-# from pre-state that another cleanup call may already have discarded.
+# The runtime, prefix, Live installation, and registry are valid.  Nothing
+# below is allowed to roll them back: the remaining work either retires old
+# recovery data or rebuilds optional host integration.
 transaction_complete=1
+# The runtime, prefix, Live payload, and registry have crossed their final
+# postconditions. Keep attempting every optional repair and cleanup step even
+# when a terminal write or another advisory operation fails; the EXIT guard
+# still reports one retry warning for any uncaught final status.
+set +e
 cleanup_status=0
-committed_cleanup_step="versioning the previous runtime"
-"$here/install.sh" --commit "$transaction"
-committed_cleanup_step="sealing runtime rollback metadata"
-persist_runtime_rollback_metadata
-committed_cleanup_step="retiring transaction snapshots"
+component_commit_ok=1
+core_marker_ready=1
+prefix_core_marker_ready=1
+ableton_mark_transaction_core_complete "$transaction" || core_marker_ready=0
+if [ -d "$transaction/prefix-host" ] && [ ! -L "$transaction/prefix-host" ]; then
+    ableton_mark_transaction_core_complete "$transaction/prefix-host" \
+        || prefix_core_marker_ready=0
+fi
+if ! : > "$cleanup_log"; then
+    cleanup_log=/dev/null
+fi
+if ! "$here/install.sh" --commit "$transaction" >> "$cleanup_log" 2>&1; then
+    component_commit_ok=0
+    cleanup_status=1
+fi
+if [ "$component_commit_ok" -eq 1 ] \
+   && ! persist_runtime_rollback_metadata >> "$cleanup_log" 2>&1; then
+    cleanup_status=1
+fi
 if [ "$link_transaction" -eq 1 ]; then
-    "$here/setup-link.sh" commit "$transaction" || cleanup_status=1
+    "$here/setup-link.sh" commit "$transaction" >> "$cleanup_log" 2>&1 || cleanup_status=1
 fi
-"$here/setup-prefix.sh" --commit "$transaction" || cleanup_status=1
-rm -f -- "$transaction/active"
-trap - EXIT
-if [ "$cleanup_status" -ne 0 ]; then
-    printf 'command=%s %s\nstatus=committed-cleanup-incomplete\n' "$command_name" "$subcommand" \
-        > "$transaction/COMMITTED_CLEANUP_FAILURE"
-    echo "!! installation committed, but rollback-snapshot cleanup was incomplete: $transaction/COMMITTED_CLEANUP_FAILURE" >&2
-    exit 1
+"$here/setup-prefix.sh" --commit "$transaction" >> "$cleanup_log" 2>&1 || cleanup_status=1
+if ! rm -f -- "$transaction/active"; then
+    cleanup_status=1
 fi
-if ! rm -rf -- "$transaction"; then
-    printf 'command=%s %s\nstatus=committed-cleanup-incomplete\nstep=retiring transaction directory\n' \
-        "$command_name" "$subcommand" > "$transaction/COMMITTED_CLEANUP_FAILURE" 2>/dev/null || true
-    echo "!! installation committed, but the transaction directory could not be removed: $transaction" >&2
-    exit 1
-fi
-
-echo "OK: $command_name${subcommand:+ $subcommand} completed"
-# runtime install writes no configuration, so it reports only what it touched.
-if [ "$command_name:$subcommand" = runtime:install ]; then
-    printf '  runtime: %s\n' "$ABLETON_WINE_ROOT"
-else
-    printf '  runtime: %s\n  prefix: %s\n' "$ABLETON_WINE_ROOT" "$ABLETON_WINEPREFIX"
-    if [ "$link_setup_failed" -eq 1 ]; then
-        printf '  Link: setup stopped (run: installer link enable --mode=%s)\n' "$ABLETON_LINK_MODE"
-    else
-        printf '  Link: %s\n' "$ABLETON_LINK_MODE"
+if [ "$cleanup_status" -eq 0 ]; then
+    if ! rm -rf -- "$transaction" || [ -e "$transaction" ] || [ -L "$transaction" ]; then
+        cleanup_status=1
     fi
 fi
+if [ "$cleanup_status" -ne 0 ]; then
+    cleanup_ready=0
+    echo "!! The install is ready, but old recovery files could not be removed. They were kept at $transaction." >&2 \
+        || true
+    if { [ "$core_marker_ready" -eq 0 ] \
+         && { [ -e "$transaction/active" ] || [ -L "$transaction/active" ]; }; } \
+       || { [ "$core_marker_ready" -eq 0 ] \
+            && [ "$prefix_core_marker_ready" -eq 0 ] \
+            && { [ -e "$transaction/prefix-host/active" ] \
+                 || [ -L "$transaction/prefix-host/active" ]; }; }; then
+        echo "!! Keep those files and report this cleanup problem before launching Live." >&2 \
+            || true
+    fi
+fi
+
+# Desktop integration and Link are deliberately outside the core transaction.
+# Their files belong to this project and are replaced authoritatively on every
+# run, so a later run is the repair path; failure here never removes Ableton.
+if [ "$command_name" = install ] || [ "$command_name" = update ]; then
+    if [ "$command_name" = update ]; then
+        core_outcome="Ableton is updated"
+    elif [ -n "$live_payload" ]; then
+        core_outcome="Ableton Live $ABLETON_LIVE_VERSION is installed"
+    else
+        core_outcome="The Ableton runtime and Wine prefix are ready"
+    fi
+    ABLETON_LINK_MODE="$desired_link"
+    export ABLETON_LINK_MODE
+    integration_status=0
+    ABLETON_INTERNAL_OPTIONAL_STATUS=1 \
+        "$here/install.sh" --integration-only "${install_args[@]}" \
+        || integration_status=$?
+    case "$integration_status" in
+        0) ;;
+        3)
+            integration_ready=0
+            echo "!! $core_outcome, but some desktop files need another update. Run the installer again to retry them." >&2 \
+                || true ;;
+        *)
+            integration_ready=0
+            echo "!! $core_outcome, but its desktop shortcuts could not be updated. Run the installer again to repair them." >&2 \
+                || true ;;
+    esac
+
+    link_resume_command="$(format_link_resume_command "$desired_link")"
+    if [ "$desired_link" = off ]; then
+        if ABLETON_LINK_COORDINATED=1 "$here/setup-link.sh" disable; then
+            ABLETON_LINK_MODE=off
+        else
+            link_ready=0
+            ABLETON_LINK_MODE="$prior_link"
+            echo "!! $core_outcome, but Link could not be turned off completely. Run the installer again to retry." >&2 \
+                || true
+        fi
+    elif "$here/install.sh" --link-assets-only "${install_args[@]}" \
+         && ABLETON_LINK_COORDINATED=1 "$here/setup-link.sh" enable "--mode=$desired_link"; then
+        ABLETON_LINK_MODE="$desired_link"
+    else
+        link_ready=0
+        ABLETON_LINK_MODE="$prior_link"
+        echo "!! $core_outcome, but Link could not be set up. Retry with: $link_resume_command" >&2 \
+            || true
+    fi
+    export ABLETON_LINK_MODE
+    # Link owns its own requested system change. Its generated preference file
+    # is safe to reload and replace; a stale parent checksum must not add a
+    # second failure path after Link has already finished.
+    unset ABLETON_CONFIG_SNAPSHOT_PATH ABLETON_CONFIG_SNAPSHOT_TOKEN \
+        ABLETON_CONFIG_SNAPSHOT_VALUES
+    if ! ableton_write_config; then
+        settings_ready=0
+        echo "!! $core_outcome, but the installer could not save these settings. Run the installer again to retry." >&2 \
+            || true
+    fi
+elif [ "$command_name:$subcommand" = runtime:install ] \
+     && [ "${ABLETON_CONFIG_REPAIR_NEEDED:-0}" = 1 ]; then
+    if ! ableton_write_config; then
+        settings_ready=0
+        echo "!! Wine is ready, but installer settings could not be saved. Run the same command again to retry." >&2 \
+            || true
+    fi
+elif [ "$command_name:$subcommand" = prefix:create ] \
+     || [ "$command_name:$subcommand" = prefix:update ]; then
+    if ! ableton_write_config; then
+        settings_ready=0
+        echo "!! The Wine prefix is ready, but the installer could not save its location. Run the same command again to retry." >&2 \
+            || true
+    fi
+fi
+
+case "$command_name:$subcommand" in
+    runtime:install)
+        echo "OK: the Wine runtime is installed"
+        printf '  runtime: %s\n' "$ABLETON_WINE_ROOT" ;;
+    install:|update:)
+        printf 'OK: %s\n' "$core_outcome"
+        printf '  runtime: %s\n  prefix: %s\n' "$ABLETON_WINE_ROOT" "$ABLETON_WINEPREFIX"
+        if [ "$integration_ready" -eq 1 ]; then
+            printf '  desktop shortcuts: ready\n'
+        else
+            printf '  desktop shortcuts: retry needed\n'
+        fi
+        if [ "$link_ready" -eq 1 ]; then
+            printf '  Link: %s\n' "$ABLETON_LINK_MODE"
+        else
+            printf '  Link: unchanged; setup can be retried\n'
+        fi
+        if [ "$settings_ready" -eq 1 ]; then
+            printf '  saved settings: ready\n'
+        else
+            printf '  saved settings: retry needed\n'
+        fi
+        if [ "$cleanup_ready" -eq 1 ]; then
+            printf '  old recovery files: removed\n'
+        else
+            printf '  old recovery files: remain at %s\n' "$transaction"
+        fi ;;
+    prefix:create)
+        echo "OK: the Wine prefix is ready"
+        printf '  runtime: %s\n  prefix: %s\n' "$ABLETON_WINE_ROOT" "$ABLETON_WINEPREFIX"
+        [ "$settings_ready" -eq 1 ] || printf '  saved settings: retry needed\n' ;;
+    prefix:update)
+        echo "OK: the Wine prefix is updated"
+        printf '  runtime: %s\n  prefix: %s\n' "$ABLETON_WINE_ROOT" "$ABLETON_WINEPREFIX"
+        [ "$settings_ready" -eq 1 ] || printf '  saved settings: retry needed\n' ;;
+    link:enable)
+        printf 'OK: Ableton Link is enabled (%s)\n' "$ABLETON_LINK_MODE" ;;
+    link:disable)
+        echo "OK: Ableton Link is off" ;;
+    *)
+        echo "OK: requested change completed"
+        printf '  runtime: %s\n  prefix: %s\n' "$ABLETON_WINE_ROOT" "$ABLETON_WINEPREFIX" ;;
+esac

--- a/scripts/lib/config.sh
+++ b/scripts/lib/config.sh
@@ -51,6 +51,7 @@ ableton_state_marker_valid()
 ableton_legacy_shortcut_state_valid()
 {
     local state="$1" expected header schema key original held extra rows=0 nul_count terminal normalized saw_header=0
+    local unexpected=""
     local -A seen=()
     expected="$(ableton_realpath_m "${XDG_STATE_HOME:-$HOME/.local/state}/ableton-wine")" \
         || return 1
@@ -59,8 +60,9 @@ ableton_legacy_shortcut_state_valid()
         && [ "$(stat -c '%a' -- "$state" 2>/dev/null || true)" = 700 ] || return 1
     # The shortcut hold was the sole state object written before ownership
     # markers.  Do not turn a broad basename exception into delete authority.
-    [ "$(find "$state" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)" = hold-v2 ] \
+    unexpected="$(find "$state" -mindepth 1 -maxdepth 1 ! -name hold-v2 -print -quit)" \
         || return 1
+    [ -z "$unexpected" ] && [ -e "$state/hold-v2" ] || return 1
     [ -f "$state/hold-v2" ] && [ ! -L "$state/hold-v2" ] \
         && [ -O "$state/hold-v2" ] && [ -r "$state/hold-v2" ] \
         && [ "$(stat -c '%a' -- "$state/hold-v2" 2>/dev/null || true)" = 600 ] || return 1
@@ -214,49 +216,91 @@ ableton_require_home()
 
 ableton_config_object_token()
 {
-    local path="$1" literal referent referent_token
+    local path="$1" literal referent referent_token object_stat digest
     if [ -L "$path" ]; then
         literal="$(readlink -n -- "$path")" || return 1
         referent="$(readlink -f -- "$path" 2>/dev/null || true)"
         if [ -n "$referent" ] && [ -f "$referent" ] && [ ! -L "$referent" ]; then
-            referent_token="file:$(sha256sum -- "$referent" | awk '{print $1}')"
+            digest="$(sha256sum -- "$referent" 2>/dev/null)" || digest=""
+            digest="${digest%% *}"
+            if [[ "$digest" =~ ^[0-9a-f]{64}$ ]]; then
+                referent_token="file:$digest"
+            else
+                object_stat="$(LC_ALL=C stat -c '%d:%i:%f:%s:%Y:%Z' -- "$path")" \
+                    || return 1
+                referent_token="unreadable:$object_stat"
+            fi
         elif [ -z "$referent" ]; then
             referent_token=dangling
         else
-            return 1
+            object_stat="$(LC_ALL=C stat -c '%d:%i:%f:%s:%Y:%Z' -- "$path")" \
+                || return 1
+            referent_token="nonfile:$object_stat"
         fi
         { printf 'symlink\0%s\0%s\n' "$literal" "$referent_token"; } \
             | sha256sum | awk '{print "symlink:"$1}'
     elif [ -f "$path" ]; then
-        sha256sum -- "$path" | awk '{print "file:"$1}'
+        digest="$(sha256sum -- "$path" 2>/dev/null)" || digest=""
+        digest="${digest%% *}"
+        if [[ "$digest" =~ ^[0-9a-f]{64}$ ]]; then
+            printf 'file:%s\n' "$digest"
+        else
+            object_stat="$(LC_ALL=C stat -c '%d:%i:%f:%s:%Y:%Z' -- "$path")" \
+                || return 1
+            printf 'unreadable-file:%s\n' "$object_stat"
+        fi
     elif [ ! -e "$path" ]; then
         printf 'absent\n'
     else
-        return 1
+        object_stat="$(LC_ALL=C stat -c '%d:%i:%f:%s:%Y:%Z' -- "$path")" \
+            || return 1
+        printf 'nonfile:%s\n' "$object_stat"
     fi
 }
 
 ableton_config_snapshot_capture()
 {
-    ABLETON_CONFIG_SNAPSHOT_PATH="$ABLETON_CONFIG_FILE"
-    ABLETON_CONFIG_SNAPSHOT_TOKEN="$(ableton_config_object_token "$ABLETON_CONFIG_FILE")" || return 1
-    ABLETON_CONFIG_SNAPSHOT_VALUES="$(printf '%s\n' \
+    local bound_token="${1:-}" values_record snapshot_path snapshot_token snapshot_values
+    snapshot_path="$ABLETON_CONFIG_FILE"
+    if [ -n "$bound_token" ]; then
+        snapshot_token="$bound_token"
+    else
+        snapshot_token="$(ableton_config_object_token "$ABLETON_CONFIG_FILE")" \
+            || return 1
+    fi
+    values_record="$(printf '%s\n' \
         "$ABLETON_WINE_ROOT" "$ABLETON_WINEPREFIX" "$ABLETON_LINKD" "$ABLETON_LINK_MODE" \
         "$ABLETON_DATA_HOME" "$ABLETON_CONFIG_HOME" "$ABLETON_STATE_HOME" \
-        "$ABLETON_CACHE_HOME" "$ABLETON_BIN_HOME" | sha256sum | awk '{print $1}')"
+        "$ABLETON_CACHE_HOME" "$ABLETON_BIN_HOME" | sha256sum)" || return 1
+    snapshot_values="${values_record%% *}"
+    [[ "$snapshot_values" =~ ^[0-9a-f]{64}$ ]] || return 1
+    # Publish the snapshot only after every field is ready. A failed recapture
+    # must leave the prior complete record intact, never a mixed partial one.
+    ABLETON_CONFIG_SNAPSHOT_PATH="$snapshot_path"
+    ABLETON_CONFIG_SNAPSHOT_TOKEN="$snapshot_token"
+    ABLETON_CONFIG_SNAPSHOT_VALUES="$snapshot_values"
     export ABLETON_CONFIG_SNAPSHOT_PATH ABLETON_CONFIG_SNAPSHOT_TOKEN ABLETON_CONFIG_SNAPSHOT_VALUES
 }
 
 ableton_config_snapshot_verify()
 {
-    local token values
-    [ -n "${ABLETON_CONFIG_SNAPSHOT_PATH:-}" ] || return 0
+    local token values values_record
+    if [ -z "${ABLETON_CONFIG_SNAPSHOT_PATH:-}" ] \
+       && [ -z "${ABLETON_CONFIG_SNAPSHOT_TOKEN:-}" ] \
+       && [ -z "${ABLETON_CONFIG_SNAPSHOT_VALUES:-}" ]; then
+        return 0
+    fi
+    [ -n "${ABLETON_CONFIG_SNAPSHOT_PATH:-}" ] \
+        && [ -n "${ABLETON_CONFIG_SNAPSHOT_TOKEN:-}" ] \
+        && [ -n "${ABLETON_CONFIG_SNAPSHOT_VALUES:-}" ] || return 1
     [ "$ABLETON_CONFIG_FILE" = "$ABLETON_CONFIG_SNAPSHOT_PATH" ] || return 1
     token="$(ableton_config_object_token "$ABLETON_CONFIG_FILE")" || return 1
-    values="$(printf '%s\n' \
+    values_record="$(printf '%s\n' \
         "$ABLETON_WINE_ROOT" "$ABLETON_WINEPREFIX" "$ABLETON_LINKD" "$ABLETON_LINK_MODE" \
         "$ABLETON_DATA_HOME" "$ABLETON_CONFIG_HOME" "$ABLETON_STATE_HOME" \
-        "$ABLETON_CACHE_HOME" "$ABLETON_BIN_HOME" | sha256sum | awk '{print $1}')"
+        "$ABLETON_CACHE_HOME" "$ABLETON_BIN_HOME" | sha256sum)" || return 1
+    values="${values_record%% *}"
+    [[ "$values" =~ ^[0-9a-f]{64}$ ]] || return 1
     [ "$token" = "$ABLETON_CONFIG_SNAPSHOT_TOKEN" ] \
         && [ "$values" = "$ABLETON_CONFIG_SNAPSHOT_VALUES" ]
 }
@@ -312,8 +356,155 @@ ableton_managed_config_valid()
         && [ -n "${seen[linkd]+x}" ]
 }
 
+# A project-written config may become invalid when a newer installer removes a
+# field or an interrupted older writer leaves the tail incomplete.  Repair mode
+# can still recover each unambiguous, syntactically safe known value from a
+# regular file that has this project's exact header and one format=1 field.
+# Unknown, duplicate, or invalid values are ignored independently.
+ableton_config_salvage_values()
+{
+    local file="$1" line key value header="" format_count=0 format_value=""
+    local -A counts=() values=()
+    ABLETON_CONFIG_REPAIR_RUNTIME_ROOT=""
+    ABLETON_CONFIG_REPAIR_PREFIX=""
+    ABLETON_CONFIG_REPAIR_LIVE_MAJOR=""
+    ABLETON_CONFIG_REPAIR_LINK_MODE=""
+    ABLETON_CONFIG_REPAIR_LINKD=""
+    [ -f "$file" ] && [ ! -L "$file" ] && [ -r "$file" ] || return 1
+    [ "$(LC_ALL=C tr -cd '\000' < "$file" 2>/dev/null | wc -c)" -eq 0 ] || return 1
+    IFS= read -r header < "$file" || return 1
+    [ "$header" = '# ableton-linux installer configuration; managed by the installer' ] \
+        || return 1
+    while IFS= read -r line || [ -n "$line" ]; do
+        [ "$line" != "$header" ] || continue
+        case "$line" in *=*) ;; *) continue ;; esac
+        key="${line%%=*}"
+        value="${line#*=}"
+        case "$key" in
+            format)
+                format_count=$((format_count + 1))
+                format_value="$value" ;;
+            runtime_root|prefix|live_major|link_mode|linkd)
+                counts["$key"]=$(( ${counts[$key]:-0} + 1 ))
+                values["$key"]="$value" ;;
+        esac
+    done < "$file"
+    [ "$format_count" -eq 1 ] && [ "$format_value" = 1 ] || return 1
+
+    if [ "${counts[runtime_root]:-0}" -eq 1 ]; then
+        value="${values[runtime_root]}"
+        case "$value" in /*) case "$value" in *$'\n'*|*$'\r'*|*$'\t'*) ;; *) ABLETON_CONFIG_REPAIR_RUNTIME_ROOT="$value" ;; esac ;; esac
+    fi
+    if [ "${counts[prefix]:-0}" -eq 1 ]; then
+        value="${values[prefix]}"
+        case "$value" in /*) case "$value" in *$'\n'*|*$'\r'*|*$'\t'*) ;; *) ABLETON_CONFIG_REPAIR_PREFIX="$value" ;; esac ;; esac
+    fi
+    if [ "${counts[live_major]:-0}" -eq 1 ]; then
+        case "${values[live_major]}" in
+            11|12) ABLETON_CONFIG_REPAIR_LIVE_MAJOR="${values[live_major]}" ;;
+        esac
+    fi
+    if [ "${counts[link_mode]:-0}" -eq 1 ]; then
+        case "${values[link_mode]}" in
+            off|session|always) ABLETON_CONFIG_REPAIR_LINK_MODE="${values[link_mode]}" ;;
+        esac
+    fi
+    if [ "${counts[linkd]:-0}" -eq 1 ]; then
+        value="${values[linkd]}"
+        case "$value" in /*) case "$value" in *$'\n'*|*$'\r'*|*$'\t'*) ;; *) ABLETON_CONFIG_REPAIR_LINKD="$value" ;; esac ;; esac
+    fi
+}
+
+ableton_config_validate_layout()
+{
+    local requested="${1:-runtime prefix data config state bin}"
+    local name configured first second i j
+    local -a checked_paths=() independent_paths=()
+    local -A seen=()
+    [ "$requested" != none ] || return 0
+    for name in $requested; do
+        [ -z "${seen[$name]+x}" ] || continue
+        seen["$name"]=1
+        case "$name" in
+            runtime) configured="$ABLETON_WINE_ROOT" ;;
+            prefix) configured="$ABLETON_WINEPREFIX" ;;
+            data) configured="$ABLETON_DATA_HOME" ;;
+            config) configured="$ABLETON_CONFIG_HOME" ;;
+            state) configured="$ABLETON_STATE_HOME" ;;
+            bin) configured="$ABLETON_BIN_HOME" ;;
+            *) ableton_config_error "unknown installation layout root: $name"; return 1 ;;
+        esac
+        checked_paths+=("$configured")
+        [ "$name" = bin ] || independent_paths+=("$configured")
+    done
+    for configured in "${checked_paths[@]}"; do
+        if [ -e "$configured" ] || [ -L "$configured" ]; then
+            [ -d "$configured" ] && [ ! -L "$configured" ] || {
+                ableton_config_error "installation directory path is not a real directory: $configured"
+                return 1
+            }
+        fi
+    done
+    for ((i=0; i<${#independent_paths[@]}; i++)); do
+        first="$(ableton_realpath_m "${independent_paths[i]}")" || return 1
+        for ((j=i+1; j<${#independent_paths[@]}; j++)); do
+            second="$(ableton_realpath_m "${independent_paths[j]}")" || return 1
+            if [ "$first" = "$second" ] || [[ "$first" = "$second/"* ]] \
+               || [[ "$second" = "$first/"* ]]; then
+                ableton_config_error "installation roots overlap: $first and $second"
+                return 1
+            fi
+        done
+    done
+}
+
+ableton_config_paths_overlap()
+{
+    local first="$1" second="$2"
+    [ "$first" = "$second" ] || [[ "$first" = "$second/"* ]] \
+        || [[ "$second" = "$first/"* ]]
+}
+
+ableton_config_validate_write_layout()
+{
+    local protected
+    # The writer uses CONFIG_HOME for its temporary file even when callers
+    # select a custom CONFIG_FILE elsewhere, so both concrete destinations must
+    # stay separate from every independently managed tree. The other roots are
+    # compared as paths only: an unrelated stale object there is not a reason to
+    # withhold otherwise safe installer settings.
+    ableton_config_validate_layout config || return 1
+    for protected in "$ABLETON_WINE_ROOT" "$ABLETON_WINEPREFIX" \
+                     "$ABLETON_DATA_HOME" "$ABLETON_STATE_HOME" \
+                     "$ABLETON_CACHE_HOME"; do
+        if ableton_config_paths_overlap "$ABLETON_CONFIG_HOME" "$protected" \
+           || ableton_config_paths_overlap "$ABLETON_CONFIG_FILE" "$protected"; then
+            ableton_config_error "installer configuration path overlaps another installation path: $protected"
+            return 1
+        fi
+    done
+}
+
 ableton_config_init()
 {
+    local requested_mode="${1:-}" repair_mode=0 config_valid=1
+    case "$requested_mode" in
+        repair) repair_mode=1 ;;
+        strict)
+            unset ABLETON_CONFIG_REPAIR_MODE ABLETON_CONFIG_REPAIR_NEEDED ;;
+        '') ;;
+        *) ableton_config_error "unknown installer configuration mode: $requested_mode"; return 1 ;;
+    esac
+    if [ -z "$requested_mode" ] \
+       && [ "${ABLETON_CONFIG_REPAIR_MODE:-0}" = 1 ] \
+       && [ -n "${ABLETON_CONFIG_SNAPSHOT_PATH:-}" ] \
+       && [ -n "${ABLETON_CONFIG_SNAPSHOT_TOKEN:-}" ] \
+       && [ -n "${ABLETON_CONFIG_SNAPSHOT_VALUES:-}" ]; then
+        repair_mode=1
+    fi
+    if [ "$repair_mode" -eq 1 ]; then
+        ABLETON_CONFIG_REPAIR_NEEDED=0
+    fi
     ableton_require_home || return 1
 
     : "${ABLETON_DATA_HOME:=${XDG_DATA_HOME:-$HOME/.local/share}/ableton-wine}"
@@ -322,27 +513,51 @@ ableton_config_init()
     : "${ABLETON_CACHE_HOME:=${XDG_CACHE_HOME:-$HOME/.cache}/ableton-wine}"
     : "${ABLETON_BIN_HOME:=$HOME/.local/bin}"
     : "${ABLETON_CONFIG_FILE:=$ABLETON_CONFIG_HOME/config}"
-    local config_file_name config_file_parent
+    local config_file_name config_file_parent config_generation_before config_generation_after
     config_file_name="$(basename -- "$ABLETON_CONFIG_FILE")" || return 1
     config_file_parent="$(dirname -- "$ABLETON_CONFIG_FILE")" || return 1
+    config_generation_before="$(ableton_config_object_token "$ABLETON_CONFIG_FILE")" || {
+        ableton_config_error "cannot read installer configuration $ABLETON_CONFIG_FILE"
+        return 1
+    }
     if [ -e "$ABLETON_CONFIG_FILE" ] || [ -L "$ABLETON_CONFIG_FILE" ]; then
-        ableton_managed_config_valid "$ABLETON_CONFIG_FILE" || {
-            ableton_config_error "refusing malformed installer configuration $ABLETON_CONFIG_FILE"
-            return 1
-        }
+        if ! ableton_managed_config_valid "$ABLETON_CONFIG_FILE"; then
+            config_valid=0
+            if [ "$repair_mode" -ne 1 ]; then
+                ableton_config_error "refusing malformed installer configuration $ABLETON_CONFIG_FILE"
+                return 1
+            fi
+            ABLETON_CONFIG_REPAIR_NEEDED=1
+            ableton_config_salvage_values "$ABLETON_CONFIG_FILE" 2>/dev/null || true
+        fi
     fi
 
     local configured
     if [ -z "${ABLETON_WINE_ROOT+x}" ]; then
-        configured="$(ableton_config_file_value runtime_root 2>/dev/null || true)"
+        configured=""
+        if [ "$config_valid" -eq 1 ]; then
+            configured="$(ableton_config_file_value runtime_root 2>/dev/null || true)"
+        elif [ "$repair_mode" -eq 1 ]; then
+            configured="${ABLETON_CONFIG_REPAIR_RUNTIME_ROOT:-}"
+        fi
         ABLETON_WINE_ROOT="${configured:-$HOME/.local/opt/$ABLETON_RUNTIME_NAME}"
     fi
     if [ -z "${ABLETON_WINEPREFIX+x}" ]; then
-        configured="$(ableton_config_file_value prefix 2>/dev/null || true)"
+        configured=""
+        if [ "$config_valid" -eq 1 ]; then
+            configured="$(ableton_config_file_value prefix 2>/dev/null || true)"
+        elif [ "$repair_mode" -eq 1 ]; then
+            configured="${ABLETON_CONFIG_REPAIR_PREFIX:-}"
+        fi
         ABLETON_WINEPREFIX="${configured:-$HOME/.wine-ableton}"
     fi
     if [ -z "${ABLETON_LINK_MODE+x}" ]; then
-        configured="$(ableton_config_file_value link_mode 2>/dev/null || true)"
+        configured=""
+        if [ "$config_valid" -eq 1 ]; then
+            configured="$(ableton_config_file_value link_mode 2>/dev/null || true)"
+        elif [ "$repair_mode" -eq 1 ]; then
+            configured="${ABLETON_CONFIG_REPAIR_LINK_MODE:-}"
+        fi
         if [ -z "$configured" ]; then
             case "$(sed -n '1p' "$ABLETON_DATA_HOME/link-configured" 2>/dev/null || true)" in
                 configured) configured=session ;;
@@ -355,12 +570,35 @@ ableton_config_init()
         ABLETON_LINK_MODE="${configured:-off}"
     fi
     if [ -z "${ABLETON_LIVE_VERSION+x}" ]; then
-        configured="$(ableton_config_file_value live_major 2>/dev/null || true)"
+        configured=""
+        if [ "$config_valid" -eq 1 ]; then
+            configured="$(ableton_config_file_value live_major 2>/dev/null || true)"
+        elif [ "$repair_mode" -eq 1 ]; then
+            configured="${ABLETON_CONFIG_REPAIR_LIVE_MAJOR:-}"
+        fi
         [ -z "$configured" ] || ABLETON_LIVE_VERSION="$configured"
     fi
     if [ -z "${ABLETON_LINKD+x}" ]; then
-        configured="$(ableton_config_file_value linkd 2>/dev/null || true)"
+        configured=""
+        if [ "$config_valid" -eq 1 ]; then
+            configured="$(ableton_config_file_value linkd 2>/dev/null || true)"
+        elif [ "$repair_mode" -eq 1 ]; then
+            configured="${ABLETON_CONFIG_REPAIR_LINKD:-}"
+        fi
         ABLETON_LINKD="${configured:-$ABLETON_DATA_HOME/ableton-linkd}"
+    fi
+
+    # The managed file is replaced atomically by compliant writers. Bind every
+    # field read above to the generation that was present before parsing; a
+    # replacement between individual reads must not produce a mixed A/B
+    # configuration whose final B token is then treated as authoritative.
+    config_generation_after="$(ableton_config_object_token "$ABLETON_CONFIG_FILE")" || {
+        ableton_config_error "cannot reread installer configuration $ABLETON_CONFIG_FILE"
+        return 1
+    }
+    if [ "$config_generation_after" != "$config_generation_before" ]; then
+        ableton_config_error "installation configuration changed while it was being read; retry the command"
+        return 1
     fi
 
     case "$ABLETON_LINK_MODE" in off|session|always) ;;
@@ -389,40 +627,29 @@ ableton_config_init()
     ABLETON_CONFIG_FILE="$config_file_parent/$config_file_name"
     ABLETON_LINKD="$(ableton_realpath_m "$ABLETON_LINKD")" || return 1
 
-    # Paths are canonicalized first, so an intentional XDG/root symlink is a
-    # projection to this resolved directory: lifecycle code mutates only the
-    # resolved child and never removes the user's symlink.  At the concrete
-    # target, however, every directory root must be absent or a real directory.
-    for configured in "$ABLETON_WINE_ROOT" "$ABLETON_WINEPREFIX" "$ABLETON_DATA_HOME" \
-                      "$ABLETON_CONFIG_HOME" "$ABLETON_STATE_HOME" "$ABLETON_CACHE_HOME" \
-                      "$ABLETON_BIN_HOME"; do
-        if [ -e "$configured" ] || [ -L "$configured" ]; then
-            [ -d "$configured" ] && [ ! -L "$configured" ] || {
-                ableton_config_error "installation directory path is not a real directory: $configured"
-                return 1
-            }
-        fi
-    done
-
-    local -a independent_paths=("$ABLETON_WINE_ROOT" "$ABLETON_WINEPREFIX" "$ABLETON_DATA_HOME" \
-        "$ABLETON_CONFIG_HOME" "$ABLETON_STATE_HOME" "$ABLETON_CACHE_HOME")
-    local i j first second
-    for ((i=0; i<${#independent_paths[@]}; i++)); do
-        first="$(ableton_realpath_m "${independent_paths[i]}")" || return 1
-        for ((j=i+1; j<${#independent_paths[@]}; j++)); do
-            second="$(ableton_realpath_m "${independent_paths[j]}")" || return 1
-            if [ "$first" = "$second" ] || [[ "$first" = "$second/"* ]] || [[ "$second" = "$first/"* ]]; then
-                ableton_config_error "installation roots overlap: $first and $second"
-                return 1
-            fi
-        done
-    done
+    # Callers select only the roots their current operation will actually use.
+    # This keeps destructive-layout checks strict without letting an unrelated
+    # desktop/config/cache location veto core runtime work.
+    ableton_config_validate_layout \
+        "${ABLETON_CONFIG_LAYOUT_ROOTS:-runtime prefix data config state bin}" || return 1
 
     export ABLETON_WINE_ROOT ABLETON_WINEPREFIX ABLETON_LINK_MODE ABLETON_LINKD
     export ABLETON_DATA_HOME ABLETON_CONFIG_HOME ABLETON_STATE_HOME ABLETON_CACHE_HOME
     export ABLETON_BIN_HOME ABLETON_CONFIG_FILE
+    export ABLETON_CONFIG_LAYOUT_ROOTS
     export ABLETON_PROTOCOL_DESKTOP_ID ABLETON_AUZ_DESKTOP_ID
-    [ -n "${ABLETON_CONFIG_SNAPSHOT_PATH:-}" ] || ableton_config_snapshot_capture
+    if [ "$repair_mode" -eq 1 ]; then
+        ABLETON_CONFIG_REPAIR_MODE=1
+        : "${ABLETON_CONFIG_REPAIR_NEEDED:=0}"
+        export ABLETON_CONFIG_REPAIR_MODE ABLETON_CONFIG_REPAIR_NEEDED
+    fi
+    if [ -z "${ABLETON_CONFIG_SNAPSHOT_PATH:-}" ] \
+       || [ -z "${ABLETON_CONFIG_SNAPSHOT_TOKEN:-}" ] \
+       || [ -z "${ABLETON_CONFIG_SNAPSHOT_VALUES:-}" ]; then
+        # Treat the exported snapshot as one record. A partial inherited
+        # environment must be replaced, never trusted or expanded under set -u.
+        ableton_config_snapshot_capture "$config_generation_before"
+    fi
 }
 
 ableton_render_config()
@@ -444,8 +671,16 @@ ableton_expected_config_token()
 
 ableton_write_config()
 {
-    ableton_config_init || return 1
+    if [ "${ABLETON_CONFIG_REPAIR_MODE:-0}" = 1 ]; then
+        ableton_config_init repair || return 1
+    else
+        ableton_config_init || return 1
+    fi
     local tmp
+    # Configuration is optional after the core operation commits, but writing
+    # it must still stay outside every independently managed tree. Callers may
+    # have selected a narrower core-only layout during initialisation.
+    ableton_config_validate_write_layout || return 1
     if [ -d "$ABLETON_CONFIG_FILE" ] && [ ! -L "$ABLETON_CONFIG_FILE" ]; then
         ableton_config_error "refusing to replace configuration directory $ABLETON_CONFIG_FILE"
         return 1
@@ -454,6 +689,14 @@ ableton_write_config()
         ableton_config_error "refusing symlink installer configuration $ABLETON_CONFIG_FILE"
         return 1
     fi
+    if [ -e "$ABLETON_CONFIG_FILE" ] && [ ! -f "$ABLETON_CONFIG_FILE" ]; then
+        ableton_config_error "refusing to replace non-file installer configuration $ABLETON_CONFIG_FILE"
+        return 1
+    fi
+    ableton_config_snapshot_verify || {
+        ableton_config_error "installation configuration changed; retry the command"
+        return 1
+    }
     mkdir -p -- "$ABLETON_CONFIG_HOME" || return 1
     tmp="$(mktemp "$ABLETON_CONFIG_HOME/.config.XXXXXX")" || return 1
     if ! chmod 600 "$tmp" \
@@ -464,12 +707,18 @@ ableton_write_config()
         rm -f -- "$tmp"
         return 1
     fi
+    ABLETON_CONFIG_REPAIR_NEEDED=0
+    export ABLETON_CONFIG_REPAIR_NEEDED
 }
 
 ableton_mark_state_home()
 {
-    local marker marker_tmp
-    ableton_config_init || return 1
+    local marker marker_tmp first_entry=""
+    if [ "${ABLETON_CONFIG_REPAIR_MODE:-0}" = 1 ]; then
+        ableton_config_init repair || return 1
+    else
+        ableton_config_init || return 1
+    fi
     marker="$ABLETON_STATE_HOME/.ableton-linux-state"
     if [ -e "$marker" ] || [ -L "$marker" ]; then
         ableton_state_marker_valid "$ABLETON_STATE_HOME" || {
@@ -478,12 +727,17 @@ ableton_mark_state_home()
         }
         return 0
     fi
-    if [ -d "$ABLETON_STATE_HOME" ] \
-       && find "$ABLETON_STATE_HOME" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
-        ableton_legacy_shortcut_state_valid "$ABLETON_STATE_HOME" || {
-            ableton_config_error "refusing to claim nonempty unmarked state directory $ABLETON_STATE_HOME"
+    if [ -d "$ABLETON_STATE_HOME" ]; then
+        if ! first_entry="$(find "$ABLETON_STATE_HOME" -mindepth 1 -maxdepth 1 -print -quit)"; then
+            ableton_config_error "cannot inspect the existing installation state directory $ABLETON_STATE_HOME"
             return 1
-        }
+        fi
+        if [ -n "$first_entry" ]; then
+            ableton_legacy_shortcut_state_valid "$ABLETON_STATE_HOME" || {
+                ableton_config_error "refusing to claim nonempty unmarked state directory $ABLETON_STATE_HOME"
+                return 1
+            }
+        fi
     fi
     mkdir -p -- "$ABLETON_STATE_HOME"
     marker_tmp="$(mktemp "$ABLETON_STATE_HOME/.state-marker.XXXXXX")" || return 1
@@ -497,6 +751,32 @@ ableton_mark_state_home()
     fi
 }
 
+ableton_prepare_transactions_dir()
+{
+    local transactions="$ABLETON_STATE_HOME/transactions"
+    ableton_mark_state_home || return 1
+    # The exact state marker proves this child belongs to the project. Repair a
+    # stale non-directory left by our own older work, but never follow or replace
+    # a symlink and never act beneath an unproven state root.
+    ableton_state_marker_valid "$ABLETON_STATE_HOME" || return 1
+    if [ -L "$transactions" ]; then
+        ableton_config_error "refusing symlink installer work directory $transactions"
+        return 1
+    fi
+    if [ -e "$transactions" ] && [ ! -d "$transactions" ]; then
+        rm -f -- "$transactions" 2>/dev/null || true
+        if [ -e "$transactions" ] || [ -L "$transactions" ]; then
+            ableton_config_error "cannot replace stale installer work file $transactions"
+            return 1
+        fi
+    fi
+    mkdir -p -- "$transactions" 2>/dev/null || true
+    [ -d "$transactions" ] && [ ! -L "$transactions" ] || {
+        ableton_config_error "cannot prepare installer work directory $transactions"
+        return 1
+    }
+}
+
 # Serialize every lifecycle mutation for this user on one existing directory.
 # Runtime-only work therefore creates no state, yet cannot race a full install.
 # Child helpers validate and reuse the inherited descriptor.
@@ -507,15 +787,20 @@ ableton_install_lock_acquire()
         ableton_config_error "flock is required to change this installation"
         return 1
     }
-    [ ! -L "$ABLETON_CONFIG_FILE" ] || {
-        ableton_config_error "refusing symlink installer configuration $ABLETON_CONFIG_FILE"
-        return 1
-    }
-    if [ -e "$ABLETON_CONFIG_FILE" ]; then
-        ableton_managed_config_valid "$ABLETON_CONFIG_FILE" || {
-            ableton_config_error "refusing malformed installer configuration $ABLETON_CONFIG_FILE"
+    if [ "${ABLETON_CONFIG_REPAIR_MODE:-0}" != 1 ] \
+       || [ -z "${ABLETON_CONFIG_SNAPSHOT_PATH:-}" ] \
+       || [ -z "${ABLETON_CONFIG_SNAPSHOT_TOKEN:-}" ] \
+       || [ -z "${ABLETON_CONFIG_SNAPSHOT_VALUES:-}" ]; then
+        [ ! -L "$ABLETON_CONFIG_FILE" ] || {
+            ableton_config_error "refusing symlink installer configuration $ABLETON_CONFIG_FILE"
             return 1
         }
+        if [ -e "$ABLETON_CONFIG_FILE" ]; then
+            ableton_managed_config_valid "$ABLETON_CONFIG_FILE" || {
+                ableton_config_error "refusing malformed installer configuration $ABLETON_CONFIG_FILE"
+                return 1
+            }
+        fi
     fi
     expected="$(ableton_realpath_m "$HOME")" || return 1
     [ -d "$expected" ] && [ ! -L "$expected" ] || {
@@ -525,8 +810,12 @@ ableton_install_lock_acquire()
     case "$inherited" in
         ''|*[!0-9]*) ;;
         *)
-            observed="$(readlink -f -- "/proc/$$/fd/$inherited" 2>/dev/null || true)"
+            observed="$(readlink -f -- "/proc/${BASHPID:-$$}/fd/$inherited" 2>/dev/null || true)"
             if [ "$observed" = "$expected" ] && flock -n "$inherited"; then
+                ableton_config_snapshot_verify || {
+                    ableton_config_error "installation configuration changed; retry the command"
+                    return 1
+                }
                 return 0
             fi
             ;;
@@ -537,15 +826,51 @@ ableton_install_lock_acquire()
     }
     if ! flock -n "$lock_fd"; then
         exec {lock_fd}<&-
-        ableton_config_error "another installer, rollback, or uninstall is already running"
+        ableton_config_error "Another Ableton Linux install, repair, or removal is already running. Wait for it to finish and try again."
         return 1
     fi
     ABLETON_INSTALL_LOCK_FD="$lock_fd"
     export ABLETON_INSTALL_LOCK_FD
+    # Deliberately not exported. An exec'd child may validate and reuse the
+    # inherited descriptor, but only the shell that opened it may issue
+    # LOCK_UN. BASHPID also distinguishes a forked Bash subshell from its parent.
+    ABLETON_INSTALL_LOCK_OWNER_BASHPID="${BASHPID:-$$}"
     ableton_config_snapshot_verify || {
         ableton_config_error "installation configuration changed; retry the command"
+        flock -u "$lock_fd" 2>/dev/null || true
+        exec {lock_fd}<&-
+        unset ABLETON_INSTALL_LOCK_FD ABLETON_INSTALL_LOCK_OWNER_BASHPID
         return 1
     }
+}
+
+# Launchers briefly participate in the lifecycle lock while they repair host
+# integration and bring a Wine prefix up.  A spawned Wine/background process
+# must close its inherited copy while the launcher keeps the lock; otherwise it
+# can retain the installation lock for the whole application session.
+ableton_install_lock_close_in_child()
+{
+    local inherited="${ABLETON_INSTALL_LOCK_FD:-}" observed expected
+    case "$inherited" in ''|*[!0-9]*) return 0 ;; esac
+    observed="$(readlink -f -- "/proc/${BASHPID:-$$}/fd/$inherited" 2>/dev/null || true)"
+    expected="$(ableton_realpath_m "$HOME" 2>/dev/null || true)"
+    [ -n "$expected" ] && [ "$observed" = "$expected" ] || return 1
+    exec {inherited}<&- || return 1
+    unset ABLETON_INSTALL_LOCK_FD ABLETON_INSTALL_LOCK_OWNER_BASHPID
+}
+
+ableton_install_lock_release()
+{
+    local inherited="${ABLETON_INSTALL_LOCK_FD:-}" observed expected rc=0
+    case "$inherited" in ''|*[!0-9]*) return 0 ;; esac
+    [ "${ABLETON_INSTALL_LOCK_OWNER_BASHPID:-}" = "${BASHPID:-$$}" ] || return 1
+    observed="$(readlink -f -- "/proc/${BASHPID:-$$}/fd/$inherited" 2>/dev/null || true)"
+    expected="$(ableton_realpath_m "$HOME" 2>/dev/null || true)"
+    [ -n "$expected" ] && [ "$observed" = "$expected" ] || return 1
+    flock -u "$inherited" || rc=1
+    exec {inherited}<&- || rc=1
+    unset ABLETON_INSTALL_LOCK_FD ABLETON_INSTALL_LOCK_OWNER_BASHPID
+    return "$rc"
 }
 
 ableton_timeout_value()
@@ -561,7 +886,7 @@ ableton_timeout_value()
 
 ableton_run_bounded()
 {
-    local seconds="$1" inherited observed expected; shift
+    local seconds="$1"; shift
     seconds="$(ableton_timeout_value "$seconds" timeout 1 86400)" || return 2
     command -v timeout >/dev/null 2>&1 || {
         ableton_config_error "GNU timeout is required to supervise external processes"
@@ -571,18 +896,7 @@ ableton_run_bounded()
     # commands start. Wine helpers can start background processes that would
     # keep later lifecycle commands locked after this process exits.
     (
-        inherited="${ABLETON_INSTALL_LOCK_FD:-}"
-        case "$inherited" in
-            ''|*[!0-9]*) ;;
-            *)
-                observed="$(readlink -f -- "/proc/${BASHPID:-$$}/fd/$inherited" 2>/dev/null || true)"
-                expected="$(ableton_realpath_m "$HOME" 2>/dev/null || true)"
-                if [ -n "$expected" ] && [ "$observed" = "$expected" ]; then
-                    exec {inherited}<&-
-                    unset ABLETON_INSTALL_LOCK_FD
-                fi
-                ;;
-        esac
+        ableton_install_lock_close_in_child || exit 125
         exec timeout --signal=TERM --kill-after=5s "${seconds}s" "$@"
     )
 }

--- a/scripts/lib/lifecycle.sh
+++ b/scripts/lib/lifecycle.sh
@@ -58,6 +58,35 @@ ableton_prefix_pids()
     return 0
 }
 
+# Prefix promotion is different from ordinary session management: moving the
+# directory is unsafe even when the process using it came from stock Wine or a
+# runtime generation that has just been replaced. Match the exact WINEPREFIX
+# environment value first, then accept only resolved Wine executable names.
+# The normal lifecycle walkers remain runtime-scoped so stop/report operations
+# never act on a foreign Wine installation.
+ableton_prefix_wine_processes_any_runtime()
+{
+    local prefix="${1:-$ABLETON_WINEPREFIX}" selected_runtime="${2:-$ABLETON_WINE_ROOT}"
+    local proc pid exe image
+    while IFS= read -r -d '' proc; do
+        pid="${proc#/proc/}"
+        pid="${pid%/environ}"
+        exe="$(readlink -f -- "/proc/$pid/exe" 2>/dev/null || true)"
+        [ -n "$exe" ] || continue
+        image="${exe##*/}"
+        if ableton_pid_uses_runtime "$pid" "$selected_runtime"; then
+            printf '%s\t%q\n' "$pid" "$exe"
+            continue
+        fi
+        case "$image" in
+            wine|wine64|wine-preloader|wine64-preloader|wineserver|wineserver64|.wine-wrapped)
+                printf '%s\t%q\n' "$pid" "$exe"
+                ;;
+        esac
+    done < <(grep -rzlFx --null "WINEPREFIX=$prefix" /proc/[0-9]*/environ 2>/dev/null)
+    return 0
+}
+
 ableton_runtime_pids()
 {
     local root="${1:-$ABLETON_WINE_ROOT}" proc pid
@@ -98,16 +127,19 @@ ableton_max_pids()
 
 ableton_live_running()
 {
-    local pid
-    pid="$(ableton_live_pids | head -n 1)"
-    [ -n "$pid" ]
+    local pids
+    # Consume the walker completely. `head -n 1` can return while the producer
+    # still owns inherited launcher descriptors, briefly retaining the global or
+    # bring-up lock after the parent has released its copies.
+    pids="$(ableton_live_pids)"
+    [ -n "$pids" ]
 }
 
 ableton_prefix_busy()
 {
-    local pid
-    pid="$(ableton_prefix_pids "${1:-}" "${2:-}" | head -n 1)"
-    [ -n "$pid" ]
+    local pids
+    pids="$(ableton_prefix_pids "${1:-}" "${2:-}")"
+    [ -n "$pids" ]
 }
 
 ableton_lifecycle_runtime_dir()
@@ -248,7 +280,7 @@ ableton_pid_image()
     local image
     # 2>/dev/null first: redirections are applied left to right, so with the input
     # last the open failure is reported before stderr has been silenced.
-    image="$(tr '\0' '\n' 2>/dev/null < "/proc/$1/cmdline" | head -n 1)"
+    image="$(tr '\0' '\n' 2>/dev/null < "/proc/$1/cmdline" | sed -n '1p')"
     image="${image##*\\}"
     image="${image##*/}"
     # A process that exits while it is being reported leaves nothing to read.
@@ -354,7 +386,8 @@ ableton_prefix_wait_progress()
             | cut -f2 | sort -u | tr '\n' ' ')"
         [ -z "${names// /}" ] \
             || printf -- '   still waiting for the prefix to settle (%ss): %s\n' \
-                "$elapsed" "$names"
+                "$elapsed" "$names" \
+            || true
     done
     wait "$waiter" || rc=$?
     return "$rc"
@@ -376,7 +409,7 @@ ableton_prefix_quiesce()
     if [ "$rc" -ne 124 ] && [ "$rc" -ne 137 ]; then
         return "$rc"
     fi
-    echo "-- a leftover background program is holding the prefix open; stopping it"
+    echo "-- a leftover background program is holding the prefix open; stopping it" || true
     ableton_run_bounded 20 env WINEPREFIX="$prefix" \
         "$runtime/bin/wineserver" -k >/dev/null 2>&1 || true
     ableton_prefix_wait "$runtime" "$prefix" || return 3

--- a/scripts/lib/live-options.sh
+++ b/scripts/lib/live-options.sh
@@ -827,7 +827,8 @@ ableton_seed_max_audio_threads_in_dir()
     done
 
     if [ "$options_existing" -eq 1 ] \
-       && tr -d '\r' < "$options_io" | grep -Eq '^-MaxAudioThreads([=[:space:]]|$)'; then
+       && tr -d '\r' < "$options_io" \
+            | grep -E '^-MaxAudioThreads([=[:space:]]|$)' >/dev/null; then
         echo "   The launcher found your audio thread setting."
     elif [ "$inherit_policy" -eq 1 ] && [ -z "$inherited_count" ]; then
         echo "   Live continues to select the audio thread count."

--- a/scripts/lib/manifest.sh
+++ b/scripts/lib/manifest.sh
@@ -8,6 +8,8 @@ declare -ag ABLETON_OWNED_PATHS=()
 declare -Ag ABLETON_OWNED_KINDS=()
 declare -Ag ABLETON_MANIFEST_TOUCHED=()
 declare -Ag ABLETON_MANIFEST_DEOWNED=()
+declare -gi ABLETON_OPTIONAL_FILE_FAILURES=0
+declare -gi ABLETON_PUBLICATION_JOURNAL_BROKEN=0
 
 ableton_file_has_no_nul()
 {
@@ -211,6 +213,28 @@ ableton_managed_path_allowed()
     esac
 }
 
+# Only private support files may use the overwrite-without-prestate policy.
+# Launchers have their own adjacent .bak policy, while shared icon/MIME paths
+# must continue preserving an unrelated file that already occupies the name.
+ableton_replace_generated_path_allowed()
+{
+    case "$1" in
+        "$ABLETON_DATA_HOME/lib/config.sh"|"$ABLETON_DATA_HOME/lib/lifecycle.sh"|\
+        "$ABLETON_DATA_HOME/lib/live-options.sh"|"$ABLETON_DATA_HOME/lib/manifest.sh"|\
+        "$ABLETON_DATA_HOME/lib/pipeasio.sh"|\
+        "$ABLETON_DATA_HOME/detect-scale.sh"|"$ABLETON_DATA_HOME/detect-theme.sh"|\
+        "$ABLETON_DATA_HOME/shortcut-hold.sh"|"$ABLETON_DATA_HOME/setup-realtime.sh"|\
+        "$ABLETON_DATA_HOME/audio-report.sh"|"$ABLETON_DATA_HOME/check-ntsync.sh"|\
+        "$ABLETON_DATA_HOME/rollback.sh"|"$ABLETON_DATA_HOME/ntsyncprobe.exe"|\
+        "$ABLETON_DATA_HOME/pipewire-version-probe"|\
+        "$ABLETON_DATA_HOME/setsyscolors.exe"|"$ABLETON_DATA_HOME/learnheal.exe"|\
+        "$ABLETON_DATA_HOME/VERSION"|"$ABLETON_DATA_HOME/ableton-linkd"|\
+        "$ABLETON_DATA_HOME/ableton-linkctl"|"$ABLETON_DATA_HOME/setup-link.sh"|\
+        "$ABLETON_DATA_HOME/ableton-linkd.service") return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 # Transaction journals are executable restoration instructions, not ownership
 # manifests.  Authorize only the exact project/configuration paths that a real
 # installer operation snapshots.  In particular, a caller-supplied transaction
@@ -341,14 +365,10 @@ ableton_txn_validate_files()
                 return 1 ;;
         esac
         post="${post:-pending}"
-        case "$post" in
-            pending|absent) ;;
-            file:*|symlink:*) [[ "${post#*:}" =~ ^[0-9a-f]{64}$ ]] || {
-                ableton_config_error "invalid post-operation token in file transaction row $index"
-                return 1
-            } ;;
-            *) ableton_config_error "invalid post-operation token in file transaction row $index"; return 1 ;;
-        esac
+        ableton_txn_post_valid "$post" || {
+            ableton_config_error "invalid post-operation token in file transaction row $index"
+            return 1
+        }
         ableton_txn_target_allowed "$status" "$path" "$backup" || {
             ableton_config_error "file transaction target is outside the allowed lifecycle scope: $path"
             return 1
@@ -356,6 +376,52 @@ ableton_txn_validate_files()
         index=$((index + 1))
     done < "$journal"
     return 0
+}
+
+ableton_txn_object_token_valid()
+{
+    case "$1" in
+        absent) return 0 ;;
+        file:*|symlink:*) [[ "${1#*:}" =~ ^[0-9a-f]{64}$ ]] ;;
+        *) return 1 ;;
+    esac
+}
+
+# The final token is the committed generation.  A second, preceding token is
+# the exact installer generation that was live immediately before publication.
+# Keeping both closes the expect->rename failure window: rollback may accept
+# either generation, while commit still accepts only the final one.
+ableton_txn_post_valid()
+{
+    local post="$1" token
+    local -a tokens=()
+    [ "$post" != pending ] || return 0
+    case "$post" in ''|,*|*,|*,,*) return 1 ;; esac
+    IFS=, read -r -a tokens <<< "$post"
+    [ "${#tokens[@]}" -ge 1 ] && [ "${#tokens[@]}" -le 2 ] || return 1
+    for token in "${tokens[@]}"; do
+        ableton_txn_object_token_valid "$token" || return 1
+    done
+    [ "${#tokens[@]}" -ne 2 ] || [ "${tokens[0]}" != "${tokens[1]}" ]
+}
+
+ableton_txn_post_final()
+{
+    local post="$1"
+    ableton_txn_post_valid "$post" && [ "$post" != pending ] || return 1
+    printf '%s\n' "${post##*,}"
+}
+
+ableton_txn_post_accepts()
+{
+    local post="$1" wanted="$2" token
+    local -a tokens=()
+    ableton_txn_post_valid "$post" && [ "$post" != pending ] || return 1
+    IFS=, read -r -a tokens <<< "$post"
+    for token in "${tokens[@]}"; do
+        [ "$token" != "$wanted" ] || return 0
+    done
+    return 1
 }
 
 ableton_txn_preflight_rollback_files()
@@ -380,8 +446,8 @@ ableton_txn_preflight_rollback_files()
         fi
         if [ -z "$current" ] \
            || { [ "$current" != "$original" ] \
-                && { [ "$post" = pending ] || [ "$current" != "$post" ]; }; }; then
-            ableton_config_error "file rollback destination changed while the transaction was open: $path"
+                && ! ableton_txn_post_accepts "$post" "$current"; }; then
+            ableton_config_error "A file changed while the installer was restoring it: $path"
             return 1
         fi
     done < "$txn/files.tsv"
@@ -389,18 +455,19 @@ ableton_txn_preflight_rollback_files()
 
 ableton_txn_preflight_commit_files()
 {
-    local txn="$1" status path backup post extra current
+    local txn="$1" status path backup post extra current final
     ableton_txn_validate_files "$txn" || return 1
     [ -e "$txn/files.tsv" ] || return 0
     while IFS=$'\t' read -r status path backup post extra \
           || [ -n "$status$path$backup$post$extra" ]; do
         [ "${post:-pending}" != pending ] || {
-            ableton_config_error "file transaction has an unfinished mutation: $path"
+            ableton_config_error "A file update stopped before it finished: $path"
             return 1
         }
+        final="$(ableton_txn_post_final "$post")" || return 1
         current="$(ableton_object_token "$path" 2>/dev/null || true)"
-        [ "$current" = "$post" ] || {
-            ableton_config_error "file transaction destination no longer matches its committed object: $path"
+        [ "$current" = "$final" ] || {
+            ableton_config_error "A file changed while the installer was updating it: $path"
             return 1
         }
     done < "$txn/files.tsv"
@@ -444,9 +511,48 @@ ableton_txn_init()
     if [ ! -e "$journal" ]; then : > "$journal" || return 1; fi
 }
 
+# Generated integration files are independent repairs. Once one publication
+# has reached its final token, retire only that file-level recovery data so a
+# later optional failure cannot undo an earlier successful repair.
+ableton_txn_checkpoint_files()
+{
+    local txn="${ABLETON_TRANSACTION_DIR:-}" journal files tmp key
+    [ -n "$txn" ] || return 0
+    if ! ableton_txn_preflight_commit_files "$txn"; then
+        ABLETON_PUBLICATION_JOURNAL_BROKEN=1
+        echo "!! A support file was updated, but temporary installer data could not be refreshed. Continuing with the installed file." >&2 \
+            || true
+        return 0
+    fi
+    journal="$txn/files.tsv"
+    files="$txn/files"
+    if ! tmp="$(mktemp "$txn/.files.tsv.XXXXXX")"; then
+        ABLETON_PUBLICATION_JOURNAL_BROKEN=1
+        echo "!! A support file was updated, but temporary installer data could not be refreshed. Continuing with the installed file." >&2 \
+            || true
+        return 0
+    fi
+    if ! chmod 600 "$tmp" || ! mv -f -- "$tmp" "$journal"; then
+        rm -f -- "$tmp" 2>/dev/null || true
+        ABLETON_PUBLICATION_JOURNAL_BROKEN=1
+        echo "!! A support file was updated, but temporary installer data could not be refreshed. Continuing with the installed file." >&2 \
+            || true
+        return 0
+    fi
+    for key in "${!ABLETON_TXN_SEEN[@]}"; do
+        case "$key" in "$txn"$'\t'*) unset 'ABLETON_TXN_SEEN[$key]' ;; esac
+    done
+    if ! rm -rf -- "$files" || ! mkdir -p -- "$files"; then
+        ABLETON_PUBLICATION_JOURNAL_BROKEN=1
+        echo "!! A support file was updated, but temporary installer data could not be removed. Continuing with the installed file." >&2 \
+            || true
+    fi
+    return 0
+}
+
 ableton_txn_snapshot()
 {
-    local path="$1" id backup existing journal_tmp status backup_created=0
+    local path="$1" id backup existing journal_tmp status backup_created=0 seen_key
     [ -n "${ABLETON_TRANSACTION_DIR:-}" ] || return 0
     ableton_manifest_path_ok "$path" || return 1
     if ! { [ -f "$ABLETON_TRANSACTION_DIR/files.tsv" ] \
@@ -461,24 +567,36 @@ ableton_txn_snapshot()
         ableton_config_error "refusing to snapshot a directory as a managed file: $path"
         return 1
     fi
-    [ -z "${ABLETON_TXN_SEEN[$path]+x}" ] || return 0
+    # One shell can deliberately switch journals (prefix-host owns prefix
+    # configuration while the outer installer owns the shared manifest).  A
+    # path-only cache makes a snapshot in one journal suppress the same path's
+    # snapshot in another.  Scope the fast-path to the actual transaction.
+    seen_key="$ABLETON_TRANSACTION_DIR"$'\t'"$path"
+    [ -z "${ABLETON_TXN_SEEN[$seen_key]+x}" ] || return 0
     existing="$(awk -F '\t' -v p="$path" '$2==p { n++ } END { print n+0 }' \
         "$ABLETON_TRANSACTION_DIR/files.tsv")" || return 1
     if [ "$existing" -eq 1 ]; then
-        ABLETON_TXN_SEEN["$path"]=1
+        ABLETON_TXN_SEEN["$seen_key"]=1
         return 0
     fi
-    ABLETON_TXN_SEEN["$path"]=1
-    id="$(wc -l < "$ABLETON_TRANSACTION_DIR/files.tsv")"
+    ABLETON_TXN_SEEN["$seen_key"]=1
+    id="$(wc -l < "$ABLETON_TRANSACTION_DIR/files.tsv")" || {
+        unset 'ABLETON_TXN_SEEN[$seen_key]'
+        return 1
+    }
+    [[ "$id" =~ ^[0-9]+$ ]] || {
+        unset 'ABLETON_TXN_SEEN[$seen_key]'
+        return 1
+    }
     backup="$ABLETON_TRANSACTION_DIR/files/$id"
     if [ -e "$backup" ] || [ -L "$backup" ]; then
-        unset 'ABLETON_TXN_SEEN[$path]'
+        unset 'ABLETON_TXN_SEEN[$seen_key]'
         ableton_config_error "transaction backup slot is already occupied: $backup"
         return 1
     fi
     if [ -e "$path" ] || [ -L "$path" ]; then
         if ! ableton_atomic_restore_object "$path" "$backup"; then
-            unset 'ABLETON_TXN_SEEN[$path]'
+            unset 'ABLETON_TXN_SEEN[$seen_key]'
             return 1
         fi
         backup_created=1
@@ -489,7 +607,7 @@ ableton_txn_snapshot()
     fi
     journal_tmp="$(mktemp "$ABLETON_TRANSACTION_DIR/.files.tsv.XXXXXX")" || {
         [ "$backup_created" -eq 0 ] || rm -f -- "$backup"
-        unset 'ABLETON_TXN_SEEN[$path]'
+        unset 'ABLETON_TXN_SEEN[$seen_key]'
         return 1
     }
     if ! cp -- "$ABLETON_TRANSACTION_DIR/files.tsv" "$journal_tmp" \
@@ -498,7 +616,7 @@ ableton_txn_snapshot()
        || ! mv -f -- "$journal_tmp" "$ABLETON_TRANSACTION_DIR/files.tsv"; then
         rm -f -- "$journal_tmp"
         [ "$backup_created" -eq 0 ] || rm -f -- "$backup"
-        unset 'ABLETON_TXN_SEEN[$path]'
+        unset 'ABLETON_TXN_SEEN[$seen_key]'
         return 1
     fi
 }
@@ -506,24 +624,57 @@ ableton_txn_snapshot()
 ableton_txn_expect()
 {
     local path="$1" post="$2" journal tmp status p backup old extra matches=0
+    local current original next safe=1 write_ok=1
     [ -n "${ABLETON_TRANSACTION_DIR:-}" ] || return 0
-    case "$post" in
-        absent) ;;
-        file:*|symlink:*) [[ "${post#*:}" =~ ^[0-9a-f]{64}$ ]] || return 1 ;;
-        *) ableton_config_error "invalid expected transaction object for $path"; return 1 ;;
-    esac
+    ableton_txn_object_token_valid "$post" || {
+        ableton_config_error "invalid expected transaction object for $path"
+        return 1
+    }
     journal="$ABLETON_TRANSACTION_DIR/files.tsv"
     ableton_txn_validate_files "$ABLETON_TRANSACTION_DIR" || return 1
+    current="$(ableton_object_token "$path" 2>/dev/null || true)"
+    [ -n "$current" ] || {
+        ableton_config_error "cannot read transaction destination before binding it: $path"
+        return 1
+    }
     tmp="$(mktemp "$ABLETON_TRANSACTION_DIR/.files.tsv.XXXXXX")" || return 1
     while IFS=$'\t' read -r status p backup old extra \
           || [ -n "$status$p$backup$old$extra" ]; do
         if [ "$p" = "$path" ]; then
             matches=$((matches + 1))
-            printf '%s\t%s\t%s\t%s\n' "$status" "$p" "$backup" "$post" >> "$tmp"
+            old="${old:-pending}"
+            if [ "$status" = present ]; then
+                original="$(ableton_object_token "$backup" 2>/dev/null || true)"
+            else
+                original=absent
+            fi
+            if [ -z "$original" ] \
+               || { [ "$current" != "$original" ] \
+                    && ! ableton_txn_post_accepts "$old" "$current"; }; then
+                safe=0
+                continue
+            fi
+            if [ "$current" = "$post" ] || [ "$current" = "$original" ]; then
+                next="$post"
+            else
+                next="$current,$post"
+            fi
+            printf '%s\t%s\t%s\t%s\n' "$status" "$p" "$backup" "$next" >> "$tmp" \
+                || write_ok=0
         else
-            printf '%s\t%s\t%s\t%s\n' "$status" "$p" "$backup" "${old:-pending}" >> "$tmp"
+            printf '%s\t%s\t%s\t%s\n' "$status" "$p" "$backup" "${old:-pending}" >> "$tmp" \
+                || write_ok=0
         fi
     done < "$journal"
+    if [ "$safe" -ne 1 ] || [ "$write_ok" -ne 1 ]; then
+        rm -f -- "$tmp"
+        if [ "$safe" -ne 1 ]; then
+            ableton_config_error "A file changed before the installer could finish updating it: $path"
+        else
+            ableton_config_error "could not prepare transaction state for $path"
+        fi
+        return 1
+    fi
     if [ "$matches" -ne 1 ] || ! chmod 600 "$tmp" || ! mv -f -- "$tmp" "$journal"; then
         rm -f -- "$tmp"
         ableton_config_error "could not bind transaction state for $path"
@@ -608,6 +759,76 @@ ableton_manifest_path_matches()
     [ -n "$actual" ] && [ "$actual" = "$expected" ]
 }
 
+ableton_transaction_core_complete()
+{
+    local transaction="$1" marker="$1/core-complete"
+    [ -d "$transaction" ] && [ ! -L "$transaction" ] \
+        && [ -f "$marker" ] && [ ! -L "$marker" ] \
+        && cmp -s -- "$marker" <(printf 'format=1\ncore=complete\n')
+}
+
+ableton_mark_transaction_core_complete()
+{
+    local transaction="$1" marker="$1/core-complete" tmp
+    [ -d "$transaction" ] && [ ! -L "$transaction" ] || return 1
+    tmp="$(mktemp "$transaction/.core-complete.XXXXXX")" || return 1
+    if ! printf 'format=1\ncore=complete\n' > "$tmp" \
+       || ! chmod 600 "$tmp" \
+       || ! mv -T -f -- "$tmp" "$marker" \
+       || ! ableton_transaction_core_complete "$transaction"; then
+        rm -f -- "$tmp" 2>/dev/null || true
+        return 1
+    fi
+}
+
+ableton_install_state_has_active_transaction()
+{
+    local root="$ABLETON_STATE_HOME/transactions" marker markers transaction parent
+    if [ -e "$root" ] || [ -L "$root" ]; then
+        [ -d "$root" ] && [ ! -L "$root" ] || return 0
+    else
+        return 1
+    fi
+    # Component/coordinator transactions keep the marker at depth two;
+    # prefix-host is a deliberately nested file journal at depth three.
+    if ! markers="$(find "$root" -mindepth 2 -maxdepth 3 -name active -print 2>/dev/null)"; then
+        # An unreadable recovery directory is not proof that installation work
+        # is absent. Launchers fail closed here because starting Wine while a
+        # core runtime/prefix recovery is unknown can damage the prefix.
+        return 0
+    fi
+    [ -n "$markers" ] || return 1
+    while IFS= read -r marker; do
+        [ -n "$marker" ] || continue
+        transaction="${marker%/active}"
+        ableton_transaction_core_complete "$transaction" && continue
+        # prefix-host is the file journal nested inside a full install.  Once
+        # the parent records that its core result is complete, failure to remove
+        # this child marker is optional recovery-file cleanup rather than an
+        # unsafe Wine-prefix transaction.
+        if [ "${transaction##*/}" = prefix-host ]; then
+            parent="${transaction%/prefix-host}"
+            ableton_transaction_core_complete "$parent" && continue
+        fi
+        return 0
+    done <<< "$markers"
+    return 1
+}
+
+ableton_live_desktop_entry_valid()
+{
+    local file="$1"
+    [ -f "$file" ] && [ ! -L "$file" ] && ableton_file_has_no_nul "$file" || return 1
+    [ "$(grep -c '^\[Desktop Entry\]$' "$file")" -eq 1 ] \
+        && [ "$(grep -c '^Type=Application$' "$file")" -eq 1 ] \
+        && [ "$(grep -c '^Name=.' "$file")" -eq 1 ] \
+        && [ "$(grep -c '^Comment=Music production and performance$' "$file")" -eq 1 ] \
+        && [ "$(grep -cF "Exec=$ABLETON_BIN_HOME/ableton-live %f" "$file")" -eq 1 ] \
+        && [ "$(grep -Ec '^Icon=live-(beta|intro|lite|standard|suite)$' "$file")" -eq 1 ] \
+        && [ "$(grep -Ec '^StartupWMClass=.+[.]exe$' "$file")" -eq 1 ] \
+        && [ "$(grep -c '^MimeType=application/x-ableton-live-set;application/x-ableton-live-clip;application/x-ableton-live-pack;$' "$file")" -eq 1 ]
+}
+
 ableton_object_token()
 {
     local path="$1" digest
@@ -674,37 +895,37 @@ ableton_validate_ownership_manifest()
     local -A seen=()
     if [ ! -e "$manifest" ] && [ ! -L "$manifest" ]; then return 0; fi
     [ -f "$manifest" ] && [ ! -L "$manifest" ] && [ -r "$manifest" ] || {
-        ableton_config_error "ownership manifest is unsafe or unreadable: $manifest"
+        ableton_config_error "the installed-file list is unsafe or unreadable: $manifest"
         return 1
     }
     ableton_file_has_no_nul "$manifest" || {
-        ableton_config_error "ownership manifest contains invalid binary data"
+        ableton_config_error "the installed-file list contains invalid binary data"
         return 1
     }
     while IFS=$'\t' read -r kind path detail extra || [ -n "$kind$path$detail$extra" ]; do
         if [ -n "$extra" ] || [ -z "$path" ] || ! ableton_manifest_path_ok "$path" \
            || [ -n "${seen[$path]+x}" ]; then
-            ableton_config_error "ownership manifest is invalid or ambiguous"
+            ableton_config_error "the installed-file list is invalid or ambiguous"
             return 1
         fi
         seen["$path"]=1
         case "$kind" in
             file|config|symlink)
                 ableton_managed_path_allowed "$kind" "$path" || {
-                    ableton_config_error "ownership manifest path is outside the managed integration set: $path"
+                    ableton_config_error "the installed-file list contains an unexpected path: $path"
                     return 1
                 }
                 [[ "$detail" =~ ^[0-9a-f]{64}$ ]] || {
-                    ableton_config_error "ownership manifest has an invalid digest for $path"
+                    ableton_config_error "the installed-file list contains an invalid entry for $path"
                     return 1
                 } ;;
             runtime)
                 [ "$detail" = "$ABLETON_RUNTIME_NAME" ] || {
-                    ableton_config_error "ownership manifest has an invalid runtime record"
+                    ableton_config_error "the installed-file list contains an invalid Wine entry"
                     return 1
                 } ;;
             *)
-                ableton_config_error "ownership manifest has an unknown record kind"
+                ableton_config_error "the installed-file list contains an unknown entry type"
                 return 1 ;;
         esac
     done < "$manifest"
@@ -718,11 +939,11 @@ ableton_validate_prestate_index()
     local -A seen=()
     if [ ! -e "$index" ] && [ ! -L "$index" ]; then return 0; fi
     [ -f "$index" ] && [ ! -L "$index" ] && [ -r "$index" ] || {
-        ableton_config_error "pre-install state index is unsafe or unreadable: $index"
+        ableton_config_error "the list of saved earlier files is unsafe or unreadable: $index"
         return 1
     }
     ableton_file_has_no_nul "$index" || {
-        ableton_config_error "pre-install state contains invalid binary data"
+        ableton_config_error "the list of saved earlier files contains invalid binary data"
         return 1
     }
     while IFS=$'\t' read -r status path backup extra || [ -n "$status$path$backup$extra" ]; do
@@ -732,18 +953,18 @@ ableton_validate_prestate_index()
                 && ! ableton_managed_path_allowed config "$path" \
                 && ! ableton_managed_path_allowed symlink "$path"; } \
            || [ -n "${seen[$path]+x}" ]; then
-            ableton_config_error "pre-install state is invalid or ambiguous"
+            ableton_config_error "the list of saved earlier files is invalid or ambiguous"
             return 1
         fi
         expected="$ABLETON_STATE_HOME/install-prestate/$(printf '%s' "$path" | sha256sum | awk '{print $1}')"
         if [ "$backup" != "$expected" ] \
            || { [ ! -f "$backup" ] && [ ! -L "$backup" ]; }; then
-            ableton_config_error "pre-install backup is missing or misplaced for $path"
+            ableton_config_error "the saved earlier copy is missing or misplaced for $path"
             return 1
         fi
         digest="$(ableton_manifest_digest "$backup" 2>/dev/null || true)"
         [ -n "$digest" ] || {
-            ableton_config_error "pre-install backup is unreadable for $path"
+            ableton_config_error "the saved earlier copy is unreadable for $path"
             return 1
         }
         seen["$path"]=1
@@ -758,16 +979,16 @@ ableton_validate_mime_prestate()
     local -A seen=()
     if [ ! -e "$state" ] && [ ! -L "$state" ]; then return 0; fi
     [ -f "$state" ] && [ ! -L "$state" ] && [ -r "$state" ] || {
-        ableton_config_error "MIME restoration state is unsafe or unreadable"
+        ableton_config_error "the saved file-opening settings are unsafe or unreadable"
         return 1
     }
     ableton_file_has_no_nul "$state" || {
-        ableton_config_error "MIME restoration state contains invalid binary data"
+        ableton_config_error "the saved file-opening settings contain invalid binary data"
         return 1
     }
     while IFS=$'\t' read -r type prior extra || [ -n "$type$prior$extra" ]; do
         [ -z "$extra" ] && [ -n "$type" ] && [ -z "${seen[$type]+x}" ] || {
-            ableton_config_error "MIME restoration state is invalid or ambiguous"
+            ableton_config_error "the saved file-opening settings are invalid or ambiguous"
             return 1
         }
         case "$type" in
@@ -775,10 +996,10 @@ ableton_validate_mime_prestate()
             application/x-ableton-live-set|application/x-ableton-live-clip|\
             application/x-ableton-live-pack|application/x-ableton-live-max-device|\
             x-scheme-handler/c74max) ;;
-            *) ableton_config_error "MIME restoration state has an unknown type"; return 1 ;;
+            *) ableton_config_error "the saved file-opening settings contain an unknown file type"; return 1 ;;
         esac
         [ -z "$prior" ] || [[ "$prior" =~ ^[A-Za-z0-9_.+-]+[.]desktop$ ]] || {
-            ableton_config_error "MIME restoration state has an invalid desktop entry"
+            ableton_config_error "the saved file-opening settings contain an invalid application"
             return 1
         }
         seen["$type"]=1
@@ -786,45 +1007,68 @@ ableton_validate_mime_prestate()
     return 0
 }
 
-ableton_validate_install_state_journals()
+ableton_validate_prestate_store()
 {
     local index="$ABLETON_STATE_HOME/install-prestate.tsv"
     local backup_dir="$ABLETON_STATE_HOME/install-prestate" slot name expected count=0 indexed=0
+    local slots_text=""
     local -A slots=()
-    ableton_validate_ownership_manifest \
-        "$ABLETON_STATE_HOME/install-manifest.tsv" || return 1
     ableton_validate_prestate_index "$index" || return 1
     if [ -e "$backup_dir" ] || [ -L "$backup_dir" ]; then
         [ -d "$backup_dir" ] && [ ! -L "$backup_dir" ] || {
-            ableton_config_error "pre-install backup directory is unsafe"
+            ableton_config_error "the directory holding saved earlier files is unsafe"
             return 1
         }
-        while IFS= read -r -d '' slot; do
-            name="${slot##*/}"
-            [[ "$name" =~ ^[0-9a-f]{64}$ ]] \
-                && { [ -f "$slot" ] || [ -L "$slot" ]; } \
-                && [ -n "$(ableton_manifest_digest "$slot" 2>/dev/null || true)" ] || {
-                ableton_config_error "pre-install backup directory contains an unsafe object"
-                return 1
-            }
-            slots["$name"]=1
-            count=$((count + 1))
-        done < <(find "$backup_dir" -mindepth 1 -maxdepth 1 -print0)
+        if ! slots_text="$(find "$backup_dir" -mindepth 1 -maxdepth 1 -print)"; then
+            ableton_config_error "the directory holding saved earlier files could not be checked"
+            return 1
+        fi
+        if [ -n "$slots_text" ]; then
+            while IFS= read -r slot; do
+                name="${slot##*/}"
+                [[ "$name" =~ ^[0-9a-f]{64}$ ]] \
+                    && { [ -f "$slot" ] || [ -L "$slot" ]; } \
+                    && [ -n "$(ableton_manifest_digest "$slot" 2>/dev/null || true)" ] || {
+                    ableton_config_error "the directory holding saved earlier files contains an unsafe object"
+                    return 1
+                }
+                slots["$name"]=1
+                count=$((count + 1))
+            done <<< "$slots_text"
+        fi
     fi
     if [ -e "$index" ]; then
         while IFS=$'\t' read -r _ path _ _; do
             expected="$(printf '%s' "$path" | sha256sum | awk '{print $1}')"
             [ -n "${slots[$expected]+x}" ] || {
-                ableton_config_error "pre-install backup inventory is incomplete"
+                ableton_config_error "the list of saved earlier files is incomplete"
                 return 1
             }
             indexed=$((indexed + 1))
         done < "$index"
     fi
     [ "$count" -eq "$indexed" ] || {
-        ableton_config_error "pre-install backup directory contains an unindexed object"
+        ableton_config_error "the directory holding saved earlier files contains an unlisted object"
         return 1
     }
+}
+
+ableton_validate_install_state_journals()
+{
+    local mode="${1:-strict}"
+    case "$mode" in strict|repair) ;; *) return 1 ;; esac
+    if [ "$mode" = strict ]; then
+        ableton_validate_ownership_manifest \
+            "$ABLETON_STATE_HOME/install-manifest.tsv" || return 1
+    elif ! ableton_validate_ownership_manifest \
+            "$ABLETON_STATE_HOME/install-manifest.tsv" >/dev/null 2>&1; then
+        echo "   rebuilding the installed-file list" || true
+    fi
+    # Repair rebuilds installer-generated files and their inventory. Saved
+    # earlier files are relevant only when uninstall needs to restore them, so
+    # stale optional restoration data cannot veto an otherwise safe repair.
+    [ "$mode" = strict ] || return 0
+    ableton_validate_prestate_store
 }
 
 ableton_legacy_owned_path()
@@ -839,7 +1083,8 @@ ableton_legacy_owned_path()
     esac
     case "$path" in
         "$ABLETON_DATA_HOME/ableton-linkd")
-            strings "$path" 2>/dev/null | grep -qF 'ableton-linkd: native Ableton Link session anchor and probe' ;;
+            strings "$path" 2>/dev/null \
+                | grep -F 'ableton-linkd: native Ableton Link session anchor and probe' >/dev/null ;;
         "$ABLETON_DATA_HOME/setup-link.sh") grep -qF 'Ableton Link setup' "$path" 2>/dev/null ;;
         "$ABLETON_DATA_HOME/ableton-linkctl") grep -qF 'Project-owned Ableton Link lifecycle controller' "$path" 2>/dev/null ;;
         "$ABLETON_DATA_HOME/ableton-linkd.service") grep -qF 'ableton-linkd' "$path" 2>/dev/null ;;
@@ -918,15 +1163,21 @@ ableton_legacy_owned_path()
 
 ableton_persist_file_prestate()
 {
-    local target="$1" source="${2:-}" prestate_policy="${3:-preserve-local}"
+    local target="$1" prestate_policy="${3:-preserve-local}"
     local index="$ABLETON_STATE_HOME/install-prestate.tsv" prestate_dir id backup
-    local record _kind expected current index_tmp
+    local manifest="$ABLETON_STATE_HOME/install-manifest.tsv"
+    local index_tmp row_count recorded
     case "$prestate_policy" in
-        preserve-local|replace-launcher) ;;
+        preserve-local|replace-launcher|replace-generated) ;;
         *)
             ableton_config_error "The installer received an unknown pre-install backup policy: $prestate_policy"
             return 1 ;;
     esac
+    if [ "$prestate_policy" = replace-generated ] \
+       && ! ableton_replace_generated_path_allowed "$target"; then
+        ableton_config_error "refusing the private-file overwrite policy outside Ableton's support directory: $target"
+        return 1
+    fi
     if [ -d "$target" ] && [ ! -L "$target" ]; then
         ableton_config_error "refusing to preserve a directory as file pre-state: $target"
         return 1
@@ -937,49 +1188,83 @@ ableton_persist_file_prestate()
         ableton_config_error "refusing to preserve a path outside the managed integration set: $target"
         return 1
     fi
-    ableton_validate_install_state_journals || return 1
     [ -e "$target" ] || [ -L "$target" ] || return 0
-    # Matching managed files use the existing fast path. Launcher checks continue
-    # so the installer backs up a matching unclaimed object before claiming it.
-    if [ "$prestate_policy" != replace-launcher ] \
-       && [ -n "$source" ] && [ ! -L "$target" ] && cmp -s -- "$source" "$target"; then
+
+    # Launchers keep a displaced object beside the generated launcher. Other
+    # files published from the installer payload are authoritative project
+    # output. Both still receive an immediate transaction copy, so persistent
+    # uninstall bookkeeping must not become a second publication gate.
+    case "$prestate_policy" in replace-launcher|replace-generated) return 0 ;; esac
+
+    # A path already listed by this invocation or by a structurally valid
+    # installed-file list is ours to refresh. Its saved digest is uninstall
+    # bookkeeping, not an installation integrity gate: updates replace the
+    # generated file even if it was edited or an older digest is stale.
+    if [ -n "${ABLETON_OWNED_KINDS[$target]+x}" ] \
+       || { ableton_validate_ownership_manifest "$manifest" >/dev/null 2>&1 \
+            && ableton_manifest_path_claimed "$target"; }; then
         return 0
     fi
-    if record="$(ableton_manifest_object_record "$target")"; then
-        IFS=$'\t' read -r _kind expected <<< "$record"
-        current="$(ableton_manifest_digest "$target" 2>/dev/null || true)"
-        [ "$current" = "$expected" ] && return 0
-        if [ "$prestate_policy" = replace-launcher ]; then
-            echo "The installer replaced a launcher because its saved checksum differed: $target"
-            return 0
-        fi
-        ableton_config_error "The installer kept the managed path because its saved checksum differs: $target"
-        return 1
-    fi
-    if [ -r "$index" ] && awk -F '\t' -v p="$target" '$2==p { found=1 } END { exit !found }' "$index"; then
-        return 0
-    fi
+    # Recognisable files from older releases are generated installer output too.
+    # Repair them directly even if optional saved-copy metadata is stale.
     ableton_legacy_owned_path "$target" && return 0
-    ableton_mark_state_home
+
+    # Preserve the first object displaced at an otherwise unclaimed path. Later
+    # repairs keep that original copy instead of replacing it with an installer
+    # generation, so uninstall can restore the user's object exactly once.
+    if [ -e "$index" ] || [ -L "$index" ]; then
+        [ -f "$index" ] && [ ! -L "$index" ] && [ -r "$index" ] || {
+            ableton_config_error "The saved copies of earlier files cannot be updated safely; the existing file was left at $target"
+            return 1
+        }
+        row_count="$(awk -F '\t' -v p="$target" '$2==p { n++ } END { print n+0 }' "$index")" \
+            || return 1
+        case "$row_count" in ''|*[!0-9]*) return 1 ;; esac
+        if [ "$row_count" -gt 0 ]; then
+            [ "$row_count" -eq 1 ] || {
+                ableton_config_error "More than one saved earlier copy is listed for $target; the existing file was left unchanged"
+                return 1
+            }
+            id="$(printf '%s' "$target" | sha256sum | awk '{print $1}')" || return 1
+            recorded="$(awk -F '\t' -v p="$target" '$1=="present" && $2==p { print $3; exit }' "$index")" \
+                || return 1
+            backup="$ABLETON_STATE_HOME/install-prestate/$id"
+            if [ "$recorded" = "$backup" ] \
+               && { [ -f "$backup" ] || [ -L "$backup" ]; } \
+               && [ -n "$(ableton_manifest_digest "$backup" 2>/dev/null || true)" ]; then
+                return 0
+            fi
+            ableton_config_error "The saved earlier copy of $target cannot be used safely; the existing file was left unchanged"
+            return 1
+        fi
+    fi
+    # Only the optional saved-copy store is checked here. A damaged installed-
+    # file list must never stop the installer from rebuilding generated files.
+    ableton_validate_prestate_store || {
+        ableton_config_error "The installer could not safely save the existing file at $target, so it was left unchanged"
+        return 1
+    }
+    ableton_mark_state_home || return 1
     prestate_dir="$ABLETON_STATE_HOME/install-prestate"
     if [ -e "$prestate_dir" ] || [ -L "$prestate_dir" ]; then
         [ -d "$prestate_dir" ] && [ ! -L "$prestate_dir" ] || {
-            ableton_config_error "pre-install backup directory is unsafe"
+            ableton_config_error "The saved-copy directory is not safe to use; the existing file was left at $target"
             return 1
         }
     else
         mkdir -- "$prestate_dir" || return 1
     fi
-    ableton_txn_snapshot "$index"
-    id="$(printf '%s' "$target" | sha256sum | awk '{print $1}')"
+    id="$(printf '%s' "$target" | sha256sum | awk '{print $1}')" || return 1
     backup="$prestate_dir/$id"
     [ ! -e "$backup" ] && [ ! -L "$backup" ] || {
-        ableton_config_error "unindexed pre-install backup already exists for $target"
+        ableton_config_error "A saved copy already exists without a usable record for $target; the existing file was left unchanged"
         return 1
     }
-    ableton_txn_snapshot "$backup"
+    ableton_txn_snapshot "$index" || return 1
+    ableton_txn_snapshot "$backup" || return 1
     index_tmp="$(mktemp "$ABLETON_STATE_HOME/.prestate.XXXXXX")" || return 1
-    [ ! -e "$index" ] || cp -- "$index" "$index_tmp" || { rm -f -- "$index_tmp"; return 1; }
+    [ ! -e "$index" ] || cp -- "$index" "$index_tmp" \
+        || { rm -f -- "$index_tmp"; return 1; }
     if ! printf 'present\t%s\t%s\n' "$target" "$backup" >> "$index_tmp" \
        || ! chmod 600 "$index_tmp" \
        || ! ableton_txn_expect "$backup" "$(ableton_object_token "$target")" \
@@ -995,16 +1280,16 @@ ableton_install_file()
 {
     local mode="$1" source="$2" target="$3" kind="${4:-file}"
     local prestate_policy="${5:-preserve-local}" post tmp parent
+    post="$(ableton_regular_source_token "$source")" || return 1
     [ ! -d "$target" ] || [ -L "$target" ] || {
         ableton_config_error "refusing to replace directory with a file: $target"
         return 1
     }
     ableton_persist_file_prestate "$target" "$source" "$prestate_policy" || return 1
-    ableton_txn_snapshot "$target"
-    post="$(ableton_regular_source_token "$source")" || return 1
+    ableton_txn_snapshot "$target" || return 1
     ableton_txn_expect "$target" "$post" || return 1
-    parent="$(dirname "$target")"
-    mkdir -p -- "$parent"
+    parent="$(dirname "$target")" || return 1
+    mkdir -p -- "$parent" || return 1
     tmp="$(mktemp "$parent/.ableton-install.XXXXXX")" || return 1
     if ! install -m "$mode" -- "$source" "$tmp" \
        || [ "$(ableton_object_token "$tmp" 2>/dev/null || true)" != "$post" ] \
@@ -1012,7 +1297,7 @@ ableton_install_file()
         rm -f -- "$tmp"
         return 1
     fi
-    ableton_record_owned "$target" "$kind"
+    ableton_record_owned "$target" "$kind" || return 1
 }
 
 ableton_install_symlink()
@@ -1023,11 +1308,11 @@ ableton_install_symlink()
         return 1
     }
     ableton_persist_file_prestate "$target" "" "$prestate_policy" || return 1
-    ableton_txn_snapshot "$target"
+    ableton_txn_snapshot "$target" || return 1
     post="$(ableton_symlink_text_token "$link_text")" || return 1
     ableton_txn_expect "$target" "$post" || return 1
-    parent="$(dirname "$target")"
-    mkdir -p -- "$parent"
+    parent="$(dirname "$target")" || return 1
+    mkdir -p -- "$parent" || return 1
     tmp="$(mktemp "$parent/.ableton-link.XXXXXX")" || return 1
     rm -f -- "$tmp" || return 1
     if ! ln -s -- "$link_text" "$tmp" \
@@ -1036,16 +1321,18 @@ ableton_install_symlink()
         rm -f -- "$tmp"
         return 1
     fi
-    ableton_record_owned "$target" symlink
+    ableton_record_owned "$target" symlink || return 1
 }
 
 # Save the most recently displaced launcher object beside its path as
 # <name>.bak. The transaction tracks both paths and restores both objects after
-# a later failure. The backup is managed too, so uninstall removes one created
-# in an empty path or restores the object that previously occupied that path.
+# a later failure. Persist each foreign object once before replacing either
+# path, so uninstall can restore both the original launcher and a personal file
+# that already occupied <name>.bak, even after later launcher updates.
 ableton_backup_launcher()
 {
     local target="$1" desired="$2" desired_mode="${3:-}" backup="$1.bak" current
+    local manifest="$ABLETON_STATE_HOME/install-manifest.tsv"
     ableton_launcher_path_allowed "$target" || {
         ableton_config_error "launcher path falls outside the managed launcher set: $target"
         return 1
@@ -1061,9 +1348,19 @@ ableton_backup_launcher()
     }
     current="$(ableton_object_token "$target")" || return 1
     if [ "$current" = "$desired" ] \
-       && ableton_launcher_claim_matches "$target" "$current" \
        && { [ -z "$desired_mode" ] \
             || { [ ! -L "$target" ] && [ "$(stat -c '%a' -- "$target")" = "$desired_mode" ]; }; }; then
+        return 0
+    fi
+    # Once both paths belong to an installed launcher pair, the adjacent copy
+    # is the first displaced launcher, not scratch space for every generation.
+    # Keep it unchanged while refreshing the canonical launcher; the active
+    # transaction already protects the canonical path if this update fails.
+    if { [ -n "${ABLETON_OWNED_KINDS[$target]+x}" ] \
+         && [ -n "${ABLETON_OWNED_KINDS[$backup]+x}" ]; } \
+       || { ableton_validate_ownership_manifest "$manifest" >/dev/null 2>&1 \
+            && ableton_manifest_path_claimed "$target" \
+            && ableton_manifest_path_claimed "$backup"; }; then
         return 0
     fi
     [ ! -d "$backup" ] || [ -L "$backup" ] || {
@@ -1074,7 +1371,7 @@ ableton_backup_launcher()
         ableton_config_error "launcher backup path is not a regular file or symlink: $backup"
         return 1
     fi
-    ableton_persist_file_prestate "$backup" "" replace-launcher || return 1
+    ableton_persist_file_prestate "$backup" "" preserve-local || return 1
     ableton_txn_snapshot "$backup" || return 1
     ableton_txn_expect "$backup" "$current" || return 1
     ableton_atomic_restore_object "$target" "$backup" || return 1
@@ -1109,6 +1406,74 @@ ableton_install_launcher_symlink()
     desired="$(ableton_symlink_text_token "$link_text")" || return 1
     ableton_backup_launcher "$target" "$desired" || return 1
     ableton_install_symlink "$link_text" "$target" replace-launcher
+}
+
+ableton_publish_file()
+{
+    if [ "$ABLETON_PUBLICATION_JOURNAL_BROKEN" -eq 1 ]; then
+        ableton_publish_without_file_journal ableton_install_file "$@"
+        return
+    fi
+    ableton_install_file "$@" || return 1
+    ableton_txn_checkpoint_files
+}
+
+ableton_publish_launcher_file()
+{
+    if [ "$ABLETON_PUBLICATION_JOURNAL_BROKEN" -eq 1 ]; then
+        ableton_publish_without_file_journal ableton_install_launcher_file "$@"
+        return
+    fi
+    ableton_install_launcher_file "$@" || return 1
+    ableton_txn_checkpoint_files
+}
+
+ableton_publish_launcher_symlink()
+{
+    if [ "$ABLETON_PUBLICATION_JOURNAL_BROKEN" -eq 1 ]; then
+        ableton_publish_without_file_journal ableton_install_launcher_symlink "$@"
+        return
+    fi
+    ableton_install_launcher_symlink "$@" || return 1
+    ableton_txn_checkpoint_files
+}
+
+# Once optional recovery bookkeeping itself becomes unavailable, keep repairing
+# independent files atomically instead of turning that bookkeeping into a gate.
+# The caller still owns and later retires the surrounding core transaction.
+ableton_publish_without_file_journal()
+{
+    local operation="$1" saved_transaction="${ABLETON_TRANSACTION_DIR:-}" rc
+    shift
+    ABLETON_TRANSACTION_DIR=""
+    export ABLETON_TRANSACTION_DIR
+    if "$operation" "$@"; then rc=0; else rc=$?; fi
+    ABLETON_TRANSACTION_DIR="$saved_transaction"
+    export ABLETON_TRANSACTION_DIR
+    return "$rc"
+}
+
+# Optional files are separate repairs. A blocked shared path must not prevent
+# later project-owned files from being refreshed in the same run.
+ableton_try_publish_file()
+{
+    if ableton_publish_file "$@"; then return 0; fi
+    ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
+    return 0
+}
+
+ableton_try_publish_launcher_file()
+{
+    if ableton_publish_launcher_file "$@"; then return 0; fi
+    ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
+    return 0
+}
+
+ableton_try_publish_launcher_symlink()
+{
+    if ableton_publish_launcher_symlink "$@"; then return 0; fi
+    ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
+    return 0
 }
 
 ableton_adopt_runtime_marker()
@@ -1162,14 +1527,15 @@ ableton_remove_managed_file()
     local target="$1" index="$ABLETON_STATE_HOME/install-prestate.tsv"
     local id backup recorded="" index_tmp row_count=0 present_count=0 backup_digest restored_digest
     ableton_validate_install_state_journals || return 1
-    id="$(printf '%s' "$target" | sha256sum | awk '{print $1}')"
+    id="$(printf '%s' "$target" | sha256sum | awk '{print $1}')" || return 1
     backup="$ABLETON_STATE_HOME/install-prestate/$id"
     if [ -r "$index" ]; then
-        row_count="$(awk -F '\t' -v p="$target" '$2==p { n++ } END { print n+0 }' "$index")"
+        row_count="$(awk -F '\t' -v p="$target" '$2==p { n++ } END { print n+0 }' "$index")" \
+            || return 1
         present_count="$(awk -F '\t' -v p="$target" \
-            '$1=="present" && $2==p { n++ } END { print n+0 }' "$index")"
+            '$1=="present" && $2==p { n++ } END { print n+0 }' "$index")" || return 1
         recorded="$(awk -F '\t' -v p="$target" \
-            '$1=="present" && $2==p { print $3; exit }' "$index")"
+            '$1=="present" && $2==p { print $3; exit }' "$index")" || return 1
         if [ "$row_count" -ne 0 ]; then
             if [ "$row_count" -ne 1 ] || [ "$present_count" -ne 1 ] \
                || [ "$recorded" != "$backup" ] \
@@ -1190,11 +1556,12 @@ ableton_remove_managed_file()
     else
         ableton_txn_expect "$target" absent || return 1
     fi
-    rm -f -- "$target" || return 1
-    [ ! -e "$target" ] && [ ! -L "$target" ] || return 1
     if [ -n "$recorded" ]; then
         ableton_txn_snapshot "$index" || return 1
         ableton_txn_snapshot "$backup" || return 1
+        # atomic_restore replaces the managed object directly. Removing it first
+        # creates an installer-owned third state that neither the original nor
+        # final journal token can authorize if the restore then fails.
         ableton_atomic_restore_object "$backup" "$target" || return 1
         restored_digest="$(ableton_manifest_digest "$target" 2>/dev/null || true)"
         [ "$restored_digest" = "$backup_digest" ] || return 1
@@ -1208,7 +1575,10 @@ ableton_remove_managed_file()
         fi
         ableton_txn_expect "$backup" absent || return 1
         rm -f -- "$backup" || return 1
-        printf '   restored your previous %s\n' "$target"
+        printf '   restored your previous %s\n' "$target" || true
+    else
+        rm -f -- "$target" || return 1
+        [ ! -e "$target" ] && [ ! -L "$target" ] || return 1
     fi
     ableton_record_deowned "$target"
 }
@@ -1221,11 +1591,13 @@ ableton_abandon_managed_file()
     local target="$1" index="$ABLETON_STATE_HOME/install-prestate.tsv"
     local id backup recorded="" index_tmp row_count=0
     ableton_validate_install_state_journals || return 1
-    id="$(printf '%s' "$target" | sha256sum | awk '{print $1}')"
+    id="$(printf '%s' "$target" | sha256sum | awk '{print $1}')" || return 1
     backup="$ABLETON_STATE_HOME/install-prestate/$id"
     if [ -r "$index" ]; then
-        row_count="$(awk -F '\t' -v p="$target" '$2==p { n++ } END { print n+0 }' "$index")"
-        recorded="$(awk -F '\t' -v p="$target" '$1=="present" && $2==p { print $3; exit }' "$index")"
+        row_count="$(awk -F '\t' -v p="$target" '$2==p { n++ } END { print n+0 }' "$index")" \
+            || return 1
+        recorded="$(awk -F '\t' -v p="$target" '$1=="present" && $2==p { print $3; exit }' "$index")" \
+            || return 1
         if [ "$row_count" -ne 0 ]; then
             if ! { [ "$row_count" -eq 1 ] && [ "$recorded" = "$backup" ] \
                    && { [ -f "$backup" ] || [ -L "$backup" ]; }; }; then
@@ -1251,34 +1623,46 @@ ableton_abandon_managed_file()
 
 ableton_write_ownership_manifest()
 {
-    local manifest="$ABLETON_STATE_HOME/install-manifest.tsv" tmp path digest
-    ableton_validate_install_state_journals || return 1
-    ableton_mark_state_home
-    ableton_txn_snapshot "$manifest"
-    tmp="$(mktemp "$ABLETON_STATE_HOME/.manifest.XXXXXX")"
+    # This file is an uninstall inventory, not installation integrity state.
+    # It is deliberately outside component/prefix journals: if it is stale or
+    # malformed, rebuild it from this invocation instead of rejecting working
+    # runtime or prefix changes. The optional transaction argument remains for
+    # compatibility with older callers but no longer changes publication.
+    [ "$#" -le 1 ] || return 1
+    local manifest="$ABLETON_STATE_HOME/install-manifest.tsv" tmp kind path digest
+    ableton_mark_state_home || return 1
+    tmp="$(mktemp "$ABLETON_STATE_HOME/.manifest.XXXXXX")" || return 1
     # Preserve records for components this invocation did not touch.  Touched
     # paths are replaced below by their new digest.
-    if [ -r "$manifest" ]; then
+    if [ -f "$manifest" ] && [ ! -L "$manifest" ] \
+       && ableton_validate_ownership_manifest "$manifest" >/dev/null 2>&1; then
         while IFS=$'\t' read -r kind path digest; do
             case "$kind" in file|config|symlink|runtime) ;; *) continue ;; esac
             [ -n "$path" ] || continue
             [ -z "${ABLETON_MANIFEST_TOUCHED[$path]+x}" ] || continue
-            printf '%s\t%s\t%s\n' "$kind" "$path" "$digest" >> "$tmp"
+            printf '%s\t%s\t%s\n' "$kind" "$path" "$digest" >> "$tmp" \
+                || { rm -f -- "$tmp"; return 1; }
         done < "$manifest"
     fi
     for path in "${ABLETON_OWNED_PATHS[@]}"; do
         [ -z "${ABLETON_MANIFEST_DEOWNED[$path]+x}" ] || continue
         [ -f "$path" ] || [ -L "$path" ] || continue
-        digest="$(ableton_manifest_digest "$path")"
-        printf '%s\t%s\t%s\n' "${ABLETON_OWNED_KINDS[$path]:-file}" "$path" "$digest" >> "$tmp"
+        digest="$(ableton_manifest_digest "$path")" \
+            || { rm -f -- "$tmp"; return 1; }
+        printf '%s\t%s\t%s\n' "${ABLETON_OWNED_KINDS[$path]:-file}" "$path" "$digest" >> "$tmp" \
+            || { rm -f -- "$tmp"; return 1; }
     done
     if [ "${ABLETON_RUNTIME_INSTALLED:-0}" -eq 1 ]; then
-        printf 'runtime\t%s\t%s\n' "$ABLETON_WINE_ROOT" "$ABLETON_RUNTIME_NAME" >> "$tmp"
+        printf 'runtime\t%s\t%s\n' "$ABLETON_WINE_ROOT" "$ABLETON_RUNTIME_NAME" >> "$tmp" \
+            || { rm -f -- "$tmp"; return 1; }
     fi
-    sort -u "$tmp" -o "$tmp"
-    chmod 600 "$tmp"
-    ableton_txn_expect "$manifest" "$(ableton_regular_source_token "$tmp")"
-    mv -f -- "$tmp" "$manifest"
+    if ! sort -u "$tmp" -o "$tmp" \
+       || ! chmod 600 "$tmp" \
+       || ! mv -f -- "$tmp" "$manifest" \
+       || ! ableton_validate_ownership_manifest "$manifest"; then
+        rm -f -- "$tmp"
+        return 1
+    fi
 }
 
 ableton_txn_rollback_files()

--- a/scripts/lib/pipeasio.sh
+++ b/scripts/lib/pipeasio.sh
@@ -76,7 +76,7 @@ ableton_pipewire_preflight()
         return 1
     }
     ableton_pipewire_version_core "$daemon" >/dev/null || {
-        printf '!! PipeWire returned an unreadable daemon version; nothing was changed.\n' >&2
+        printf '!! PipeWire reported an unreadable version; nothing was changed.\n' >&2
         return 1
     }
     # The observations are intentionally available to callers and tests.
@@ -97,7 +97,10 @@ ableton_pipewire_preflight()
         printf '!! Upgrade the complete PipeWire stack, then retry. Nothing was changed.\n' >&2
         return 1
     fi
-    printf '   PipeWire %s (client %s): supported\n' "$daemon" "$client"
+    # Reporting comes after the compatibility gate has succeeded. A closed
+    # terminal must not turn that successful proof into a rollback request.
+    printf '   PipeWire %s (client %s): supported\n' "$daemon" "$client" || true
+    return 0
 }
 
 ableton_pipeasio_build_info_value()
@@ -116,9 +119,9 @@ ableton_pipeasio_validate_panel()
     local mode record expected actual count=0 part panel_re
     [ -s "$info" ] || { echo "!! runtime build information is missing" >&2; return 1; }
     mode="$(ableton_pipeasio_build_info_value "$info" pipeasio-panel)" || {
-        echo "!! runtime has an invalid PipeASIO panel record" >&2; return 1; }
+        echo "!! The Wine build has invalid PipeASIO Settings information." >&2; return 1; }
     record="$(ableton_pipeasio_build_info_value "$info" pipeasio-settings)" || {
-        echo "!! runtime has an invalid PipeASIO settings record" >&2; return 1; }
+        echo "!! The Wine build has invalid PipeASIO Settings version information." >&2; return 1; }
     for part in bin/pipeasio-settings \
         share/applications/pipeasio-settings.desktop \
         share/icons/hicolor/scalable/apps/pipeasio.svg; do
@@ -138,7 +141,7 @@ ableton_pipeasio_validate_panel()
                 panel_re='^([0-9a-f]{64}) \(Qt 6\.2 link\)$'
             fi
             [[ "$record" =~ $panel_re ]] || {
-                echo "!! runtime has a malformed built-panel record" >&2; return 1; }
+                echo "!! The Wine build's PipeASIO Settings information is malformed." >&2; return 1; }
             expected="${BASH_REMATCH[1]}"
             [ "$count" -eq 3 ] && [ -x "$runtime/bin/pipeasio-settings" ] \
                 && [ -s "$runtime/share/applications/pipeasio-settings.desktop" ] \
@@ -160,7 +163,7 @@ ableton_pipeasio_validate_panel()
         skipped)
             case "$record" in
                 'skipped (disabled)'|'skipped (Qt6 Widgets unavailable)') ;;
-                *) echo "!! runtime has a malformed skipped-panel record" >&2; return 1 ;;
+                *) echo "!! The Wine build's PipeASIO Settings information is malformed." >&2; return 1 ;;
             esac
             [ "$count" -eq 0 ] || {
                 echo "!! runtime says the settings panel was skipped, but panel files are present" >&2
@@ -172,9 +175,11 @@ ableton_pipeasio_validate_panel()
     esac
 }
 
-# Validate the sealed PipeASIO portion of a runtime.  When EXTERNAL_INFO is
-# supplied (the kit's versioned BUILD-INFO), it must be byte-identical to the
-# copy inside the tarball.
+# Validate the sealed core PipeASIO portion of a runtime. The optional settings
+# panel has its own validator above: a broken GUI must never make the Wine
+# runtime or ASIO driver unusable. When EXTERNAL_INFO is supplied (the kit's
+# versioned BUILD-INFO), it must be byte-identical to the copy inside the
+# tarball.
 ableton_pipeasio_validate_runtime()
 {
     local runtime="${1:?runtime root required}" external_info="${2:-}" expected_version="${3:-}"
@@ -243,7 +248,6 @@ EOF
         echo "!! PipeWire compatibility check does not match runtime build information" >&2
         return 1
     }
-    ableton_pipeasio_validate_panel "$runtime" "$info"
 }
 
 # Quote one executable pathname for a Desktop Entry Exec key.  The Desktop
@@ -271,9 +275,100 @@ ableton_pipeasio_icon_may_replace()
     return 1
 }
 
+ableton_pipeasio_restore_adjacent_backup()
+{
+    local path="$1" saved="$1.bak" path_record saved_record path_kind path_digest
+    local saved_kind saved_digest current saved_current index status=0
+    ableton_manifest_path_claimed "$path" \
+        && ableton_manifest_path_claimed "$saved" || return 2
+    path_record="$(ableton_manifest_object_record "$path")" || return 2
+    saved_record="$(ableton_manifest_object_record "$saved")" || return 2
+    IFS=$'\t' read -r path_kind path_digest <<< "$path_record"
+    IFS=$'\t' read -r saved_kind saved_digest <<< "$saved_record"
+    case "$path_kind:$saved_kind" in
+        file:file|file:symlink|symlink:file|symlink:symlink) ;;
+        *) return 2 ;;
+    esac
+
+    # Older releases may have a durable pre-install copy for either member.
+    # That remains authoritative; the adjacent-pair rule is only for current,
+    # snapshot-free launcher replacements.
+    index="$ABLETON_STATE_HOME/install-prestate.tsv"
+    if [ -e "$index" ] || [ -L "$index" ]; then
+        ableton_validate_install_state_journals >/dev/null 2>&1 || return 2
+        if [ -r "$index" ] \
+           && awk -F '\t' -v p="$path" -v s="$saved" \
+                '$1=="present" && ($2==p || $2==s) { found=1 } END { exit !found }' \
+                "$index"; then
+            return 2
+        fi
+    fi
+
+    current="$(ableton_object_token "$path" 2>/dev/null || true)"
+    saved_current="$(ableton_object_token "$saved" 2>/dev/null || true)"
+    if [ "$current" != "$path_kind:$path_digest" ] \
+       && [ "$current" != "$saved_kind:$saved_digest" ] \
+       && [ "$current" != absent ]; then
+        ableton_record_deowned "$path" >/dev/null 2>&1 || true
+        ableton_record_deowned "$saved" >/dev/null 2>&1 || true
+        if [ "$saved_current" = absent ]; then
+            echo "!! Kept $path because its saved earlier shortcut is missing." >&2
+        else
+            echo "!! Kept both $path and $saved because the current shortcut was changed." >&2
+        fi
+        return 0
+    fi
+    if [ "$saved_current" != "$saved_kind:$saved_digest" ]; then
+        ableton_record_deowned "$path" >/dev/null 2>&1 || true
+        ableton_record_deowned "$saved" >/dev/null 2>&1 || true
+        if [ "$saved_current" = absent ]; then
+            echo "!! Kept $path because its saved earlier shortcut is missing." >&2
+        else
+            echo "!! Kept both $path and $saved because the saved earlier shortcut was changed." >&2
+        fi
+        return 0
+    fi
+
+    ableton_txn_snapshot "$path" || return 1
+    ableton_txn_snapshot "$saved" || return 1
+    ableton_txn_expect "$path" "$saved_kind:$saved_digest" || return 1
+    ableton_txn_expect "$saved" absent || return 1
+    if [ "$current" != "$saved_kind:$saved_digest" ]; then
+        if ! ableton_atomic_restore_object "$saved" "$path" \
+           || [ "$(ableton_object_token "$path" 2>/dev/null || true)" \
+                != "$saved_kind:$saved_digest" ]; then
+            ableton_txn_expect "$path" "$current" || return 1
+            ableton_txn_expect "$saved" "$saved_current" || return 1
+            ableton_record_deowned "$path" >/dev/null 2>&1 || true
+            ableton_record_deowned "$saved" >/dev/null 2>&1 || true
+            echo "!! Could not restore $saved to $path; both files were kept." >&2 \
+                || true
+            return 0
+        fi
+    fi
+    if ! rm -f -- "$saved" || [ -e "$saved" ] || [ -L "$saved" ]; then
+        ableton_txn_expect "$saved" "$saved_current" || status=1
+        ableton_record_deowned "$path" >/dev/null 2>&1 || true
+        ableton_record_deowned "$saved" >/dev/null 2>&1 || true
+        echo "!! Restored the earlier shortcut at $path, but its extra saved copy remains at $saved." >&2 \
+            || true
+        return "$status"
+    fi
+    ableton_record_deowned "$path" || return 1
+    ableton_record_deowned "$saved" || return 1
+    printf '   restored your previous %s\n' "$path" || true
+    return 0
+}
+
 ableton_pipeasio_remove_panel_path()
 {
-    local path="$1"
+    local path="$1" adjacent_status=0
+    if ableton_pipeasio_restore_adjacent_backup "$path"; then
+        return 0
+    else
+        adjacent_status=$?
+        [ "$adjacent_status" -eq 2 ] || return "$adjacent_status"
+    fi
     if [ ! -e "$path" ] && [ ! -L "$path" ]; then
         if ableton_manifest_path_claimed "$path"; then
             ableton_remove_managed_file "$path"
@@ -284,7 +379,7 @@ ableton_pipeasio_remove_panel_path()
         ableton_remove_managed_file "$path"
     else
         ableton_record_deowned "$path"
-        printf '   preserved your existing %s\n' "$path"
+        printf '   preserved your existing %s\n' "$path" || true
     fi
 }
 
@@ -292,17 +387,17 @@ ableton_pipeasio_refresh_panel_caches()
 {
     update-desktop-database \
         "${XDG_DATA_HOME:-$HOME/.local/share}/applications" >/dev/null 2>&1 || true
-    gtk-update-icon-cache -q \
-        "${XDG_DATA_HOME:-$HOME/.local/share}/icons/hicolor" >/dev/null 2>&1 || true
 }
 
 ableton_pipeasio_remove_panel_integration()
 {
-    ableton_pipeasio_remove_panel_path "$ABLETON_BIN_HOME/pipeasio-settings"
+    local rc=0
+    ableton_pipeasio_remove_panel_path "$ABLETON_BIN_HOME/pipeasio-settings" || rc=1
     ableton_pipeasio_remove_panel_path \
-        "${XDG_DATA_HOME:-$HOME/.local/share}/applications/pipeasio-settings.desktop"
+        "${XDG_DATA_HOME:-$HOME/.local/share}/applications/pipeasio-settings.desktop" || rc=1
     ableton_pipeasio_remove_panel_path \
-        "${XDG_DATA_HOME:-$HOME/.local/share}/icons/hicolor/scalable/apps/pipeasio.svg"
+        "${XDG_DATA_HOME:-$HOME/.local/share}/icons/hicolor/scalable/apps/pipeasio.svg" || rc=1
+    return "$rc"
 }
 
 ableton_pipeasio_qt_package_hint()
@@ -343,10 +438,12 @@ ableton_pipeasio_optional_tools_advice()
     for tool in pw-dump pw-top; do
         command -v "$tool" >/dev/null 2>&1 || missing="${missing}${missing:+, }$tool"
     done
-    [ -z "$missing" ] || {
-        printf '   Optional PipeWire tools missing: %s.\n' "$missing"
-        echo '   pw-dump enables panel device lists; pw-top enables Monitor; both enrich audio-report.sh.'
-    }
+    if [ -n "$missing" ]; then
+        printf '   Optional PipeWire tools missing: %s.\n' "$missing" || true
+        echo '   pw-dump enables panel device lists; pw-top enables Monitor; both enrich audio-report.sh.' \
+            || true
+    fi
+    return 0
 }
 
 # The driver remains usable without Qt.  This is advice for the optional panel,
@@ -391,8 +488,9 @@ ableton_pipeasio_qt_advice()
     fi
     if [ -n "$missing" ]; then
         printf '   PipeASIO Settings is optional. To enable it, run: %s\n' \
-            "$(ableton_pipeasio_qt_package_hint "$qpa")"
+            "$(ableton_pipeasio_qt_package_hint "$qpa")" || true
     fi
+    return 0
 }
 
 ableton_pipeasio_sync_panel()
@@ -403,48 +501,55 @@ ableton_pipeasio_sync_panel()
     local icon="${XDG_DATA_HOME:-$HOME/.local/share}/icons/hicolor/scalable/apps/pipeasio.svg"
     local source_desktop="$runtime/share/applications/pipeasio-settings.desktop"
     local source_icon="$runtime/share/icons/hicolor/scalable/apps/pipeasio.svg"
-    local tmp
+    local tmp="" failures_before="$ABLETON_OPTIONAL_FILE_FAILURES" removal_ok=1
     case "$policy" in install|reconcile) ;; *) return 2 ;; esac
-    ableton_pipeasio_validate_panel "$runtime"
+    ableton_pipeasio_validate_panel "$runtime" || return 1
     state="$ABLETON_PIPEASIO_PANEL_STATE"
     if [ "$state" = skipped ]; then
-        ableton_pipeasio_remove_panel_integration
-        echo "   PipeASIO Settings was not packaged; edit the INI file when needed"
+        ableton_pipeasio_remove_panel_integration || removal_ok=0
+        echo "   PipeASIO Settings was not packaged; edit the INI file when needed" \
+            || true
         ableton_pipeasio_refresh_panel_caches
-        return 0
+        [ "$removal_ok" -eq 1 ]
+        return
     fi
 
     if [ "$policy" = reconcile ] && [ ! -e "$command" ] && [ ! -L "$command" ] \
        && ! ableton_manifest_path_claimed "$command"; then
-        ableton_record_deowned "$command"
+        ableton_record_deowned "$command" || true
     else
-        ableton_install_launcher_symlink "$runtime/bin/pipeasio-settings" "$command"
+        ableton_try_publish_launcher_symlink "$runtime/bin/pipeasio-settings" "$command"
     fi
     if [ "$policy" = reconcile ] && [ ! -e "$desktop" ] && [ ! -L "$desktop" ] \
        && ! ableton_manifest_path_claimed "$desktop"; then
-        ableton_record_deowned "$desktop"
+        ableton_record_deowned "$desktop" || true
     else
-        tmp="$(mktemp "${TMPDIR:-/tmp}/pipeasio-settings.desktop.XXXXXX")"
-        while IFS= read -r line || [ -n "$line" ]; do
-            if [ "$line" = 'Exec=pipeasio-settings' ]; then
-                printf 'Exec="%s"\n' \
-                    "$(ableton_pipeasio_desktop_exec_arg "$runtime/bin/pipeasio-settings")"
-            else
-                printf '%s\n' "$line"
-            fi
-        done < "$source_desktop" > "$tmp"
-        printf '%s\n' 'X-Ableton-Wine-Managed=true' >> "$tmp"
-        ableton_install_launcher_file 644 "$tmp" "$desktop"
-        rm -f -- "$tmp"
+        if tmp="$(mktemp "${TMPDIR:-/tmp}/pipeasio-settings.desktop.XXXXXX")" \
+           && { while IFS= read -r line || [ -n "$line" ]; do
+                    if [ "$line" = 'Exec=pipeasio-settings' ]; then
+                        printf 'Exec="%s"\n' \
+                            "$(ableton_pipeasio_desktop_exec_arg "$runtime/bin/pipeasio-settings")"
+                    else
+                        printf '%s\n' "$line"
+                    fi
+                done < "$source_desktop"
+                printf '%s\n' 'X-Ableton-Wine-Managed=true';
+              } > "$tmp"; then
+            ableton_try_publish_launcher_file 644 "$tmp" "$desktop"
+        else
+            ABLETON_OPTIONAL_FILE_FAILURES=$((ABLETON_OPTIONAL_FILE_FAILURES + 1))
+        fi
+        [ -z "$tmp" ] || rm -f -- "$tmp" 2>/dev/null || true
     fi
     if [ "$policy" = reconcile ] && [ ! -e "$icon" ] && [ ! -L "$icon" ] \
        && ! ableton_manifest_path_claimed "$icon"; then
-        ableton_record_deowned "$icon"
+        ableton_record_deowned "$icon" || true
     elif ableton_pipeasio_icon_may_replace "$icon"; then
-        ableton_install_file 644 "$source_icon" "$icon"
+        ableton_try_publish_file 644 "$source_icon" "$icon"
     fi
     [ "$policy" != install ] || ableton_pipeasio_qt_advice "$runtime/bin/pipeasio-settings"
     ableton_pipeasio_refresh_panel_caches
+    [ "$ABLETON_OPTIONAL_FILE_FAILURES" -eq "$failures_before" ]
 }
 
 ableton_pipeasio_wait_command()

--- a/scripts/lib/tsan.sh
+++ b/scripts/lib/tsan.sh
@@ -26,7 +26,7 @@ pipeasio_tsan_log_is_infrastructure_failure()
     if grep -E 'WARNING: ThreadSanitizer:' "$log" \
             | grep -Ev \
                 'WARNING: ThreadSanitizer:.*(memory layout is incompatible|unexpectedly found incompatible memory layout|high-entropy ASLR|fixed virtual address space)' \
-            | grep -q .; then
+                >/dev/null; then
         return 1
     fi
     if grep -Eq \
@@ -36,12 +36,12 @@ pipeasio_tsan_log_is_infrastructure_failure()
     fi
     if grep -E 'FATAL: ThreadSanitizer:' "$log" \
             | grep -Ev 'FATAL: ThreadSanitizer: unexpected memory mapping' \
-            | grep -q .; then
+                >/dev/null; then
         return 1
     fi
     if grep -E 'CHECK failed:' "$log" \
             | grep -Ev '(personality|ADDR_NO_RANDOMIZE)' \
-            | grep -q .; then
+                >/dev/null; then
         return 1
     fi
 

--- a/scripts/max9
+++ b/scripts/max9
@@ -6,12 +6,28 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 for lib in "$here/lib/config.sh" "${XDG_DATA_HOME:-$HOME/.local/share}/ableton-wine/lib/config.sh"; do
     if [ -r "$lib" ]; then . "$lib"; break; fi
 done
-declare -F ableton_config_init >/dev/null 2>&1 || { echo "max9: configuration helper is missing" >&2; exit 1; }
-ableton_config_init
+declare -F ableton_config_init >/dev/null 2>&1 || {
+    echo "max9: support files are incomplete. Run the latest installer again." >&2
+    exit 1
+}
+if ! ableton_config_init 2>/dev/null; then
+    echo "max9: installer settings could not be read. Run the latest installer to repair them, then try again." >&2
+    exit 1
+fi
 for lib in "$here/lib/lifecycle.sh" "$ABLETON_DATA_HOME/lib/lifecycle.sh"; do
     if [ -r "$lib" ]; then . "$lib"; break; fi
 done
-declare -F ableton_max_pids >/dev/null 2>&1 || { echo "max9: lifecycle helper is missing" >&2; exit 1; }
+declare -F ableton_max_pids >/dev/null 2>&1 || {
+    echo "max9: support files are incomplete. Run the latest installer again." >&2
+    exit 1
+}
+for lib in "$here/lib/manifest.sh" "$ABLETON_DATA_HOME/lib/manifest.sh"; do
+    if [ -r "$lib" ]; then . "$lib"; break; fi
+done
+declare -F ableton_install_state_has_active_transaction >/dev/null 2>&1 || {
+    echo "max9: support files are incomplete. Run the latest installer again." >&2
+    exit 1
+}
 
 # Max exits cleanly, but a Max session leaves the same updater behind as a Live
 # one, and it holds the wineserver for the rest of the login session.
@@ -25,7 +41,14 @@ session_teardown()
 {
     local rc=$?
     [ -n "$session_started" ] || return "$rc"
-    ABLETON_SESSION_LABEL="Max" ableton_session_teardown || true
+    if ableton_install_lock_acquire; then
+        ABLETON_SESSION_LABEL="Max" ableton_session_teardown || true
+        # The descriptor closes automatically when this launcher exits. A
+        # failed explicit unlock here has no remaining user-visible effect.
+        ableton_install_lock_release || true
+    else
+        echo "max9: Max closed, but its background Wine processes were left running because installation work started." >&2
+    fi
     return "$rc"
 }
 
@@ -36,6 +59,27 @@ MAX_UNIX="$WINEPREFIX/drive_c/Program Files/Cycling '74/Max 9/Max.exe"
 [ -x "$WINE_ROOT/bin/wine" ] || { echo "max9: Wine runtime is missing at $WINE_ROOT" >&2; exit 1; }
 [ -f "$WINEPREFIX/system.reg" ] || { echo "max9: Wine prefix is missing at $WINEPREFIX" >&2; exit 1; }
 [ -f "$MAX_UNIX" ] || { echo "max9: no Max 9 installation in $WINEPREFIX" >&2; exit 1; }
+
+# Serialize launcher-side prefix work with installer, rollback, and uninstall.
+# The launcher releases this lock once Max is observable; its Wine child closes
+# only the inherited descriptor so the parent can hold the handoff safely.
+ableton_install_lock_acquire || {
+    echo "max9: installation work is in progress; retry this launch when it finishes" >&2
+    exit 1
+}
+if ableton_install_state_has_active_transaction; then
+    active_transaction_marker="$(find "$ABLETON_STATE_HOME/transactions" \
+        -mindepth 2 -maxdepth 3 -name active -print -quit 2>/dev/null || true)"
+    active_transaction="${active_transaction_marker%/active}"
+    [ -n "$active_transaction" ] || active_transaction="$ABLETON_STATE_HOME/transactions"
+    echo "max9: an earlier install stopped before it restored the Wine runtime or prefix." >&2
+    echo "max9: keep the recovery files at $active_transaction and report the problem before launching Max." >&2
+    ableton_install_lock_release || true
+    exit 1
+fi
+max_was_running=0
+max_running_pids="$(ableton_max_pids)"
+[ -z "$max_running_pids" ] || max_was_running=1
 
 # Armed after the guards: teardown ends this prefix's agents, and a launch that
 # refused to start has no session to end - Live may be running in this prefix.
@@ -50,14 +94,26 @@ export WINE_DISABLE_UNIX_MOUNT_REPARSE="${WINE_DISABLE_UNIX_MOUNT_REPARSE:-1}"
 export WINESERVER="$WINE_ROOT/bin/wineserver"
 export WINEDLLOVERRIDES="${caller_winedlloverrides:+$caller_winedlloverrides;}mscoree,mshtml="
 
-coordinator_dir="$(ableton_lifecycle_runtime_dir)"
-mkdir -p -- "$coordinator_dir"
-exec 9>"$coordinator_dir/bring-up.lock"
+coordinator_dir="$(ableton_lifecycle_runtime_dir)" || {
+    echo "max9: Max was not started because its launch lock could not be prepared. Try again; if it repeats, report the problem." >&2
+    exit 1
+}
+mkdir -p -- "$coordinator_dir" || {
+    echo "max9: Max was not started because its launch lock directory could not be created at $coordinator_dir. Check the directory permissions and try again." >&2
+    exit 1
+}
+exec 9>"$coordinator_dir/bring-up.lock" || {
+    echo "max9: Max was not started because its launch lock could not be opened. Check the file permissions and try again." >&2
+    exit 1
+}
 if ! flock -n 9; then
-    echo "max9: another Live/Max launcher is bringing this prefix up" >&2
+    echo "max9: another Live or Max launch is starting. Wait a few seconds and try again." >&2
     exit 1
 fi
-printf 'max %s\n' "$$" >&9
+printf 'max %s\n' "$$" >&9 || {
+    echo "max9: Max was not started because its launch lock could not be initialised. Try again; if it repeats, report the problem." >&2
+    exit 1
+}
 # This launcher owns the session from here: every wine invocation is below.
 session_started=1
 
@@ -74,7 +130,10 @@ fi
 args=()
 for arg in "$@"; do
     if [ -f "$arg" ]; then
-        converted="$(ableton_run_bounded 30 "$WINE_ROOT/bin/winepath" -w "$arg" 9>&- 2>/dev/null || true)"
+        converted="$(
+            ableton_install_lock_close_in_child || exit 1
+            ableton_run_bounded 30 "$WINE_ROOT/bin/winepath" -w "$arg" 9>&- 2>/dev/null
+        )" || converted=""
         [ -z "$converted" ] || arg="$converted"
     fi
     args+=("$arg")
@@ -84,28 +143,52 @@ linkctl="$ABLETON_DATA_HOME/ableton-linkctl"
 # Packaged installs (nix) stage it under the runtime root instead of $HOME.
 [ -x "$linkctl" ] || linkctl="$WINE_ROOT/share/ableton-wine/scripts/ableton-linkctl"
 if [ "$ABLETON_LINK_MODE" != off ] && [ -x "$linkctl" ]; then
-    "$linkctl" start || echo "max9: configured Link anchor failed to start" >&2
+    "$linkctl" start || echo "max9: Ableton Link could not start; Max will continue without it." >&2
 fi
 
+launch_timeout="$(ableton_timeout_value "${ABLETON_LAUNCH_TIMEOUT:-90}" ABLETON_LAUNCH_TIMEOUT 5 600)" || exit 2
 process_group=0
+handoff_token="${BASHPID:-$$}-${RANDOM:-0}-$SECONDS"
 if command -v setsid >/dev/null 2>&1; then
-    setsid -- "${run[@]}" "$MAX_EXE" "${args[@]}" 9>&- &
+    ( ableton_install_lock_close_in_child || exit 1
+      export ABLETON_LAUNCH_HANDOFF="$handoff_token"
+      exec setsid -- "${run[@]}" "$MAX_EXE" "${args[@]}" 9>&- ) &
     process_group=1
 else
-    "${run[@]}" "$MAX_EXE" "${args[@]}" 9>&- &
+    ( ableton_install_lock_close_in_child || exit 1
+      export ABLETON_LAUNCH_HANDOFF="$handoff_token"
+      exec "${run[@]}" "$MAX_EXE" "${args[@]}" 9>&- ) &
 fi
 child=$!
 ready=0
-launch_timeout="$(ableton_timeout_value "${ABLETON_LAUNCH_TIMEOUT:-90}" ABLETON_LAUNCH_TIMEOUT 5 600)" || exit 2
+rc=0
 for ((i=0; i<launch_timeout*10; i++)); do
-    if [ -n "$(ableton_max_pids | head -n 1)" ]; then ready=1; break; fi
+    if [ "$max_was_running" -eq 1 ]; then
+        readiness_pids="$(ableton_prefix_pids)"
+    else
+        readiness_pids="$(ableton_max_pids)"
+    fi
+    while IFS= read -r readiness_pid; do
+        [ -n "$readiness_pid" ] || continue
+        if ableton_pid_has_env "$readiness_pid" "ABLETON_LAUNCH_HANDOFF=$handoff_token"; then
+            ready=1
+            break
+        fi
+    done <<< "$readiness_pids"
+    [ "$ready" -ne 1 ] || break
     kill -0 "$child" 2>/dev/null || break
     sleep 0.1
 done
-flock -u 9 2>/dev/null || true
-exec 9>&-
 if [ "$ready" -ne 1 ]; then
-    if [ "$process_group" -eq 1 ] && kill -0 -- "-$child" 2>/dev/null; then
+    if ! kill -0 "$child" 2>/dev/null; then
+        wait "$child" 2>/dev/null || rc=$?
+        if [ "$max_was_running" -eq 1 ] && [ "$rc" -eq 0 ]; then
+            flock -u 9 2>/dev/null || true
+            exec 9>&-
+            ableton_install_lock_release || true
+            exit 0
+        fi
+    elif [ "$process_group" -eq 1 ] && kill -0 -- "-$child" 2>/dev/null; then
         kill -TERM -- "-$child" 2>/dev/null || true
         for _ in {1..50}; do kill -0 -- "-$child" 2>/dev/null || break; sleep 0.1; done
         kill -0 -- "-$child" 2>/dev/null && kill -KILL -- "-$child" 2>/dev/null || true
@@ -114,8 +197,16 @@ if [ "$ready" -ne 1 ]; then
         for _ in {1..50}; do kill -0 "$child" 2>/dev/null || break; sleep 0.1; done
         kill -0 "$child" 2>/dev/null && kill -KILL "$child" 2>/dev/null || true
     fi
-    wait "$child" 2>/dev/null || true
-    echo "max9: Max did not become observable within ${launch_timeout}s" >&2
+    if kill -0 "$child" 2>/dev/null; then
+        wait "$child" 2>/dev/null || true
+    fi
+    flock -u 9 2>/dev/null || true
+    exec 9>&-
+    echo "max9: Max did not start within ${launch_timeout}s. Try again; if it repeats, run the latest installer." >&2
     exit 1
 fi
+flock -u 9 2>/dev/null || true
+exec 9>&-
+ableton_install_lock_release || \
+    echo "max9: Max started, but installer changes will remain blocked until Max closes." >&2
 wait "$child"

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -11,8 +11,15 @@ for lib in "$here/lib/config.sh" "$here/config.sh" \
     if [ -r "$lib" ]; then . "$lib"; break; fi
 done
 declare -F ableton_config_init >/dev/null 2>&1 || {
-    echo "!! rollback cannot find its installation configuration" >&2; exit 1; }
-ableton_config_init
+    echo "!! The previous-version restore cannot find its installation settings." >&2; exit 1; }
+# Saved settings are optional to the runtime rollback.  Repair mode salvages
+# any individually valid paths from a damaged settings file and, when trusted
+# paths were supplied by the caller, lets the core runtime/registry checks
+# proceed.  The post-core settings restore below still refuses directories,
+# symlinks, and concurrent changes without undoing a valid runtime swap.
+ABLETON_CONFIG_LAYOUT_ROOTS='runtime prefix state'
+export ABLETON_CONFIG_LAYOUT_ROOTS
+ableton_config_init repair
 for name in lifecycle manifest pipeasio; do
     found=""
     for lib in "$here/lib/$name.sh" "$ABLETON_DATA_HOME/lib/$name.sh"; do
@@ -22,22 +29,31 @@ for name in lifecycle manifest pipeasio; do
         found=1
         break
     done
-    [ -n "$found" ] || { echo "!! rollback helper $name.sh is missing" >&2; exit 1; }
+    [ -n "$found" ] || { echo "!! The previous-version restore is missing $name.sh." >&2; exit 1; }
 done
 
-[ $# -eq 0 ] || { echo "!! rollback takes no arguments" >&2; exit 2; }
+[ $# -eq 0 ] || { echo "!! Restoring the previous Wine version does not take options." >&2; exit 2; }
 ableton_install_lock_acquire
 
 runtime="$ABLETON_WINE_ROOT"
 runtime_parent="$(dirname "$runtime")"
 runtime_base="$(basename "$runtime")"
 if [ -L "$runtime" ] || ! ableton_runtime_marker_valid "$runtime" "$ABLETON_RUNTIME_NAME"; then
-    echo "!! current runtime is not a managed Ableton runtime" >&2
+    echo "!! The installed Wine runtime is not recognized." >&2
     exit 1
 fi
 
 saved=""
 saved_mtime=-1
+candidate_inventory="$(mktemp "${TMPDIR:-/tmp}/ableton-runtime-rollbacks.XXXXXX")" || {
+    echo "!! cannot prepare the search for a previous Wine runtime" >&2
+    exit 1
+}
+if ! find "$runtime_parent" -maxdepth 1 -mindepth 1 -type d -print0 > "$candidate_inventory"; then
+    rm -f -- "$candidate_inventory" 2>/dev/null || true
+    echo "!! cannot inspect the previous Wine runtimes under $runtime_parent" >&2
+    exit 1
+fi
 while IFS= read -r -d '' candidate; do
     [ -n "$candidate" ] || continue
     candidate_base="$(basename "$candidate")"
@@ -50,24 +66,31 @@ while IFS= read -r -d '' candidate; do
        || [ -L "$candidate/.ableton-linux-rollback-incomplete" ]; then
         continue
     fi
-    candidate_mtime="$(stat -c '%Y' -- "$candidate" 2>/dev/null || printf 0)"
+    if ! candidate_mtime="$(stat -c '%Y' -- "$candidate" 2>/dev/null)"; then
+        continue
+    fi
     if [ "$candidate_mtime" -gt "$saved_mtime" ]; then
         saved="$candidate"
         saved_mtime="$candidate_mtime"
     fi
-done < <(find "$runtime_parent" -maxdepth 1 -mindepth 1 -type d -print0 2>/dev/null)
-[ -n "$saved" ] || { echo "!! no completed runtime rollback is available" >&2; exit 1; }
+done < "$candidate_inventory"
+rm -f -- "$candidate_inventory" 2>/dev/null || true
+[ -n "$saved" ] || { echo "!! There is no previous Wine version to restore." >&2; exit 1; }
 for required in bin/wine bin/wineserver \
     lib/wine/x86_64-windows/pipeasio64.dll \
     lib/wine/x86_64-unix/pipeasio64.dll.so; do
-    [ -s "$saved/$required" ] || { echo "!! saved runtime is incomplete: $required" >&2; exit 1; }
+    [ -s "$saved/$required" ] || { echo "!! The previous Wine version is incomplete: $required" >&2; exit 1; }
 done
+ableton_pipeasio_validate_runtime "$runtime" >/dev/null 2>&1 || {
+    echo "!! The installed Wine runtime did not pass its Wine and PipeASIO checks." >&2
+    exit 1
+}
+ableton_pipeasio_validate_runtime "$saved" >/dev/null 2>&1 || {
+    echo "!! The previous Wine version did not pass its Wine and PipeASIO checks." >&2
+    exit 1
+}
 
 saved_meta_dir="$saved/.ableton-linux-rollback"
-if [ -e "$saved_meta_dir" ] || [ -L "$saved_meta_dir" ]; then
-    [ ! -L "$saved_meta_dir" ] && [ -d "$saved_meta_dir" ] || {
-        echo "!! saved rollback metadata directory is unsafe" >&2; exit 1; }
-fi
 metadata="$saved_meta_dir/metadata"
 rollback_config_snapshot_valid()
 {
@@ -82,13 +105,6 @@ rollback_config_snapshot_valid()
     digest="$(ableton_manifest_digest "$snapshot" 2>/dev/null || true)"
     [ -n "$digest" ]
 }
-if [ -e "$metadata" ] || [ -L "$metadata" ]; then
-    if ! { [ -f "$metadata" ] && [ ! -L "$metadata" ] && [ -r "$metadata" ] \
-           && ableton_file_has_no_nul "$metadata"; }; then
-        echo "!! saved rollback metadata is unsafe or unreadable" >&2
-        exit 1
-    fi
-fi
 metadata_value()
 {
     local key="$1" count value
@@ -105,42 +121,57 @@ installer_config_state=unchanged
 pipeasio_config_state=unchanged
 desired_panel=0
 metadata_present=0
-if [ -r "$metadata" ]; then
-    metadata_present=1
-    [ "$(metadata_value format)" = 1 ] || { echo "!! saved rollback metadata is invalid" >&2; exit 1; }
-    [ "$(metadata_value runtime_root)" = "$runtime" ] || {
-        echo "!! saved rollback belongs to a different runtime path" >&2; exit 1; }
-    recorded_prefix="$(metadata_value prefix)"
-    [ "$recorded_prefix" = "$ABLETON_WINEPREFIX" ] || {
-        echo "!! saved rollback belongs to a different Wine prefix" >&2; exit 1; }
-    [ "$(metadata_value installer_config_path)" = "$installer_config_path" ] || {
-        echo "!! saved rollback belongs to a different configuration directory" >&2; exit 1; }
-    [ "$(metadata_value pipeasio_config_path)" = "$pipeasio_config_path" ] || {
-        echo "!! saved rollback belongs to a different PipeASIO configuration directory" >&2; exit 1; }
-    installer_config_state="$(metadata_value installer_config_state)"
-    pipeasio_config_state="$(metadata_value pipeasio_config_state)"
-    desired_panel="$(metadata_value panel_integration)"
-    case "$installer_config_state:$pipeasio_config_state:$desired_panel" in
+load_saved_settings()
+{
+    local format recorded_runtime recorded_prefix recorded_installer_path
+    local recorded_pipeasio_path saved_installer_state saved_pipeasio_state saved_panel
+    [ -d "$saved_meta_dir" ] && [ ! -L "$saved_meta_dir" ] || return 1
+    [ -f "$metadata" ] && [ ! -L "$metadata" ] && [ -r "$metadata" ] \
+        && ableton_file_has_no_nul "$metadata" || return 1
+    format="$(metadata_value format)" || return 1
+    recorded_runtime="$(metadata_value runtime_root)" || return 1
+    recorded_prefix="$(metadata_value prefix)" || return 1
+    recorded_installer_path="$(metadata_value installer_config_path)" || return 1
+    recorded_pipeasio_path="$(metadata_value pipeasio_config_path)" || return 1
+    saved_installer_state="$(metadata_value installer_config_state)" || return 1
+    saved_pipeasio_state="$(metadata_value pipeasio_config_state)" || return 1
+    saved_panel="$(metadata_value panel_integration)" || return 1
+    [ "$format" = 1 ] \
+        && [ "$recorded_runtime" = "$runtime" ] \
+        && [ "$recorded_prefix" = "$ABLETON_WINEPREFIX" ] \
+        && [ "$recorded_installer_path" = "$installer_config_path" ] \
+        && [ "$recorded_pipeasio_path" = "$pipeasio_config_path" ] || return 1
+    case "$saved_installer_state:$saved_pipeasio_state:$saved_panel" in
         present:present:0|present:present:1|present:absent:0|present:absent:1|\
-        absent:present:0|absent:present:1|absent:absent:0|absent:absent:1) ;;
-        *) echo "!! saved rollback configuration state is invalid" >&2; exit 1 ;;
+        present:unchanged:0|present:unchanged:1|\
+        absent:present:0|absent:present:1|absent:absent:0|absent:absent:1|\
+        absent:unchanged:0|absent:unchanged:1|\
+        unchanged:present:0|unchanged:present:1|\
+        unchanged:absent:0|unchanged:absent:1|\
+        unchanged:unchanged:0|unchanged:unchanged:1) ;;
+        *) return 1 ;;
     esac
-    [ "$installer_config_state" != present ] \
+    [ "$saved_installer_state" != present ] \
         || rollback_config_snapshot_valid "$saved/.ableton-linux-rollback/installer-config" \
-        || { echo "!! saved installer configuration is missing" >&2; exit 1; }
-    [ "$pipeasio_config_state" != present ] \
+        || return 1
+    [ "$saved_pipeasio_state" != present ] \
         || rollback_config_snapshot_valid "$saved/.ableton-linux-rollback/pipeasio-config.ini" \
-        || { echo "!! saved PipeASIO configuration is missing" >&2; exit 1; }
-fi
-
-for current_config in "$installer_config_path" "$pipeasio_config_path"; do
-    if [ -e "$current_config" ] || [ -L "$current_config" ]; then
-        rollback_config_snapshot_valid "$current_config" || {
-            echo "!! current rollback configuration is unsafe: $current_config" >&2
-            exit 1
-        }
+        || return 1
+    installer_config_state="$saved_installer_state"
+    pipeasio_config_state="$saved_pipeasio_state"
+    desired_panel="$saved_panel"
+    metadata_present=1
+}
+if [ -e "$saved_meta_dir" ] || [ -L "$saved_meta_dir" ]; then
+    if ! load_saved_settings; then
+        installer_config_state=unchanged
+        pipeasio_config_state=unchanged
+        desired_panel=0
+        metadata_present=0
+        echo "!! The saved runtime is usable, but its saved settings are unavailable. Current settings will stay in place." >&2 \
+            || true
     fi
-done
+fi
 
 refuse_runtime_users()
 {
@@ -151,9 +182,9 @@ refuse_runtime_users()
             ableton_pid_uses_prefix "$pid" && selected_prefix_user=1
         done
         if [ "$selected_prefix_user" -eq 1 ]; then
-            echo "!! Live, Max, or another Wine client is running; close it before rollback" >&2
+            echo "!! Close Live, Max, or the listed Wine program before restoring the previous version." >&2
         else
-            echo "!! another Wine prefix is using this runtime; close it before rollback" >&2
+            echo "!! Close the listed program using this Wine runtime before restoring the previous version." >&2
         fi
         # "close Live" is unactionable when the holder is a windowless agent.
         for pid in $runtime_users; do
@@ -164,40 +195,74 @@ refuse_runtime_users()
 }
 refuse_runtime_users
 
-probe="$ABLETON_DATA_HOME/pipewire-version-probe"
-[ -x "$probe" ] || probe="$runtime/bin/pipewire-version-probe"
+probe="$runtime/bin/pipewire-version-probe"
 ableton_pipewire_preflight "$probe" "rolling PipeASIO back"
 
-ableton_mark_state_home
-mkdir -p -- "$ABLETON_STATE_HOME/transactions"
-transaction="$(mktemp -d "$ABLETON_STATE_HOME/transactions/rollback.XXXXXX")"
-ABLETON_TRANSACTION_DIR="$transaction"
+transaction=""
+transaction_kind=none
+transaction_parent=""
+# A failure record is useful, but it is not a prerequisite for swapping two
+# already validated runtimes. Prefer durable state, fall back to private
+# temporary scratch, and continue without either if the host cannot create it.
+if ableton_prepare_transactions_dir >/dev/null 2>&1 \
+   && transaction="$(mktemp -d "$ABLETON_STATE_HOME/transactions/rollback.XXXXXX" 2>/dev/null)"; then
+    transaction_kind=state
+    transaction_parent="$ABLETON_STATE_HOME/transactions"
+elif transaction="$(mktemp -d "${TMPDIR:-/tmp}/ableton-runtime-restore.XXXXXX" 2>/dev/null)"; then
+    transaction_kind=temporary
+    transaction_parent="${transaction%/*}"
+else
+    transaction=""
+fi
+# The runtime swap has no host-file mutations to journal, so optional panel
+# repair does not use manifest.sh's file transaction.
+ABLETON_TRANSACTION_DIR=""
 export ABLETON_TRANSACTION_DIR
+
+remove_failure_scratch()
+{
+    local expected_prefix
+    [ -n "$transaction" ] || return 0
+    case "$transaction_kind" in
+        state) expected_prefix="$ABLETON_STATE_HOME/transactions/rollback." ;;
+        temporary) expected_prefix="$transaction_parent/ableton-runtime-restore." ;;
+        *) return 1 ;;
+    esac
+    case "$transaction" in "$expected_prefix"*) ;; *) return 1 ;; esac
+    if [ ! -e "$transaction" ] && [ ! -L "$transaction" ]; then return 0; fi
+    [ -d "$transaction" ] && [ ! -L "$transaction" ] || return 1
+    rm -rf -- "$transaction"
+    [ ! -e "$transaction" ] && [ ! -L "$transaction" ]
+}
 # ShellCheck does not follow function names stored in traps.
 # shellcheck disable=SC2329
 cleanup_unstarted_rollback()
 {
     local rc=$?
     trap - EXIT
-    if [ "$rc" -ne 0 ] && ! rm -rf -- "$transaction"; then
-        echo "!! failed to remove unstarted rollback transaction: $transaction" >&2
+    if [ "$rc" -ne 0 ] && ! remove_failure_scratch; then
+        echo "!! The previous-version restore stopped before changing Wine. Temporary files remain at $transaction." >&2 \
+            || true
     fi
     exit "$rc"
 }
 trap cleanup_unstarted_rollback EXIT
-ableton_txn_init
 
 now="$(date -u +%Y%m%dT%H%M%SZ)"
 reverse="$runtime-rollback-$now"
 if [ -e "$reverse" ] || [ -L "$reverse" ]; then reverse="$reverse-$$"; fi
 [ ! -e "$reverse" ] && [ ! -L "$reverse" ] || {
-    echo "!! cannot choose an unused reverse-rollback path" >&2; exit 1; }
+    echo "!! A safe path for the current Wine version could not be prepared." >&2; exit 1; }
 current_moved=0
 saved_promoted=0
 registration_attempted=0
 reverse_meta=""
 reverse_meta_tmp=""
 reverse_meta_preexisting=0
+reverse_metadata_ready=0
+config_restore_ready=1
+panel_restore_ready=1
+rollback_committed=0
 
 rollback_wine()
 {
@@ -220,17 +285,25 @@ move_runtime_to_empty()
 
 rollback_failure()
 {
-    local rc=$? restore_error="" runtime_layout_restored=1 failure_complete
+    local rc=$? restore_error="" runtime_layout_restored=1 failure_complete failure_record=""
     trap - EXIT
+    # Recovery must not depend on being able to write its explanation to a
+    # terminal that may already have closed.
+    set +e
+    # A normal end reaches the EXIT trap too.  It needs no recovery message;
+    # printing the committed-error warning here would falsely tell every
+    # successful rollback to rerun the installer.
+    [ "$rc" -ne 0 ] || return 0
+    if [ "$rollback_committed" -eq 1 ]; then
+        echo "!! The previous Wine version is restored. Run the installer again to retry its shortcuts or saved settings." >&2 || true
+        exit 0
+    fi
     case "$reverse_meta_tmp" in
         "$reverse_meta/.metadata."*)
             if ! rm -f -- "$reverse_meta_tmp"; then
                 restore_error="temporary rollback metadata cleanup failed"
             fi ;;
     esac
-    if ! ableton_txn_rollback_files "$transaction" >/dev/null 2>&1; then
-        restore_error="host file restoration failed"
-    fi
     if [ "$reverse_meta_preexisting" -eq 0 ] && [ -n "$reverse_meta" ]; then
         if ! rmdir -- "$reverse_meta" 2>/dev/null; then
             restore_error="${restore_error}${restore_error:+; }temporary rollback directory cleanup failed"
@@ -262,7 +335,10 @@ rollback_failure()
     if [ "$registration_attempted" -eq 1 ]; then
         if [ "$runtime_layout_restored" -eq 1 ] && [ -x "$runtime/bin/wine" ] \
            && [ -f "$ABLETON_WINEPREFIX/system.reg" ]; then
-            if ! ableton_pipeasio_register rollback_wine rollback_wineserver_wait >/dev/null 2>&1; then
+            if ! ableton_pipewire_preflight "$runtime/bin/pipewire-version-probe" \
+                    "restoring the original PipeASIO registration" >/dev/null 2>&1 \
+               || ! ableton_pipeasio_register rollback_wine rollback_wineserver_wait \
+                    >/dev/null 2>&1; then
                 restore_error="${restore_error}${restore_error:+; }original PipeASIO registration could not be restored"
             fi
         else
@@ -270,17 +346,27 @@ rollback_failure()
         fi
     fi
     failure_complete="$([ -z "$restore_error" ] && echo yes || echo no)"
-    if ! printf 'exit=%s\nsaved=%s\nruntime_restored=%s\nrestoration_complete=%s\n' \
-        "$rc" "$saved" "$([ "$runtime_layout_restored" -eq 1 ] && echo yes || echo no)" \
-        "$failure_complete" > "$transaction/FAILURE"; then
-        restore_error="${restore_error}${restore_error:+; }failure record could not be written"
+    if [ -n "$transaction" ]; then
+        failure_record="$transaction/FAILURE"
+        if ! printf 'exit=%s\nsaved=%s\nruntime_restored=%s\nrestoration_complete=%s\n' \
+            "$rc" "$saved" "$([ "$runtime_layout_restored" -eq 1 ] && echo yes || echo no)" \
+            "$failure_complete" > "$failure_record"; then
+            failure_record=""
+        fi
     fi
     if [ -n "$restore_error" ]; then
-        printf '!! rollback failed and automatic runtime restoration is incomplete: %s\n' \
-            "$restore_error" >&2
-        echo "!! Leave the runtime directories in place and inspect the failure record." >&2
+        printf '!! The previous Wine version could not be restored automatically: %s\n' \
+            "$restore_error" >&2 || true
+        if [ -n "$failure_record" ]; then
+            echo "!! Leave both Wine runtime directories in place and keep $failure_record before retrying." >&2 \
+                || true
+        else
+            echo "!! Leave both Wine runtime directories in place before retrying; failure details could not be saved." >&2 \
+                || true
+        fi
     else
-        echo "!! rollback failed; the previous runtime and files were restored" >&2
+        echo "!! The restore did not finish. The Wine version from before this attempt is back in place." >&2 \
+            || true
     fi
     exit "$rc"
 }
@@ -298,7 +384,7 @@ if [ -r "$manifest" ] && awk -F '\t' -v b="$ABLETON_BIN_HOME/pipeasio-settings" 
 fi
 [ "$metadata_present" -eq 1 ] || desired_panel="$panel_integration_now"
 
-echo "== restore the previous runtime =="
+echo "== Restore the previous Wine version ==" || true
 refuse_runtime_users
 # The two same-filesystem renames are a single logical swap.  Ignore terminal
 # signals only for this tiny critical section so EXIT recovery never observes
@@ -317,109 +403,136 @@ saved_promoted=1
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
-# Store the state being displaced inside the reverse rollback before changing
-# host configuration.  This makes a second invocation a safe undo.
-reverse_meta="$reverse/.ableton-linux-rollback"
-if [ -e "$reverse_meta" ] || [ -L "$reverse_meta" ]; then
-    [ ! -L "$reverse_meta" ] && [ -d "$reverse_meta" ] || {
-        echo "!! current runtime has an unsafe rollback metadata directory" >&2; exit 1; }
-    reverse_meta_preexisting=1
-else
-    mkdir -p -- "$reverse_meta"
+# The runtime swap is usable only after PipeASIO has been registered from the
+# restored runtime.  This is the last core rollback step; failures before it put
+# the original runtime and registration back.
+if [ -f "$ABLETON_WINEPREFIX/system.reg" ]; then
+    export WINEPREFIX="$ABLETON_WINEPREFIX"
+    probe="$runtime/bin/pipewire-version-probe"
+    ableton_pipewire_preflight "$probe" "registering the restored PipeASIO"
+    registration_attempted=1
+    ableton_pipeasio_register rollback_wine rollback_wineserver_wait
 fi
-ableton_txn_snapshot "$reverse_meta/installer-config"
-ableton_txn_snapshot "$reverse_meta/pipeasio-config.ini"
-ableton_txn_snapshot "$reverse_meta/metadata"
-if [ -e "$installer_config_path" ] || [ -L "$installer_config_path" ]; then
-    ableton_txn_expect "$reverse_meta/installer-config" \
-        "$(ableton_object_token "$installer_config_path")"
-    ableton_atomic_restore_object "$installer_config_path" "$reverse_meta/installer-config"
-    reverse_installer_state=present
-else
-    ableton_txn_expect "$reverse_meta/installer-config" absent
-    rm -f -- "$reverse_meta/installer-config"
-    reverse_installer_state=absent
-fi
-if [ -e "$pipeasio_config_path" ] || [ -L "$pipeasio_config_path" ]; then
-    ableton_txn_expect "$reverse_meta/pipeasio-config.ini" \
-        "$(ableton_object_token "$pipeasio_config_path")"
-    ableton_atomic_restore_object "$pipeasio_config_path" "$reverse_meta/pipeasio-config.ini"
-    reverse_pipeasio_state=present
-else
-    ableton_txn_expect "$reverse_meta/pipeasio-config.ini" absent
-    rm -f -- "$reverse_meta/pipeasio-config.ini"
-    reverse_pipeasio_state=absent
-fi
-reverse_meta_tmp="$(mktemp "$reverse_meta/.metadata.XXXXXX")"
+rollback_committed=1
+# Everything after the validated runtime swap and PipeASIO registration is
+# optional repair, cleanup, or presentation. A closed terminal must not stop
+# later saved-setting, panel, inventory, and recovery-file work from running.
+set +e
+
+# Save enough information to undo this rollback. This is a convenience after
+# the restored runtime and registry are already valid, so failure only removes
+# the automatic undo option; it does not reverse a successful rollback.
+save_reverse_metadata()
 {
-    printf 'format=1\n'
-    printf 'runtime_root=%s\n' "$runtime"
-    printf 'prefix=%s\n' "$ABLETON_WINEPREFIX"
-    printf 'installer_config_path=%s\n' "$installer_config_path"
-    printf 'installer_config_state=%s\n' "$reverse_installer_state"
-    printf 'pipeasio_config_path=%s\n' "$pipeasio_config_path"
-    printf 'pipeasio_config_state=%s\n' "$reverse_pipeasio_state"
-    printf 'panel_integration=%s\n' "$panel_integration_now"
-} > "$reverse_meta_tmp"
-chmod 600 "$reverse_meta_tmp"
-ableton_txn_expect "$reverse_meta/metadata" \
-    "$(ableton_regular_source_token "$reverse_meta_tmp")"
-mv -f -- "$reverse_meta_tmp" "$reverse_meta/metadata"
+    reverse_meta="$reverse/.ableton-linux-rollback"
+    if [ -e "$reverse_meta" ] || [ -L "$reverse_meta" ]; then
+        [ ! -L "$reverse_meta" ] && [ -d "$reverse_meta" ] || return 1
+        reverse_meta_preexisting=1
+    else
+        mkdir -p -- "$reverse_meta" || return 1
+    fi
+    if [ -e "$installer_config_path" ] || [ -L "$installer_config_path" ]; then
+        ableton_atomic_restore_object "$installer_config_path" \
+            "$reverse_meta/installer-config" || return 1
+        reverse_installer_state=present
+    else
+        rm -f -- "$reverse_meta/installer-config" || return 1
+        reverse_installer_state=absent
+    fi
+    if [ -e "$pipeasio_config_path" ] || [ -L "$pipeasio_config_path" ]; then
+        ableton_atomic_restore_object "$pipeasio_config_path" \
+            "$reverse_meta/pipeasio-config.ini" || return 1
+        reverse_pipeasio_state=present
+    else
+        rm -f -- "$reverse_meta/pipeasio-config.ini" || return 1
+        reverse_pipeasio_state=absent
+    fi
+    reverse_meta_tmp="$(mktemp "$reverse_meta/.metadata.XXXXXX")" || return 1
+    if ! {
+        printf 'format=1\n'
+        printf 'runtime_root=%s\n' "$runtime"
+        printf 'prefix=%s\n' "$ABLETON_WINEPREFIX"
+        printf 'installer_config_path=%s\n' "$installer_config_path"
+        printf 'installer_config_state=%s\n' "$reverse_installer_state"
+        printf 'pipeasio_config_path=%s\n' "$pipeasio_config_path"
+        printf 'pipeasio_config_state=%s\n' "$reverse_pipeasio_state"
+        printf 'panel_integration=%s\n' "$panel_integration_now"
+    } > "$reverse_meta_tmp" \
+       || ! chmod 600 "$reverse_meta_tmp" \
+       || ! mv -f -- "$reverse_meta_tmp" "$reverse_meta/metadata"; then
+        return 1
+    fi
+    reverse_meta_tmp=""
+    reverse_metadata_ready=1
+}
+
+if ! save_reverse_metadata; then
+    case "$reverse_meta_tmp" in
+        "$reverse_meta/.metadata."*) rm -f -- "$reverse_meta_tmp" 2>/dev/null || true ;;
+    esac
+    echo "!! The previous Wine version is restored, but the newer version could not be saved for another switch." >&2 \
+        || true
+fi
 
 restore_config_snapshot()
 {
     local state="$1" source="$2" target="$3"
     [ "$state" != unchanged ] || return 0
-    ableton_txn_snapshot "$target"
     [ ! -d "$target" ] || { echo "!! refusing to replace configuration directory $target" >&2; return 1; }
     if [ "$state" = present ]; then
-        ableton_txn_expect "$target" "$(ableton_object_token "$source")"
+        ableton_atomic_restore_object "$source" "$target" || return 1
     else
-        ableton_txn_expect "$target" absent
-    fi
-    if [ "$state" = present ]; then
-        ableton_atomic_restore_object "$source" "$target"
-    else
-        rm -f -- "$target"
+        rm -f -- "$target" || return 1
     fi
 }
 
-echo "== restore recorded configuration =="
-restore_config_snapshot "$installer_config_state" \
-    "$runtime/.ableton-linux-rollback/installer-config" "$installer_config_path"
-restore_config_snapshot "$pipeasio_config_state" \
-    "$runtime/.ableton-linux-rollback/pipeasio-config.ini" "$pipeasio_config_path"
+echo "== Restore saved settings ==" || true
+if ! restore_config_snapshot "$installer_config_state" \
+    "$runtime/.ableton-linux-rollback/installer-config" "$installer_config_path"; then
+    config_restore_ready=0
+    echo "!! The previous Wine version is restored, but its installer settings could not be restored." >&2 \
+        || true
+fi
+if ! restore_config_snapshot "$pipeasio_config_state" \
+    "$runtime/.ableton-linux-rollback/pipeasio-config.ini" "$pipeasio_config_path"; then
+    config_restore_ready=0
+    echo "!! The previous Wine version is restored, but its PipeASIO settings could not be restored." >&2 \
+        || true
+fi
 
 if ableton_pipeasio_validate_runtime "$runtime" >/dev/null 2>&1; then
     if [ "$desired_panel" -eq 1 ]; then
-        ableton_pipeasio_sync_panel "$runtime" install
+        ableton_pipeasio_sync_panel "$runtime" install || panel_restore_ready=0
     else
-        ableton_pipeasio_remove_panel_integration
+        ableton_pipeasio_remove_panel_integration || panel_restore_ready=0
     fi
 else
     # Legacy runtimes have no sealed panel contract.  Remove only projections
     # whose literal manifest digest still proves this project owns them.
-    ableton_pipeasio_remove_panel_integration
+    ableton_pipeasio_remove_panel_integration || panel_restore_ready=0
 fi
-
-if [ -f "$ABLETON_WINEPREFIX/system.reg" ]; then
-    export WINEPREFIX="$ABLETON_WINEPREFIX"
-    probe="$ABLETON_DATA_HOME/pipewire-version-probe"
-    [ -x "$probe" ] || probe="$reverse/bin/pipewire-version-probe"
-    ableton_pipewire_preflight "$probe" "registering the restored PipeASIO"
-    registration_attempted=1
-    ableton_pipeasio_register rollback_wine rollback_wineserver_wait
-fi
+[ "$panel_restore_ready" -eq 1 ] \
+    || echo "!! The previous Wine version is restored, but the PipeASIO Settings shortcut could not be updated." >&2 \
+    || true
 
 ABLETON_RUNTIME_INSTALLED=1
 export ABLETON_RUNTIME_INSTALLED
-ableton_write_ownership_manifest
+ableton_write_ownership_manifest \
+    || echo "!! The previous Wine version is restored, but the installed-file list could not be updated." >&2 \
+    || true
 update-desktop-database "${XDG_DATA_HOME:-$HOME/.local/share}/applications" >/dev/null 2>&1 || true
-gtk-update-icon-cache -q "${XDG_DATA_HOME:-$HOME/.local/share}/icons/hicolor" >/dev/null 2>&1 || true
 
-rm -f -- "$transaction/active"
-trap - EXIT
-case "$transaction" in "$ABLETON_STATE_HOME/transactions/rollback."*) rm -rf -- "$transaction" ;; esac
+rollback_cleanup_ready=1
+remove_failure_scratch || rollback_cleanup_ready=0
+[ "$rollback_cleanup_ready" -eq 1 ] \
+    || echo "!! The previous Wine version is restored, but temporary files remain at $transaction." >&2 \
+    || true
 
-echo "OK: restored the previous runtime and its recorded configuration"
-printf '   current runtime: %s\n   undo rollback: %s\n' "$runtime" "$reverse"
+echo "OK: The previous Wine version is restored." || true
+printf '   Wine runtime: %s\n' "$runtime" || true
+if [ "$reverse_metadata_ready" -eq 1 ]; then
+    printf '   newer Wine version saved at: %s\n' "$reverse" || true
+else
+    echo "   newer Wine version: not saved" || true
+fi
+[ "$config_restore_ready" -eq 1 ] || echo "   saved settings: retry needed" || true

--- a/scripts/setup-link.sh
+++ b/scripts/setup-link.sh
@@ -6,15 +6,11 @@ set -euo pipefail
 here="$(cd "$(dirname "$0")" && pwd)"
 for lib in "$here/lib/config.sh" "$here/config.sh" \
            "${XDG_DATA_HOME:-$HOME/.local/share}/ableton-wine/lib/config.sh"; do
+    # The first installed/repository helper wins.
+    # shellcheck disable=SC1090
     if [ -r "$lib" ]; then . "$lib"; break; fi
 done
 declare -F ableton_config_init >/dev/null 2>&1 || { echo "!! setup-link: config helper is missing" >&2; exit 1; }
-ableton_config_init
-for lib in "$here/lib/manifest.sh" "$ABLETON_DATA_HOME/lib/manifest.sh"; do
-    if [ -r "$lib" ]; then . "$lib"; break; fi
-done
-declare -F ableton_validate_install_state_journals >/dev/null 2>&1 || {
-    echo "!! setup-link: ownership helper is missing" >&2; exit 1; }
 
 action="${1:-enable}"
 [ $# -eq 0 ] || shift
@@ -40,16 +36,93 @@ fi
 case "$action" in enable|disable|status|snapshot|preflight-rollback|preflight-commit|rollback|commit|plan-enable|plan-disable) ;;
     *) echo "usage: setup-link.sh enable [--mode=session|always] | disable | status" >&2; exit 2 ;;
 esac
+
+LINK_COORDINATED_ACTION=0
+coordinator_dir="${ABLETON_TRANSACTION_DIR:-}"
+if [ "${ABLETON_LINK_COORDINATED:-0}" = 1 ]; then
+    LINK_COORDINATED_ACTION=1
+fi
+case "$action:$coordinator_dir" in
+    enable:/*|disable:/*)
+        if [ -d "$coordinator_dir" ] && [ ! -L "$coordinator_dir" ] \
+           && [ -f "$coordinator_dir/active" ] && [ ! -L "$coordinator_dir/active" ] \
+           && [ ! -s "$coordinator_dir/active" ]; then
+            LINK_COORDINATED_ACTION=1
+        fi ;;
+esac
+
+repair_link_config_before_init()
+{
+    local candidate parent name header format nul_count
+    case "$action" in enable|disable) ;; *) return 0 ;; esac
+    if [ "${ABLETON_CONFIG_REPAIR_MODE:-0}" = 1 ] \
+       && [ -n "${ABLETON_CONFIG_SNAPSHOT_PATH:-}" ] \
+       && [ -n "${ABLETON_CONFIG_SNAPSHOT_TOKEN:-}" ] \
+       && [ -n "${ABLETON_CONFIG_SNAPSHOT_VALUES:-}" ]; then
+        # The public installer already bound this object under the lifecycle
+        # lock and salvaged/defaulted its usable values.
+        return 0
+    fi
+    candidate="${ABLETON_CONFIG_FILE:-${XDG_CONFIG_HOME:-$HOME/.config}/ableton-wine/config}"
+    parent="$(ableton_realpath_m "$(dirname -- "$candidate")")" || return 1
+    name="$(basename -- "$candidate")" || return 1
+    candidate="$parent/$name"
+    [ -e "$candidate" ] || [ -L "$candidate" ] || return 0
+    ableton_managed_config_valid "$candidate" && return 0
+    # A project-owned regular file from an older format can be repaired by the
+    # shared field-by-field parser. Foreign objects, directories, and symlinks
+    # remain a hard pre-mutation boundary.
+    [ -f "$candidate" ] && [ ! -L "$candidate" ] && [ -r "$candidate" ] || {
+        echo "!! Installer settings at $candidate were left unchanged because they are not a regular project file" >&2
+        return 1
+    }
+    nul_count="$(LC_ALL=C tr -cd '\000' < "$candidate" 2>/dev/null | wc -c)" \
+        || return 1
+    [ "$nul_count" -eq 0 ] || return 1
+    IFS= read -r header < "$candidate" || return 1
+    [ "$header" = '# ableton-linux installer configuration; managed by the installer' ] || {
+        echo "!! Installer settings at $candidate were left unchanged because they do not belong to Ableton Linux" >&2
+        return 1
+    }
+    format="$(awk -F = '$1=="format" { n++; value=substr($0, index($0, "=")+1) } END { if (n==1) print value; else exit 1 }' "$candidate")" || return 1
+    [ "$format" = 1 ] || return 1
+    return 0
+}
+
+if ! repair_link_config_before_init; then
+    echo "!! Installer settings are damaged. Re-run the main installer to rebuild them before changing Link." >&2
+    exit 1
+fi
+case "$action" in
+    status)
+        ABLETON_CONFIG_LAYOUT_ROOTS=none
+        ableton_config_init repair
+        if [ "${ABLETON_CONFIG_REPAIR_NEEDED:-0}" = 1 ]; then
+            echo "!! Installer settings need repair; showing Link status from the usable saved values" >&2
+        fi ;;
+    plan-enable|plan-disable)
+        ABLETON_CONFIG_LAYOUT_ROOTS=none; ableton_config_init repair ;;
+    *)
+        ABLETON_CONFIG_LAYOUT_ROOTS='data config state'; ableton_config_init repair ;;
+esac
+export ABLETON_CONFIG_LAYOUT_ROOTS
+for lib in "$here/lib/manifest.sh" "$ABLETON_DATA_HOME/lib/manifest.sh"; do
+    # The first installed/repository helper wins.
+    # shellcheck disable=SC1090
+    if [ -r "$lib" ]; then . "$lib"; break; fi
+done
+declare -F ableton_validate_install_state_journals >/dev/null 2>&1 || {
+    echo "!! setup-link: lifecycle helper is missing" >&2; exit 1; }
+
 case "$action" in
     enable|disable|snapshot|preflight-rollback|preflight-commit|rollback|commit)
         ableton_install_lock_acquire
-        ableton_validate_install_state_journals ;;
-    status)
-        # status reads the manifest, so check it.  Taking the install lock would
-        # fail status during the install someone is asking about.  Skip the
-        # prestate journals: status never reads them, and an install writes them
-        # in two steps, so an unlocked read can catch them half written.
-        ableton_validate_ownership_manifest ;;
+        # Link files are generated integration. Stale installed-file or legacy
+        # restoration records must not prevent them from being rebuilt.
+        if ! ableton_validate_install_state_journals repair >/dev/null 2>&1; then
+            echo "!! Old Link file records could not be repaired; Link will ignore them" >&2
+        fi ;;
+    status) ;;
 esac
 
 state_file="$ABLETON_STATE_HOME/link-firewall"
@@ -58,9 +131,13 @@ unit_file="$unit_dir/ableton-linkd.service"
 data_unit="$ABLETON_DATA_HOME/ableton-linkd.service"
 linkctl="$ABLETON_DATA_HOME/ableton-linkctl"
 link_pid_file="${XDG_RUNTIME_DIR:-$ABLETON_STATE_HOME/run}/ableton-wine/linkd.pid"
+legacy_policy_file="$ABLETON_DATA_HOME/link-configured"
 legacy_hook=/etc/NetworkManager/dispatcher.d/50-link-multicast
+LINK_ENABLE_RECOVERED_STATUS=75
+LINK_ENABLE_INCOMPLETE_STATUS=70
 link_residual=0
-declare -A link_deowned=()
+LINK_DISABLE_COMMITTED=0
+LINK_SETTING_SAVED=1
 
 owned_link_pids()
 {
@@ -89,6 +166,14 @@ owned_link_pids()
     return 0
 }
 
+first_owned_link_pid()
+{
+    local pids
+    pids="$(owned_link_pids)" || return 1
+    [ -n "$pids" ] || return 0
+    printf '%s\n' "${pids%%$'\n'*}"
+}
+
 stop_owned_detached_link_daemons()
 {
     # ableton-linkctl serialises its own start and stop on this lock, and the
@@ -99,7 +184,7 @@ stop_owned_detached_link_daemons()
     mkdir -p -- "${link_pid_file%/*}" || return 1
     (
         flock -w 10 9 || {
-            echo "!! timed out waiting for the Link lifecycle lock" >&2
+            echo "!! Another Ableton Link command is still running. Wait a few seconds and try again." >&2
             exit 1
         }
         stop_owned_detached_link_daemons_locked
@@ -108,9 +193,12 @@ stop_owned_detached_link_daemons()
 
 stop_owned_detached_link_daemons_locked()
 {
-    local pid exe want running=0 failed=0
+    local pid exe want running=0 failed=0 pids_text=""
     local -a pids=()
-    mapfile -t pids < <(owned_link_pids)
+    pids_text="$(owned_link_pids)" || return 1
+    if [ -n "$pids_text" ]; then
+        mapfile -t pids <<< "$pids_text"
+    fi
     want="$(readlink -f "$ABLETON_LINKD" 2>/dev/null || true)"
     for pid in "${pids[@]}"; do
         exe="$(readlink -f "/proc/$pid/exe" 2>/dev/null || true)"
@@ -139,10 +227,12 @@ stop_owned_detached_link_daemons_locked()
         [ -z "$want" ] || [ "$exe" != "$want" ] || failed=1
     done
     [ "$failed" -eq 0 ] || {
-        echo "!! could not stop every project-owned detached Link daemon" >&2
+        echo "!! Ableton Link is still running and could not be stopped" >&2
         return 1
     }
-    rm -f -- "$link_pid_file"
+    rm -f -- "$link_pid_file" 2>/dev/null || true
+    [ ! -e "$link_pid_file" ] && [ ! -L "$link_pid_file" ] || \
+        link_cleanup_warning "Ableton Link stopped, but its old process marker could not be removed"
 }
 
 legacy_unit_is_owned()
@@ -231,13 +321,259 @@ loaded_unit_is_owned()
 stop_owned_service()
 {
     loaded_unit_is_owned || return 0
-    if command -v systemctl >/dev/null 2>&1; then
-        ableton_run_bounded 20 systemctl --user disable --now \
-            ableton-linkd.service >/dev/null 2>&1 || {
-            echo "!! could not stop the project-owned Link service" >&2
+    stop_canonical_link_service
+}
+
+stop_canonical_link_service()
+{
+    local fragment="" wants="$unit_dir/default.target.wants/ableton-linkd.service"
+    local enabled_status=0 active_status=0
+    if systemd_user_available; then
+        if ! fragment="$(ableton_run_bounded 20 systemctl --user show \
+                -p FragmentPath --value ableton-linkd.service 2>/dev/null)"; then
+            echo "!! Ableton Link could not inspect the user service" >&2
+            return 1
+        fi
+        if [ -n "$fragment" ] \
+           && [ "$(ableton_realpath_m "$fragment")" != "$(ableton_realpath_m "$unit_file")" ]; then
+            echo "!! Kept the unrelated user service named ableton-linkd.service: $fragment" >&2
+            return 0
+        fi
+        if { [ -n "$fragment" ] && ! loaded_unit_is_owned; } \
+           || { [ -z "$fragment" ] && ! unit_is_owned; }; then
+            if [ -n "$fragment" ] || [ -e "$unit_file" ] || [ -L "$unit_file" ] \
+               || [ -e "$wants" ] || [ -L "$wants" ]; then
+                echo "!! Kept the unfamiliar Ableton Link user service because it does not match one installed by Ableton Linux" >&2
+            fi
+            return 0
+        fi
+        ableton_run_bounded 20 systemctl --user is-enabled --quiet \
+            ableton-linkd.service 2>/dev/null || enabled_status=$?
+        ableton_run_bounded 20 systemctl --user is-active --quiet \
+            ableton-linkd.service 2>/dev/null || active_status=$?
+        case "$enabled_status" in 0|1|3|4) ;; *)
+            echo "!! Ableton Link could not determine whether its user service is enabled" >&2
+            return 1 ;;
+        esac
+        case "$active_status" in 0|1|3|4) ;; *)
+            echo "!! Ableton Link could not determine whether its user service is running" >&2
+            return 1 ;;
+        esac
+        if [ -n "$fragment" ] || [ -e "$wants" ] || [ -L "$wants" ] \
+           || [ "$enabled_status" -eq 0 ] || [ "$active_status" -eq 0 ]; then
+            ableton_run_bounded 20 systemctl --user disable --now \
+                ableton-linkd.service >/dev/null 2>&1 || true
+            enabled_status=0
+            active_status=0
+            ableton_run_bounded 20 systemctl --user is-enabled --quiet \
+                ableton-linkd.service 2>/dev/null || enabled_status=$?
+            ableton_run_bounded 20 systemctl --user is-active --quiet \
+                ableton-linkd.service 2>/dev/null || active_status=$?
+            case "$enabled_status" in 1|3|4) ;; *)
+                echo "!! Ableton Link is still enabled as a user service" >&2
+                return 1 ;;
+            esac
+            case "$active_status" in 1|3|4) ;; *)
+                echo "!! Ableton Link is still running as a user service" >&2
+                return 1 ;;
+            esac
+        fi
+        return 0
+    fi
+    if [ -e "$wants" ] || [ -L "$wants" ]; then
+        if ! unit_is_owned \
+           || [ ! -L "$wants" ] \
+           || [ "$(readlink -f -- "$wants" 2>/dev/null || true)" \
+                != "$(ableton_realpath_m "$unit_file")" ]; then
+            echo "!! Kept the unfamiliar Ableton Link user-service entry: $wants" >&2
+            return 0
+        fi
+        rm -f -- "$wants" 2>/dev/null || true
+        [ ! -e "$wants" ] && [ ! -L "$wants" ] || {
+            echo "!! Ableton Link could not turn off its background service" >&2
             return 1
         }
     fi
+}
+
+snapshot_link_service_state()
+{
+    local snapshot="$1" first_pid="" enabled_status=0 active_status=0
+    if systemd_user_available; then
+        : > "$snapshot/manager" || return 1
+        ableton_run_bounded 20 systemctl --user is-enabled --quiet \
+            ableton-linkd.service 2>/dev/null || enabled_status=$?
+        ableton_run_bounded 20 systemctl --user is-active --quiet \
+            ableton-linkd.service 2>/dev/null || active_status=$?
+        case "$enabled_status" in 0|1|3|4) ;; *)
+            echo "!! Ableton Link could not read the current user-service setting" >&2
+            return 1 ;;
+        esac
+        case "$active_status" in 0|1|3|4) ;; *)
+            echo "!! Ableton Link could not read whether its user service is running" >&2
+            return 1 ;;
+        esac
+        if [ "$enabled_status" -eq 0 ]; then
+            : > "$snapshot/enabled" || return 1
+        else
+            : > "$snapshot/enabled.absent" || return 1
+        fi
+        if [ "$active_status" -eq 0 ]; then
+            : > "$snapshot/active" || return 1
+        else
+            : > "$snapshot/active.absent" || return 1
+        fi
+    else
+        : > "$snapshot/manager.absent" || return 1
+        : > "$snapshot/enabled.absent" || return 1
+        : > "$snapshot/active.absent" || return 1
+    fi
+    first_pid="$(first_owned_link_pid)" || return 1
+    if [ -n "$first_pid" ]; then
+        : > "$snapshot/detached-active" || return 1
+    else
+        : > "$snapshot/detached-active.absent" || return 1
+    fi
+}
+
+link_snapshot_prior_token()
+{
+    local base="$1"
+    if [ -e "$base" ] || [ -L "$base" ]; then
+        ableton_object_token "$base"
+    elif [ -f "$base.absent" ] && [ ! -L "$base.absent" ]; then
+        printf '%s\n' absent
+    else
+        return 1
+    fi
+}
+
+link_service_matches_snapshot()
+{
+    local snapshot="$1" enabled_status=0 active_status=0
+    [ -e "$snapshot/manager" ] || return 0
+    systemd_user_available || return 1
+    ableton_run_bounded 20 systemctl --user is-enabled --quiet \
+        ableton-linkd.service 2>/dev/null || enabled_status=$?
+    ableton_run_bounded 20 systemctl --user is-active --quiet \
+        ableton-linkd.service 2>/dev/null || active_status=$?
+    case "$enabled_status:$active_status" in
+        0:0|0:1|0:3|0:4|1:0|1:1|1:3|1:4|3:0|3:1|3:3|3:4|4:0|4:1|4:3|4:4) ;;
+        *) return 1 ;;
+    esac
+    if [ -e "$snapshot/enabled" ]; then
+        [ "$enabled_status" -eq 0 ] || return 1
+    else
+        [ "$enabled_status" -ne 0 ] || return 1
+    fi
+    if [ -e "$snapshot/active" ]; then
+        [ "$active_status" -eq 0 ]
+    else
+        [ "$active_status" -ne 0 ]
+    fi
+}
+
+link_detached_matches_snapshot()
+{
+    local snapshot="$1" pid=""
+    pid="$(first_owned_link_pid)" || return 1
+    { [ -e "$snapshot/detached-active" ] && [ -n "$pid" ]; } \
+        || { [ -e "$snapshot/detached-active.absent" ] && [ -z "$pid" ]; }
+}
+
+quiesce_link_process_state_for_restore()
+{
+    local snapshot="$1" rc=0 restore_service=1 restore_detached=1
+    if [ -e "$snapshot/local-recovery" ]; then
+        [ -e "$snapshot/service-mutating" ] || restore_service=0
+        [ -e "$snapshot/detached-mutating" ] || restore_detached=0
+    else
+        link_service_matches_snapshot "$snapshot" && restore_service=0
+        link_detached_matches_snapshot "$snapshot" && restore_detached=0
+    fi
+    if [ "$restore_service" -eq 1 ] && [ -e "$snapshot/manager" ]; then
+        systemd_user_available || {
+            echo "!! The previous Link service state cannot be restored outside a running user session" >&2
+            return 1
+        }
+        stop_owned_service || rc=$?
+    elif [ "$restore_service" -eq 1 ] && [ -e "$snapshot/service-mutating" ]; then
+        echo "!! The previous Link service state cannot be restored outside a running user session" >&2
+        rc=1
+    fi
+    if [ "$rc" -eq 0 ] && [ "$restore_detached" -eq 1 ]; then
+        stop_owned_detached_link_daemons || rc=$?
+    fi
+    return "$rc"
+}
+
+restore_link_process_state()
+{
+    local snapshot="$1" ctl actual_enabled=0 actual_active=0 restored_pid="" rc=0
+    local restore_service=1 restore_detached=1
+    if [ -e "$snapshot/local-recovery" ]; then
+        [ -e "$snapshot/service-mutating" ] || restore_service=0
+        [ -e "$snapshot/detached-mutating" ] || restore_detached=0
+    fi
+    if [ "$restore_service" -eq 1 ] && [ -e "$snapshot/manager" ]; then
+        systemd_user_available || {
+            echo "!! no systemd user manager is reachable to restore the Link unit state" >&2
+            return 1
+        }
+        ableton_run_bounded 20 systemctl --user daemon-reload >/dev/null 2>&1 || true
+        if [ -e "$snapshot/enabled" ]; then
+            unit_is_owned || rc=1
+            [ "$rc" -ne 0 ] || ableton_run_bounded 20 systemctl --user enable \
+                ableton-linkd.service >/dev/null 2>&1 || true
+        elif unit_is_owned; then
+            ableton_run_bounded 20 systemctl --user disable \
+                ableton-linkd.service >/dev/null 2>&1 || true
+        fi
+        if [ "$rc" -eq 0 ] && [ -e "$snapshot/active" ]; then
+            unit_is_owned || rc=1
+            [ "$rc" -ne 0 ] || ableton_run_bounded 20 systemctl --user start \
+                ableton-linkd.service >/dev/null 2>&1 || true
+        elif [ "$rc" -eq 0 ] && loaded_unit_is_owned; then
+            ableton_run_bounded 20 systemctl --user stop \
+                ableton-linkd.service >/dev/null 2>&1 || true
+        fi
+    fi
+    if [ "$rc" -eq 0 ] && [ -e "$snapshot/manager" ]; then
+        systemd_user_available || rc=1
+        if [ "$rc" -eq 0 ]; then
+            ableton_run_bounded 20 systemctl --user is-enabled --quiet \
+                ableton-linkd.service 2>/dev/null || actual_enabled=$?
+            ableton_run_bounded 20 systemctl --user is-active --quiet \
+                ableton-linkd.service 2>/dev/null || actual_active=$?
+            case "$actual_enabled:$actual_active" in
+                0:0|0:1|0:3|0:4|1:0|1:1|1:3|1:4|3:0|3:1|3:3|3:4|4:0|4:1|4:3|4:4) ;;
+                *) rc=1 ;;
+            esac
+            if [ "$rc" -eq 0 ] \
+               && { { [ -e "$snapshot/enabled" ] && [ "$actual_enabled" -ne 0 ]; } \
+               || { [ -e "$snapshot/enabled.absent" ] && [ "$actual_enabled" -eq 0 ]; } \
+               || { [ -e "$snapshot/active" ] && [ "$actual_active" -ne 0 ]; } \
+               || { [ -e "$snapshot/active.absent" ] && [ "$actual_active" -eq 0 ]; }; }; then
+                echo "!! The previous Link user-service state could not be verified" >&2
+                rc=1
+            fi
+        fi
+    fi
+    ctl="$here/ableton-linkctl"; [ -x "$ctl" ] || ctl="$linkctl"
+    if [ "$rc" -eq 0 ] && [ "$restore_detached" -eq 1 ] \
+       && [ -e "$snapshot/detached-active" ]; then
+        [ -x "$ctl" ] || rc=1
+        [ "$rc" -ne 0 ] || ABLETON_LINK_MODE=session "$ctl" start || true
+    fi
+    if [ "$rc" -eq 0 ]; then
+        restored_pid="$(first_owned_link_pid)" || rc=$?
+        if { [ -e "$snapshot/detached-active" ] && [ -z "$restored_pid" ]; } \
+           || { [ -e "$snapshot/detached-active.absent" ] && [ -n "$restored_pid" ]; }; then
+            echo "!! The previous Link process state could not be verified" >&2
+            rc=1
+        fi
+    fi
+    return "$rc"
 }
 
 link_firewall_record_valid()
@@ -255,15 +591,44 @@ link_firewall_record_valid()
 validate_link_firewall_state()
 {
     [ ! -e "$state_file" ] && [ ! -L "$state_file" ] && return 0
-    link_firewall_record_valid "$state_file"
+    ableton_state_marker_valid "$ABLETON_STATE_HOME" \
+        && link_firewall_record_valid "$state_file"
+}
+
+snapshot_link_firewall_state()
+{
+    local destination="$1"
+    if [ ! -e "$state_file" ] && [ ! -L "$state_file" ]; then
+        : > "$destination.absent" || return 1
+        return 0
+    fi
+    validate_link_firewall_state || {
+        echo "!! unsafe Link firewall ownership record: $state_file" >&2
+        return 1
+    }
+    cp -a -- "$state_file" "$destination"
+}
+
+prepare_link_firewall_state_for_enable()
+{
+    validate_link_firewall_state && return 0
+    echo "!! Old Link firewall information was unreadable, so the firewall will be checked again" >&2
+    if [ -d "$state_file" ] && [ ! -L "$state_file" ]; then
+        echo "!! Ableton Link cannot replace the firewall information at $state_file" >&2
+        return 1
+    fi
+    rm -f -- "$state_file" 2>/dev/null || true
+    [ ! -e "$state_file" ] && [ ! -L "$state_file" ] || {
+        echo "!! Ableton Link cannot replace its firewall information" >&2
+        return 1
+    }
 }
 
 write_link_firewall_state()
 {
-    local value="$1" tmp token
+    local value="$1" tmp
     case "$value" in ufw-added|firewalld-added|none) ;; *) return 1 ;; esac
     ableton_mark_state_home || return 1
-    ableton_txn_snapshot "$state_file" || return 1
     tmp="$(mktemp "$ABLETON_STATE_HOME/.link-firewall.XXXXXX")" || return 1
     if ! printf '%s\n' "$value" > "$tmp" \
        || ! chmod 600 "$tmp" \
@@ -271,12 +636,15 @@ write_link_firewall_state()
         rm -f -- "$tmp"
         return 1
     fi
-    token="$(ableton_object_token "$tmp")" || { rm -f -- "$tmp"; return 1; }
-    ableton_txn_expect "$state_file" "$token" || { rm -f -- "$tmp"; return 1; }
-    if ! mv -T -f -- "$tmp" "$state_file" || ! link_firewall_record_valid "$state_file"; then
+    mv -T -f -- "$tmp" "$state_file" 2>/dev/null || true
+    if ! link_firewall_record_valid "$state_file" \
+       || [ "$(sed -n '1p' "$state_file")" != "$value" ]; then
         rm -f -- "$tmp"
         return 1
     fi
+    [ ! -e "$tmp" ] || rm -f -- "$tmp" 2>/dev/null || true
+    [ ! -e "$tmp" ] && [ ! -L "$tmp" ] || \
+        echo "!! Temporary Link firewall files could not be removed: $tmp" >&2
 }
 
 # Return 0 when the rule exists, 1 when a successful query proves it absent,
@@ -285,8 +653,7 @@ ufw_link_rule_state()
 {
     local output
     output="$(ableton_sudo_run_bounded 120 ufw status)" || return 2
-    printf '%s\n' "$output" \
-        | grep -Eq '(^|[[:space:]])20808/udp([[:space:]]|$)'
+    grep -Eq '(^|[[:space:]])20808/udp([[:space:]]|$)' <<< "$output"
 }
 
 firewalld_link_rule_state()
@@ -294,7 +661,14 @@ firewalld_link_rule_state()
     local output
     output="$(ableton_sudo_run_bounded 120 \
         firewall-cmd --permanent --list-ports)" || return 2
-    printf '%s\n' "$output" | tr ' ' '\n' | grep -qxF 20808/udp
+    grep -Eq '(^|[[:space:]])20808/udp([[:space:]]|$)' <<< "$output"
+}
+
+firewalld_runtime_link_rule_state()
+{
+    local output
+    output="$(ableton_sudo_run_bounded 120 firewall-cmd --list-ports)" || return 2
+    grep -Eq '(^|[[:space:]])20808/udp([[:space:]]|$)' <<< "$output"
 }
 
 firewalld_offline_link_rule_state()
@@ -302,58 +676,76 @@ firewalld_offline_link_rule_state()
     local output
     output="$(ableton_sudo_run_bounded 120 \
         firewall-offline-cmd --list-ports)" || return 2
-    printf '%s\n' "$output" | tr ' ' '\n' | grep -qxF 20808/udp
+    grep -Eq '(^|[[:space:]])20808/udp([[:space:]]|$)' <<< "$output"
 }
 
 remove_owned_firewall()
 {
     validate_link_firewall_state || {
-        echo "!! unsafe Link firewall ownership record: $state_file" >&2
+        echo "!! Link firewall information changed before its rule could be safely removed" >&2
         return 1
     }
     [ ! -e "$state_file" ] && [ ! -L "$state_file" ] && return 0
     local state rc=0 rule_state=0
     state="$(sed -n '1p' "$state_file")"
-    # Record the ownership file before changing the matching system rule. If a
-    # later command fails, the outer transaction can still restore both.
-    ableton_txn_snapshot "$state_file" || return 1
     case "$state" in
         ufw-added)
-            echo "-- removing the project-owned ufw allowance for UDP 20808"
+            echo "-- removing the ufw rule added for Ableton Link"
             ufw_link_rule_state || rule_state=$?
             if [ "$rule_state" -eq 0 ]; then
-                ableton_sudo_run_bounded 120 ufw delete allow 20808/udp || rc=$?
+                ableton_sudo_run_bounded 120 ufw delete allow 20808/udp || true
             elif [ "$rule_state" -ne 1 ]; then
                 rc=1
+            fi
+            if [ "$rc" -eq 0 ]; then
+                rule_state=0
+                ufw_link_rule_state || rule_state=$?
+                [ "$rule_state" -eq 1 ] || rc=1
             fi ;;
         firewalld-added)
-            echo "-- removing the project-owned firewalld allowance for UDP 20808"
+            echo "-- removing the firewalld rule added for Ableton Link"
             if command -v firewall-cmd >/dev/null 2>&1 \
                && ableton_run_bounded 20 firewall-cmd --state >/dev/null 2>&1; then
                 firewalld_link_rule_state || rule_state=$?
                 if [ "$rule_state" -eq 0 ]; then
-                    ableton_sudo_run_bounded 120 firewall-cmd --permanent --remove-port=20808/udp || rc=$?
-                    [ "$rc" -ne 0 ] || ableton_sudo_run_bounded 120 firewall-cmd --reload || rc=$?
+                    ableton_sudo_run_bounded 120 firewall-cmd --permanent --remove-port=20808/udp || true
+                    ableton_sudo_run_bounded 120 firewall-cmd --reload || true
                 elif [ "$rule_state" -ne 1 ]; then
                     rc=1
+                fi
+                if [ "$rc" -eq 0 ]; then
+                    rule_state=0
+                    firewalld_link_rule_state || rule_state=$?
+                    [ "$rule_state" -eq 1 ] || rc=1
+                fi
+                if [ "$rc" -eq 0 ]; then
+                    rule_state=0
+                    firewalld_runtime_link_rule_state || rule_state=$?
+                    [ "$rule_state" -eq 1 ] || rc=1
                 fi
             elif command -v firewall-offline-cmd >/dev/null 2>&1; then
                 firewalld_offline_link_rule_state || rule_state=$?
                 if [ "$rule_state" -eq 0 ]; then
                     ableton_sudo_run_bounded 120 \
-                        firewall-offline-cmd --remove-port=20808/udp || rc=$?
+                        firewall-offline-cmd --remove-port=20808/udp || true
                 elif [ "$rule_state" -ne 1 ]; then
                     rc=1
+                fi
+                if [ "$rc" -eq 0 ]; then
+                    rule_state=0
+                    firewalld_offline_link_rule_state || rule_state=$?
+                    [ "$rule_state" -eq 1 ] || rc=1
                 fi
             else
                 rc=127
             fi ;;
         none|'') ;;
-        *) echo "!! unrecognised Link firewall ownership record: $state_file" >&2; return 1 ;;
+        *) echo "!! Link firewall information changed before its rule could be safely removed" >&2; return 1 ;;
     esac
-    [ "$rc" -eq 0 ] || { echo "!! failed to remove the recorded Link firewall rule" >&2; return "$rc"; }
-    ableton_txn_expect "$state_file" absent || return 1
-    rm -f -- "$state_file"
+    [ "$rc" -eq 0 ] || { echo "!! The firewall rule added for Ableton Link could not be removed" >&2; return "$rc"; }
+    rm -f -- "$state_file" 2>/dev/null || true
+    [ ! -e "$state_file" ] && [ ! -L "$state_file" ] || \
+        link_cleanup_warning "The old Link firewall information could not be removed"
 }
 
 restore_firewall_snapshot()
@@ -366,7 +758,13 @@ restore_firewall_snapshot()
     validate_link_firewall_state || return 1
     [ ! -r "$state_file" ] || current="$(sed -n '1p' "$state_file")"
     if [ -r "$snapshot" ] && [ "$current" = "$prior" ]; then
-        return 0
+        # The ownership record is authoritative. Revalidate/repair the actual
+        # owned rule as well; equal record bytes alone do not prove host state.
+        case "$prior" in
+            ufw-added|firewalld-added) restore_firewall_record "$prior" ;;
+            none) return 0 ;;
+        esac
+        return
     fi
     [ ! -e "$state_file" ] && [ ! -L "$state_file" ] \
         || remove_owned_firewall || rc=$?
@@ -374,18 +772,54 @@ restore_firewall_snapshot()
     if [ -r "$snapshot" ]; then
         restore_firewall_record "$prior"
     else
-        ableton_txn_snapshot "$state_file" || return 1
-        ableton_txn_expect "$state_file" absent || return 1
-        rm -f -- "$state_file"
+        rm -f -- "$state_file" 2>/dev/null || true
+        [ ! -e "$state_file" ] && [ ! -L "$state_file" ] || \
+            echo "!! The old Link firewall information could not be removed" >&2
     fi
+}
+
+firewall_matches_snapshot()
+{
+    local snapshot="$1" prior current rule_state=0
+    prior="$(link_snapshot_prior_token "$snapshot")" || return 1
+    current="$(ableton_object_token "$state_file" 2>/dev/null || true)"
+    [ "$current" = "$prior" ] || return 1
+    [ ! -e "$snapshot" ] && return 0
+    case "$(sed -n '1p' "$snapshot")" in
+        ufw-added)
+            ufw_link_rule_state || rule_state=$?
+            [ "$rule_state" -eq 0 ] ;;
+        firewalld-added)
+            if command -v firewall-cmd >/dev/null 2>&1 \
+               && ableton_run_bounded 20 firewall-cmd --state >/dev/null 2>&1; then
+                firewalld_link_rule_state || rule_state=$?
+                [ "$rule_state" -eq 0 ] || return 1
+                rule_state=0
+                firewalld_runtime_link_rule_state || rule_state=$?
+            else
+                firewalld_offline_link_rule_state || rule_state=$?
+            fi
+            [ "$rule_state" -eq 0 ] ;;
+        none) return 0 ;;
+        *) return 1 ;;
+    esac
 }
 
 legacy_hook_is_owned()
 {
     [ -f "$legacy_hook" ] && [ ! -L "$legacy_hook" ] \
         && grep -qxF '#!/bin/sh' "$legacy_hook" 2>/dev/null \
-        && grep -qF '[ "$2" = "up" ] || exit 0' "$legacy_hook" 2>/dev/null \
+        && grep -qF "[ \"\$2\" = \"up\" ] || exit 0" "$legacy_hook" 2>/dev/null \
         && grep -qF 'ip route replace 224.0.0.0/4' "$legacy_hook" 2>/dev/null
+}
+
+first_multicast_route()
+{
+    local routes
+    command -v ip >/dev/null 2>&1 || return 127
+    routes="$(ip -4 route show 224.0.0.0/4 2>/dev/null)" || return 1
+    [ -n "$routes" ] || return 0
+    printf '%s\n' "${routes%%$'\n'*}"
 }
 
 snapshot_legacy_network()
@@ -393,85 +827,212 @@ snapshot_legacy_network()
     local destination="$1" route_line=""
     if legacy_hook_is_owned; then
         cp -a -- "$legacy_hook" "$destination.hook" || return 1
+        route_line="$(first_multicast_route)" || {
+            echo "!! Link cannot safely inspect the old multicast route" >&2
+            return 1
+        }
+        if [ -n "$route_line" ]; then
+            printf '%s\n' "$route_line" > "$destination.route" || return 1
+        else
+            : > "$destination.route.absent" || return 1
+        fi
     else
         : > "$destination.hook.absent" || return 1
-    fi
-    route_line="$(ip -4 route show 224.0.0.0/4 2>/dev/null | head -n 1 || true)"
-    if [ -n "$route_line" ]; then
-        printf '%s\n' "$route_line" > "$destination.route" || return 1
-    else
+        # No recognised project hook means this command will not touch the
+        # legacy route, so its live value is outside Link recovery.
         : > "$destination.route.absent" || return 1
     fi
 }
 
 restore_legacy_network()
 {
-    local snapshot="$1" mode route_line
+    local snapshot="$1" mode route_line current_route prior_hook current_hook
     [ -e "$snapshot.hook" ] || return 0
     if [ -e "$legacy_hook" ] && ! legacy_hook_is_owned; then
-        echo "!! refusing to overwrite unrecognised legacy-hook path $legacy_hook during rollback" >&2
+        echo "!! The old Link network hook changed, so it was left alone" >&2
         return 1
     fi
-    mode="$(stat -c '%a' "$snapshot.hook")"
-    ableton_sudo_run_bounded 120 install -m "$mode" -- "$snapshot.hook" "$legacy_hook"
+    mode="$(stat -c '%a' "$snapshot.hook")" || return 1
+    prior_hook="$(ableton_object_token "$snapshot.hook" 2>/dev/null || true)"
+    [ -n "$prior_hook" ] || return 1
+    ableton_sudo_run_bounded 120 install -m "$mode" -- "$snapshot.hook" "$legacy_hook" || true
+    current_hook="$(ableton_object_token "$legacy_hook" 2>/dev/null || true)"
+    [ "$current_hook" = "$prior_hook" ] || {
+        echo "!! The old Link network hook could not be restored" >&2
+        return 1
+    }
     route_line="$(sed -n '1p' "$snapshot.route" 2>/dev/null || true)"
     if [ -n "$route_line" ]; then
         local -a route_args=()
         read -r -a route_args <<< "$route_line"
         [ "${route_args[0]:-}" = 224.0.0.0/4 ] || {
-            echo "!! refusing malformed legacy route snapshot" >&2; return 1; }
-        ableton_sudo_run_bounded 120 ip route replace "${route_args[@]}"
+            echo "!! The saved multicast route is unreadable" >&2; return 1; }
+        ableton_sudo_run_bounded 120 ip route replace "${route_args[@]}" || true
+        current_route="$(first_multicast_route)" || return 1
+        [ "$current_route" = "$route_line" ] || {
+            echo "!! The previous multicast route could not be restored" >&2
+            return 1
+        }
+    else
+        current_route="$(first_multicast_route)" || return 1
+        [ -z "$current_route" ] || {
+            echo "!! The multicast route changed while Link was being restored" >&2
+            return 1
+        }
     fi
+}
+
+legacy_network_safe_for_restore()
+{
+    local snapshot="$1" prior_route current_route prior_hook=absent current_hook=absent
+    [ -e "$snapshot.hook" ] || return 0
+    [ ! -e "$snapshot.hook" ] \
+        || prior_hook="$(ableton_object_token "$snapshot.hook" 2>/dev/null || true)"
+    [ ! -e "$legacy_hook" ] \
+        || current_hook="$(ableton_object_token "$legacy_hook" 2>/dev/null || true)"
+    [ -n "$prior_hook$current_hook" ] || return 1
+    [ "$current_hook" = absent ] || [ "$current_hook" = "$prior_hook" ] \
+        || legacy_hook_is_owned || return 1
+    prior_route="$(sed -n '1p' "$snapshot.route" 2>/dev/null || true)"
+    current_route="$(first_multicast_route)" || return 1
+    [ -z "$current_route" ] || [ "$current_route" = "$prior_route" ]
+}
+
+legacy_network_matches_snapshot()
+{
+    local snapshot="$1" prior_hook=absent current_hook=absent prior_route current_route
+    [ -e "$snapshot.hook" ] || return 0
+    [ ! -e "$snapshot.hook" ] \
+        || prior_hook="$(ableton_object_token "$snapshot.hook" 2>/dev/null || true)"
+    [ ! -e "$legacy_hook" ] \
+        || current_hook="$(ableton_object_token "$legacy_hook" 2>/dev/null || true)"
+    prior_route="$(sed -n '1p' "$snapshot.route" 2>/dev/null || true)"
+    current_route="$(first_multicast_route)" || return 1
+    [ "$current_hook" = "$prior_hook" ] && [ "$current_route" = "$prior_route" ]
 }
 
 remove_owned_legacy_hook()
 {
-    local route_line=""
+    local route_line="" current_route=""
     [ -e "$legacy_hook" ] || return 0
     if ! legacy_hook_is_owned; then
-        echo "!! keeping unrecognised legacy-hook path $legacy_hook" >&2
+        echo "!! An existing NetworkManager hook was not created by Ableton Linux and was left unchanged: $legacy_hook" >&2
         return 0
     fi
     command -v ip >/dev/null 2>&1 || {
-        echo "!! cannot inspect the project-owned legacy multicast route because ip is missing" >&2
+        echo "!! The old Ableton Link multicast route cannot be checked because the ip command is missing" >&2
         return 127
     }
-    route_line="$(ip -4 route show 224.0.0.0/4 2>/dev/null | head -n 1)" || {
-        echo "!! could not inspect the project-owned legacy multicast route" >&2
+    route_line="$(first_multicast_route)" || {
+        echo "!! The old Ableton Link multicast route could not be checked" >&2
         return 1
     }
-    echo "-- removing the project-owned legacy multicast hook"
+    echo "-- removing the old Ableton Link multicast hook"
     if [ -n "$route_line" ]; then
-        ableton_sudo_run_bounded 120 ip route del 224.0.0.0/4 >/dev/null
+        ableton_sudo_run_bounded 120 ip route del 224.0.0.0/4 >/dev/null || true
+        current_route="$(first_multicast_route)" || {
+            echo "!! The old Ableton Link multicast route could not be checked after removal" >&2
+            return 1
+        }
+        [ -z "$current_route" ] || {
+            echo "!! The old Ableton Link multicast route could not be removed" >&2
+            return 1
+        }
     fi
-    ableton_sudo_run_bounded 120 rm -f -- "$legacy_hook"
+    if [ -e "$legacy_hook" ] && ! legacy_hook_is_owned; then
+        echo "!! The old Link network hook changed and was left alone: $legacy_hook" >&2
+        return 0
+    fi
+    ableton_sudo_run_bounded 120 rm -f -- "$legacy_hook" || true
+    [ ! -e "$legacy_hook" ] && [ ! -L "$legacy_hook" ] || \
+        link_cleanup_warning "The obsolete Link network hook could not be removed: $legacy_hook"
 }
 
 manifest_digest_for()
 {
-    local wanted="$1" kind path digest manifest="$ABLETON_STATE_HOME/install-manifest.tsv"
-    [ -r "$manifest" ] || return 1
-    while IFS=$'\t' read -r kind path digest; do
+    local wanted="$1" kind path digest extra found=""
+    local manifest="$ABLETON_STATE_HOME/install-manifest.tsv"
+    [ -f "$manifest" ] && [ ! -L "$manifest" ] && [ -r "$manifest" ] || return 1
+    while IFS=$'\t' read -r kind path digest extra; do
         [ "$kind" = file ] && [ "$path" = "$wanted" ] || continue
-        printf '%s\n' "$digest"
-        return 0
+        [ -z "$extra" ] && [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || return 1
+        [ -z "$found" ] || return 1
+        found="$digest"
     done < "$manifest"
-    return 1
+    [ -n "$found" ] || return 1
+    printf '%s\n' "$found"
 }
 
 legacy_link_file_is_owned()
 {
     local target="$1"
-    [ -f "$target" ] && [ ! -L "$target" ] || return 1
+    [ -f "$target" ] && [ ! -L "$target" ] && [ -r "$target" ] || return 1
     case "$target" in
         "$ABLETON_DATA_HOME/ableton-linkd")
-            strings "$target" 2>/dev/null | grep -qF 'ableton-linkd: native Ableton Link session anchor and probe' ;;
+            strings "$target" 2>/dev/null \
+                | grep -xF 'ableton-linkd: native Ableton Link session anchor and probe' \
+                    >/dev/null ;;
         "$ABLETON_DATA_HOME/ableton-linkctl")
-            grep -qF 'Project-owned Ableton Link lifecycle controller' "$target" 2>/dev/null ;;
+            ableton_file_has_no_nul "$target" \
+                && [ "$(sed -n '1p' "$target")" = '#!/usr/bin/env bash' ] \
+                && grep -qxF '# Project-owned Ableton Link lifecycle controller.  The PID record plus exact' \
+                    "$target" \
+                && grep -qxF "case \"\$link_action\" in" "$target" \
+                && grep -qxF '    *) echo "usage: ableton-linkctl start|stop|restart|status" >&2; exit 2 ;;' \
+                    "$target" ;;
         "$ABLETON_DATA_HOME/setup-link.sh")
-            grep -qF 'Ableton Link setup' "$target" 2>/dev/null ;;
+            ableton_file_has_no_nul "$target" \
+                && [ "$(sed -n '1p' "$target")" = '#!/usr/bin/env bash' ] \
+                && grep -qxF '# Enable, disable, or inspect the single persistent Ableton Link policy.' \
+                    "$target" \
+                && grep -qxF "legacy_policy_file=\"\$ABLETON_DATA_HOME/link-configured\"" \
+                    "$target" \
+                && grep -qxF '    enable) enable_link ;;' "$target" ;;
         "$ABLETON_DATA_HOME/ableton-linkd.service")
-            grep -qF 'ableton-linkd' "$target" 2>/dev/null ;;
+            cmp -s -- "$target" <(cat <<'EOF'
+# Template only. setup-link.sh renders @ABLETON_LINKD@ to the one resolved
+# executable path and adds the ownership marker before installing this unit.
+[Unit]
+Description=Ableton Link session anchor (ableton-linkd)
+After=default.target
+X-AbletonLinuxOwned=true
+
+[Service]
+ExecStart="@ABLETON_LINKD@" --linger 0
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+EOF
+            ) ;;
+        *) return 1 ;;
+    esac
+}
+
+generated_link_file_is_owned()
+{
+    local target="$1" expected current
+    [ -f "$target" ] && [ ! -L "$target" ] || return 1
+    case "$target" in
+        "$unit_file") unit_is_owned; return ;;
+    esac
+    expected="$(manifest_digest_for "$target" 2>/dev/null || true)"
+    if [ -n "$expected" ]; then
+        current="$(link_path_digest "$target" 2>/dev/null || true)"
+        [ -n "$current" ] && [ "$current" = "$expected" ] && return 0
+    fi
+    legacy_link_file_is_owned "$target"
+}
+
+legacy_policy_file_is_owned()
+{
+    [ -f "$legacy_policy_file" ] && [ ! -L "$legacy_policy_file" ] \
+        && [ -r "$legacy_policy_file" ] \
+        && ableton_file_has_no_nul "$legacy_policy_file" \
+        && [ "$(wc -l < "$legacy_policy_file")" -eq 1 ] || return 1
+    case "$(sed -n '1p' "$legacy_policy_file")" in
+        configured|declined) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -483,40 +1044,11 @@ link_binary_is_owned()
     expected="$(manifest_digest_for "$ABLETON_LINKD" 2>/dev/null || true)"
     if [ -n "$expected" ]; then
         current="$(link_path_digest "$ABLETON_LINKD" 2>/dev/null || true)"
-        [ -n "$current" ] && [ "$current" = "$expected" ]
-        return
+        [ -n "$current" ] && [ "$current" = "$expected" ] && return 0
     fi
     legacy_link_file_is_owned "$ABLETON_LINKD"
 }
 
-remove_owned_link_file()
-{
-    local target="$1" expected current
-    expected="$(manifest_digest_for "$target" 2>/dev/null || true)"
-    if [ -n "$expected" ]; then
-        current="$(link_path_digest "$target" 2>/dev/null || true)"
-        if [ "$current" != "$expected" ]; then
-            echo "!! keeping modified Link file $target" >&2
-            ableton_abandon_managed_file "$target" || return 1
-            link_deowned["$target"]=1
-            link_residual=1
-            return 0
-        fi
-    elif ! legacy_link_file_is_owned "$target"; then
-        if [ ! -e "$target" ] && [ ! -L "$target" ]; then
-            ableton_remove_managed_file "$target" || return 1
-            link_deowned["$target"]=1
-            return 0
-        fi
-        echo "!! keeping unowned Link path $target" >&2
-        link_residual=1
-        return 0
-    fi
-    ableton_remove_managed_file "$target" || return 1
-    link_deowned["$target"]=1
-}
-
-LINK_PRESTATE_BACKUP=""
 link_path_digest()
 {
     if [ -L "$1" ]; then
@@ -528,126 +1060,188 @@ link_path_digest()
     fi
 }
 
-validate_link_prestate()
+link_cleanup_warning()
 {
-    local target="$1" index="$ABLETON_STATE_HOME/install-prestate.tsv"
-    local backup expected count
-    LINK_PRESTATE_BACKUP=""
-    [ -r "$index" ] || return 0
-    count="$(awk -F '\t' -v p="$target" '$1=="present" && $2==p { n++ } END { print n+0 }' "$index")"
-    [ "$count" -le 1 ] || {
-        echo "!! Link pre-install state is ambiguous for $target" >&2; return 1; }
-    [ "$count" -eq 1 ] || return 0
-    backup="$(awk -F '\t' -v p="$target" '$1=="present" && $2==p { print $3; exit }' "$index")"
-    expected="$ABLETON_STATE_HOME/install-prestate/$(printf '%s' "$target" | sha256sum | awk '{print $1}')"
-    if [ "$backup" != "$expected" ] || [ ! -e "$backup" ] \
-       || { [ ! -f "$backup" ] && [ ! -L "$backup" ]; }; then
-        echo "!! cannot safely restore the pre-install Link file $target" >&2
-        return 1
-    fi
-    LINK_PRESTATE_BACKUP="$backup"
+    link_residual=1
+    printf '!! %s\n' "$*" >&2 || true
+    return 0
 }
 
-restore_link_prestate()
+remove_owned_link_file()
 {
-    local target="$1" index="$ABLETON_STATE_HOME/install-prestate.tsv" backup tmp digest
-    validate_link_prestate "$target" || return 1
-    backup="$LINK_PRESTATE_BACKUP"
-    [ -n "$backup" ] || return 0
-    digest="$(link_path_digest "$backup")" || return 1
-    ableton_atomic_restore_object "$backup" "$target" || return 1
-    [ "$(link_path_digest "$target" 2>/dev/null || true)" = "$digest" ] || return 1
-    tmp="$(mktemp "$ABLETON_STATE_HOME/.prestate-link.XXXXXX")"
-    if ! awk -F '\t' -v p="$target" '$2 != p' "$index" > "$tmp" \
-       || ! chmod 600 "$tmp" || ! mv -f -- "$tmp" "$index"; then
-        rm -f -- "$tmp"
-        return 1
+    local target="$1" before current
+    [ -e "$target" ] || [ -L "$target" ] || return 0
+    if ! generated_link_file_is_owned "$target"; then
+        printf '!! Kept %s because it does not match a file installed by Ableton Linux\n' \
+            "$target" >&2 || true
+        return 0
     fi
-    rm -f -- "$backup" || return 1
-    link_deowned["$target"]=1
+    before="$(ableton_object_token "$target" 2>/dev/null || true)"
+    current="$(ableton_object_token "$target" 2>/dev/null || true)"
+    if [ -z "$before" ] || [ "$current" != "$before" ] \
+       || ! generated_link_file_is_owned "$target"; then
+        printf '!! Kept %s because it changed while Ableton Link was being turned off\n' \
+            "$target" >&2 || true
+        return 0
+    fi
+    rm -f -- "$target" 2>/dev/null || true
+    [ ! -e "$target" ] && [ ! -L "$target" ] || \
+        link_cleanup_warning "An obsolete Link file could not be removed: $target"
 }
 
-prune_link_manifest()
+remove_legacy_policy_file()
 {
-    local manifest="$ABLETON_STATE_HOME/install-manifest.tsv" tmp kind path digest
-    [ -r "$manifest" ] || return 0
-    tmp="$(mktemp "$ABLETON_STATE_HOME/.manifest-link.XXXXXX")"
-    while IFS=$'\t' read -r kind path digest; do
-        case "$path" in
-            "$ABLETON_DATA_HOME/ableton-linkd"|"$data_unit"|"$linkctl"|"$ABLETON_DATA_HOME/setup-link.sh")
-                [ -z "${link_deowned[$path]+x}" ] || continue
-                [ -e "$path" ] || [ -L "$path" ] || continue ;;
-        esac
-        printf '%s\t%s\t%s\n' "$kind" "$path" "$digest" >> "$tmp"
-    done < "$manifest"
-    chmod 600 "$tmp"
-    if [ -n "${ABLETON_TRANSACTION_DIR:-}" ] \
-       && [ -e "$ABLETON_TRANSACTION_DIR/files.tsv" ]; then
-        ableton_txn_snapshot "$manifest"
-        ableton_txn_expect "$manifest" "$(ableton_regular_source_token "$tmp")"
+    local before current
+    [ -e "$legacy_policy_file" ] || [ -L "$legacy_policy_file" ] || return 0
+    if ! legacy_policy_file_is_owned; then
+        printf '!! Kept %s because it is not an old Ableton Linux Link setting\n' \
+            "$legacy_policy_file" >&2 || true
+        return 0
     fi
-    mv -f -- "$tmp" "$manifest"
+    before="$(ableton_object_token "$legacy_policy_file" 2>/dev/null || true)"
+    current="$(ableton_object_token "$legacy_policy_file" 2>/dev/null || true)"
+    if [ -z "$before" ] || [ "$current" != "$before" ] \
+       || ! legacy_policy_file_is_owned; then
+        printf '!! Kept %s because it changed while Ableton Link was being updated\n' \
+            "$legacy_policy_file" >&2 || true
+        return 0
+    fi
+    rm -f -- "$legacy_policy_file" 2>/dev/null || true
+    [ ! -e "$legacy_policy_file" ] && [ ! -L "$legacy_policy_file" ] || \
+        link_cleanup_warning "The old Link setting could not be removed: $legacy_policy_file"
+}
+
+prune_link_metadata()
+{
+    local manifest="$ABLETON_STATE_HOME/install-manifest.tsv"
+    local index="$ABLETON_STATE_HOME/install-prestate.tsv" tmp="" target id
+    local legacy_custom="${ABLETON_PR182_CUSTOM_LINKD:-}"
+    local -a targets=("$ABLETON_DATA_HOME/ableton-linkd" "$data_unit" "$linkctl" \
+        "$ABLETON_DATA_HOME/setup-link.sh")
+    if [ -e "$manifest" ] || [ -L "$manifest" ]; then
+        if [ -f "$manifest" ] && [ ! -L "$manifest" ] && [ -r "$manifest" ] \
+           && tmp="$(mktemp "$ABLETON_STATE_HOME/.installed-files-link.XXXXXX")" \
+           && awk -F '\t' -v a="${targets[0]}" -v b="${targets[1]}" \
+                -v c="${targets[2]}" -v d="${targets[3]}" \
+                -v e="$legacy_custom" \
+                '$2 != a && $2 != b && $2 != c && $2 != d && (e == "" || $2 != e)' \
+                "$manifest" > "$tmp" \
+           && chmod 600 "$tmp" && mv -f -- "$tmp" "$manifest"; then
+            :
+        else
+            [ -z "$tmp" ] || rm -f -- "$tmp"
+            link_cleanup_warning "Old Link file records could not be updated; a later installer run can rebuild them"
+        fi
+    fi
+    if [ -e "$index" ] || [ -L "$index" ]; then
+        tmp=""
+        if [ -f "$index" ] && [ ! -L "$index" ] && [ -r "$index" ] \
+           && tmp="$(mktemp "$ABLETON_STATE_HOME/.old-link-files.XXXXXX")" \
+           && awk -F '\t' -v a="${targets[0]}" -v b="${targets[1]}" \
+                -v c="${targets[2]}" -v d="${targets[3]}" \
+                '$2 != a && $2 != b && $2 != c && $2 != d' \
+                "$index" > "$tmp" \
+           && chmod 600 "$tmp" && mv -f -- "$tmp" "$index"; then
+            for target in "${targets[@]}"; do
+                id="$(printf '%s' "$target" | sha256sum | awk '{print $1}')" \
+                    || continue
+                rm -f -- "$ABLETON_STATE_HOME/install-prestate/$id" 2>/dev/null || true
+                [ ! -e "$ABLETON_STATE_HOME/install-prestate/$id" ] \
+                    && [ ! -L "$ABLETON_STATE_HOME/install-prestate/$id" ] || \
+                    link_cleanup_warning "An obsolete Link backup could not be removed"
+            done
+        else
+            [ -z "$tmp" ] || rm -f -- "$tmp"
+            link_cleanup_warning "Old Link restoration records could not be updated; they will be ignored"
+        fi
+    fi
 }
 
 disable_link()
 {
-    echo "== disable Ableton Link =="
-    validate_link_firewall_state || {
-        echo "!! unsafe Link firewall ownership record: $state_file" >&2
-        return 1
-    }
-    stop_owned_service
+    local firewall_trusted=1
+    trap 'if [ "$LINK_DISABLE_COMMITTED" -eq 1 ]; then exit 0; else exit 130; fi' INT
+    trap 'if [ "$LINK_DISABLE_COMMITTED" -eq 1 ]; then exit 0; else exit 143; fi' TERM
+    # Repair project settings before any firewall or service change. A later
+    # genuine host failure must not leave an interrupted old generation behind.
+    if [ "${ABLETON_CONFIG_REPAIR_NEEDED:-0}" = 1 ]; then
+        if ! save_link_mode; then
+            echo "!! Installer settings could not be repaired yet; continuing with the Link change" >&2
+        fi
+    fi
+    printf '%s\n' "== turn off Ableton Link ==" || true
+    if ! validate_link_firewall_state; then
+        firewall_trusted=0
+        printf '%s\n' "!! Link firewall information was unreadable, so no firewall rule was changed" >&2 || true
+    fi
+    stop_canonical_link_service
     stop_owned_detached_link_daemons
     remove_owned_legacy_hook
-    remove_owned_firewall
-    if unit_is_owned; then
-        rm -f -- "$unit_file"
-        # Clear the directory if nothing else is using it.
-        rmdir --ignore-fail-on-non-empty -- "$unit_dir" 2>/dev/null || true
+    [ "$firewall_trusted" -eq 0 ] || remove_owned_firewall
+    if [ "$firewall_trusted" -eq 0 ] \
+       && { [ -e "$state_file" ] || [ -L "$state_file" ]; }; then
+        if ableton_state_marker_valid "$ABLETON_STATE_HOME"; then
+            if [ -d "$state_file" ] && [ ! -L "$state_file" ]; then
+                link_cleanup_warning "Unreadable Link firewall information could not be removed"
+            else
+                rm -f -- "$state_file" 2>/dev/null || true
+                [ ! -e "$state_file" ] && [ ! -L "$state_file" ] || \
+                    link_cleanup_warning "Unreadable Link firewall information could not be removed"
+            fi
+        else
+            echo "!! Unfamiliar Link firewall information was left unchanged: $state_file" >&2 || true
+        fi
     fi
+    ABLETON_LINK_MODE=off
+    export ABLETON_LINK_MODE
+    if ! save_link_mode; then
+        LINK_SETTING_SAVED=0
+        echo "!! Ableton Link is off, but its saved preference could not be updated" >&2
+    fi
+    LINK_DISABLE_COMMITTED=1
+    trap '' INT TERM PIPE
+    # From here on the requested external Link state is off. Generated-file,
+    # preference, and terminal cleanup cannot turn that completed outcome into
+    # an installer failure.
+    set +e
+    remove_owned_link_file "$unit_file"
+    # Clear the directory if nothing else is using it.
+    rmdir --ignore-fail-on-non-empty -- "$unit_dir" 2>/dev/null || true
     if command -v systemctl >/dev/null 2>&1; then
-        ableton_run_bounded 20 systemctl --user daemon-reload >/dev/null 2>&1 || true
+        ableton_run_bounded 20 systemctl --user daemon-reload >/dev/null 2>&1 || \
+            link_cleanup_warning "The user-service list will refresh at the next login"
     fi
     remove_owned_link_file "$ABLETON_DATA_HOME/ableton-linkd"
+    if [ -n "${ABLETON_PR182_CUSTOM_LINKD:-}" ]; then
+        echo "   Kept the older custom Link helper at $ABLETON_PR182_CUSTOM_LINKD"
+    fi
     if [ "$ABLETON_LINKD" != "$ABLETON_DATA_HOME/ableton-linkd" ]; then
-        echo "kept externally managed Link daemon $ABLETON_LINKD"
+        echo "   Kept the external Link helper at $ABLETON_LINKD"
     fi
     remove_owned_link_file "$data_unit"
     remove_owned_link_file "$linkctl"
     remove_owned_link_file "$ABLETON_DATA_HOME/setup-link.sh"
-    prune_link_manifest
-    rm -f -- "$ABLETON_DATA_HOME/link-configured"
-    ABLETON_LINK_MODE=off
-    export ABLETON_LINK_MODE
-    ableton_write_config
-    if [ "$link_residual" -eq 0 ]; then
-        echo "OK: Link policy is off; no owned Link binary, service, firewall rule, or daemon remains"
-    else
-        echo "OK: Link policy is off; unowned or modified Link files were kept"
-    fi
-}
-
-install_unit()
-{
-    local escaped loaded_fragment="" tmp=""
-    [ -x "$ABLETON_LINKD" ] || { echo "!! ableton-linkd is missing at $ABLETON_LINKD" >&2; return 1; }
-    if { [ -e "$unit_file" ] || [ -L "$unit_file" ]; } && ! unit_is_owned; then
-        echo "!! refusing to replace foreign systemd unit $unit_file" >&2
-        return 1
-    fi
-    if [ ! -e "$unit_file" ] && command -v systemctl >/dev/null 2>&1; then
-        loaded_fragment="$(ableton_run_bounded 20 systemctl --user show -p FragmentPath --value ableton-linkd.service 2>/dev/null || true)"
-        if [ -n "$loaded_fragment" ] && [ "$(ableton_realpath_m "$loaded_fragment")" != "$(ableton_realpath_m "$unit_file")" ]; then
-            echo "!! refusing to shadow foreign systemd unit $loaded_fragment" >&2
-            return 1
+    prune_link_metadata
+    remove_legacy_policy_file
+    if [ "$LINK_COORDINATED_ACTION" -ne 1 ]; then
+        if [ "$LINK_SETTING_SAVED" -ne 1 ]; then
+            echo "OK: Ableton Link is off; run the installer again to save that preference"
+        elif [ "$link_residual" -eq 0 ]; then
+            echo "OK: Ableton Link is off"
+        else
+            echo "OK: Ableton Link is off; some obsolete local files can be cleaned up by a later installer run"
         fi
     fi
-    mkdir -p -- "$unit_dir"
+    return 0
+}
+
+render_owned_link_unit()
+{
+    local escaped
     escaped="${ABLETON_LINKD//\\/\\\\}"
     escaped="${escaped//\"/\\\"}"
     escaped="${escaped//%/%%}"
-    tmp="$(mktemp "$unit_dir/.ableton-linkd.service.XXXXXX")" || return 1
-    if ! cat > "$tmp" <<EOF
+    cat <<EOF
 [Unit]
 Description=Ableton Link session anchor (ableton-linux)
 After=default.target
@@ -661,18 +1255,105 @@ RestartSec=5
 [Install]
 WantedBy=default.target
 EOF
-    then
+}
+
+save_link_mode()
+{
+    local tmp="" expected="" actual=""
+    if [ -L "$ABLETON_CONFIG_FILE" ]; then
+        echo "!! Ableton Link left the settings symlink unchanged: $ABLETON_CONFIG_FILE" >&2
+        return 1
+    fi
+    if [ -d "$ABLETON_CONFIG_FILE" ] && [ ! -L "$ABLETON_CONFIG_FILE" ]; then
+        echo "!! Ableton Link cannot replace a directory at $ABLETON_CONFIG_FILE" >&2
+        return 1
+    fi
+    if [ -e "$ABLETON_CONFIG_FILE" ] && [ ! -f "$ABLETON_CONFIG_FILE" ]; then
+        echo "!! Ableton Link left the non-file settings object unchanged: $ABLETON_CONFIG_FILE" >&2
+        return 1
+    fi
+    mkdir -p -- "$ABLETON_CONFIG_HOME" || return 1
+    tmp="$(mktemp "$ABLETON_CONFIG_HOME/.config.XXXXXX")" || return 1
+    if ! chmod 600 "$tmp" \
+       || ! ableton_render_config > "$tmp" \
+       || ! ableton_managed_config_valid "$tmp"; then
+        rm -f -- "$tmp"
+        echo "!! Ableton Link could not save its setting" >&2
+        return 1
+    fi
+    expected="$(ableton_config_object_token "$tmp")" || {
+        rm -f -- "$tmp"
+        return 1
+    }
+    mv -T -f -- "$tmp" "$ABLETON_CONFIG_FILE" 2>/dev/null || true
+    actual="$(ableton_config_object_token "$ABLETON_CONFIG_FILE" 2>/dev/null || true)"
+    if [ "$actual" != "$expected" ] \
+       || ! ableton_managed_config_valid "$ABLETON_CONFIG_FILE"; then
+        rm -f -- "$tmp"
+        echo "!! Ableton Link could not save its setting" >&2
+        return 1
+    fi
+    [ ! -e "$tmp" ] || rm -f -- "$tmp" 2>/dev/null || true
+    [ ! -e "$tmp" ] && [ ! -L "$tmp" ] || \
+        echo "!! Temporary Link settings could not be removed: $tmp" >&2
+    # This checksum only coordinates later installer helpers. The settings file
+    # above is already complete and verified, so bookkeeping cannot undo it.
+    ableton_config_snapshot_capture >/dev/null 2>&1 || true
+    ABLETON_CONFIG_REPAIR_NEEDED=0
+    export ABLETON_CONFIG_REPAIR_NEEDED
+}
+
+install_unit()
+{
+    local loaded_fragment="" tmp=""
+    [ -x "$ABLETON_LINKD" ] || {
+        echo "!! The Ableton Link helper is missing. Re-run the installer to restore it." >&2
+        return 1
+    }
+    if [ -d "$unit_file" ] && [ ! -L "$unit_file" ]; then
+        echo "!! Ableton Link cannot replace a directory at $unit_file" >&2
+        return 1
+    fi
+    if systemd_user_available; then
+        if ! loaded_fragment="$(ableton_run_bounded 20 systemctl --user show \
+                -p FragmentPath --value ableton-linkd.service 2>/dev/null)"; then
+            echo "!! Ableton Link could not inspect the user service" >&2
+            return 1
+        fi
+        if [ -n "$loaded_fragment" ] && [ "$(ableton_realpath_m "$loaded_fragment")" != "$(ableton_realpath_m "$unit_file")" ]; then
+            echo "!! Another user service already uses the name ableton-linkd.service: $loaded_fragment" >&2
+            return 1
+        fi
+    fi
+    mkdir -p -- "$unit_dir" || {
+        echo "!! Ableton Link could not create its user-service directory" >&2
+        return 1
+    }
+    tmp="$(mktemp "$unit_dir/.ableton-linkd.service.XXXXXX")" || return 1
+    if ! render_owned_link_unit > "$tmp"; then
         rm -f -- "$tmp"
         return 1
     fi
-    if ! chmod 644 "$tmp" || ! mv -f -- "$tmp" "$unit_file"; then
+    if ! chmod 644 "$tmp"; then
         rm -f -- "$tmp"
+        echo "!! Ableton Link could not write its user service" >&2
         return 1
     fi
+    mv -T -f -- "$tmp" "$unit_file" 2>/dev/null || true
+    if ! unit_is_owned; then
+        rm -f -- "$tmp"
+        echo "!! Ableton Link could not write its user service" >&2
+        return 1
+    fi
+    [ ! -e "$tmp" ] || rm -f -- "$tmp" 2>/dev/null || true
+    [ ! -e "$tmp" ] && [ ! -L "$tmp" ] || \
+        echo "!! Temporary Link service files could not be removed: $tmp" >&2
     # This writes the unit for a later session either way. With no running user
     # manager there is nothing to reload, and session policy never needs it.
     systemd_user_available || return 0
-    ableton_run_bounded 20 systemctl --user daemon-reload
+    if ! ableton_run_bounded 20 systemctl --user daemon-reload; then
+        echo "!! The Link user service could not be refreshed yet; its requested state will be checked before setup finishes" >&2
+    fi
 }
 
 ensure_recorded_firewall()
@@ -681,44 +1362,62 @@ ensure_recorded_firewall()
     case "$state" in
         ufw-added)
             command -v ufw >/dev/null 2>&1 || {
-                echo "!! cannot verify the recorded ufw rule because ufw is missing" >&2
+                echo "!! The ufw rule previously added for Link cannot be checked because ufw is missing" >&2
                 return 127
             }
-            echo "   verifying the recorded ufw allowance for UDP 20808 (sudo, each step bounded to two minutes)"
+            echo "   Checking the ufw rule for Link (UDP 20808)"
             ufw_link_rule_state || rule_state=$?
             if [ "$rule_state" -eq 1 ]; then
-                echo "   restoring the recorded ufw allowance for UDP 20808"
-                ableton_sudo_run_bounded 120 ufw allow 20808/udp
+                echo "   Restoring the missing ufw rule for Link"
+                ableton_sudo_run_bounded 120 ufw allow 20808/udp || true
+                rule_state=0
+                ufw_link_rule_state || rule_state=$?
+                [ "$rule_state" -eq 0 ] || {
+                    echo "!! The ufw rule for Link could not be restored" >&2
+                    return 1
+                }
             elif [ "$rule_state" -ne 0 ]; then
-                echo "!! could not verify the recorded ufw rule" >&2
+                echo "!! The ufw rule for Link could not be checked" >&2
                 return 1
             fi ;;
         firewalld-added)
-            echo "   verifying the recorded firewalld allowance for UDP 20808 (sudo, each step bounded to two minutes)"
+            echo "   Checking the firewalld rule for Link (UDP 20808)"
             if command -v firewall-cmd >/dev/null 2>&1 \
                && ableton_run_bounded 20 firewall-cmd --state >/dev/null 2>&1; then
                 firewalld_link_rule_state || rule_state=$?
                 if [ "$rule_state" -eq 1 ]; then
-                    echo "   restoring the recorded firewalld allowance for UDP 20808"
+                    echo "   Restoring the missing firewalld rule for Link"
                     ableton_sudo_run_bounded 120 \
-                        firewall-cmd --permanent --add-port=20808/udp || return $?
-                    ableton_sudo_run_bounded 120 firewall-cmd --reload
+                        firewall-cmd --permanent --add-port=20808/udp || true
+                    ableton_sudo_run_bounded 120 firewall-cmd --reload || true
                 elif [ "$rule_state" -ne 0 ]; then
-                    echo "!! could not verify the recorded firewalld rule" >&2
+                    echo "!! The firewalld rule for Link could not be checked" >&2
                     return 1
                 fi
+                rule_state=0
+                firewalld_link_rule_state || rule_state=$?
+                [ "$rule_state" -eq 0 ] || return 1
+                rule_state=0
+                firewalld_runtime_link_rule_state || rule_state=$?
+                [ "$rule_state" -eq 0 ] || {
+                    echo "!! The firewalld rule for Link is not active" >&2
+                    return 1
+                }
             elif command -v firewall-offline-cmd >/dev/null 2>&1; then
                 firewalld_offline_link_rule_state || rule_state=$?
                 if [ "$rule_state" -eq 1 ]; then
-                    echo "   restoring the recorded offline firewalld allowance for UDP 20808"
+                    echo "   Restoring the missing firewalld rule for Link"
                     ableton_sudo_run_bounded 120 \
-                        firewall-offline-cmd --add-port=20808/udp
+                        firewall-offline-cmd --add-port=20808/udp || true
                 elif [ "$rule_state" -ne 0 ]; then
-                    echo "!! could not verify the recorded offline firewalld rule" >&2
+                    echo "!! The firewalld rule for Link could not be checked" >&2
                     return 1
                 fi
+                rule_state=0
+                firewalld_offline_link_rule_state || rule_state=$?
+                [ "$rule_state" -eq 0 ] || return 1
             else
-                echo "!! cannot verify the recorded firewalld rule because firewalld is missing" >&2
+                echo "!! The firewalld rule previously added for Link cannot be checked because firewalld is missing" >&2
                 return 127
             fi ;;
         *) return 2 ;;
@@ -728,30 +1427,42 @@ ensure_recorded_firewall()
 configure_firewall()
 {
     validate_link_firewall_state || {
-        echo "!! unsafe Link firewall ownership record: $state_file" >&2
+        echo "!! Link firewall information is unreadable" >&2
         return 1
     }
-    ableton_mark_state_home
+    ableton_mark_state_home || return 1
     if [ -r "$state_file" ]; then
         case "$(sed -n '1p' "$state_file")" in
             ufw-added) ensure_recorded_firewall ufw-added; return $? ;;
             firewalld-added) ensure_recorded_firewall firewalld-added; return $? ;;
             none) : ;;
-            *) echo "!! unrecognised Link firewall ownership record: $state_file" >&2; return 1 ;;
+            *) echo "!! Link firewall information is unreadable" >&2; return 1 ;;
         esac
     fi
     if command -v ufw >/dev/null 2>&1 && grep -qsi '^ENABLED=yes' /etc/ufw/ufw.conf; then
         local rule_state=0
         ufw_link_rule_state || rule_state=$?
         if [ "$rule_state" -eq 0 ]; then
-            write_link_firewall_state none
-            echo "   ufw already allows UDP 20808; leaving the foreign/pre-existing rule alone"
+            write_link_firewall_state none || {
+                echo "!! Ableton Link could not save that the existing ufw rule was left unchanged" >&2
+                return 1
+            }
+            echo "   ufw already allows UDP 20808; leaving the existing rule unchanged"
         elif [ "$rule_state" -eq 1 ]; then
-            echo "   ufw is active: adding UDP 20808 (sudo, each step bounded to two minutes)"
-            write_link_firewall_state ufw-added
+            echo "   ufw is active: opening UDP 20808 for Ableton Link"
+            write_link_firewall_state ufw-added || {
+                echo "!! Ableton Link cannot safely track a new ufw rule" >&2
+                return 1
+            }
             # Persist ownership before ufw can make a partial change. The
             # caller's recovery can then remove only this attempted rule.
-            ableton_sudo_run_bounded 120 ufw allow 20808/udp || return $?
+            ableton_sudo_run_bounded 120 ufw allow 20808/udp || true
+            rule_state=0
+            ufw_link_rule_state || rule_state=$?
+            [ "$rule_state" -eq 0 ] || {
+                echo "!! ufw did not open UDP 20808 for Ableton Link" >&2
+                return 1
+            }
         else
             echo "!! could not inspect the active ufw rules" >&2
             return 1
@@ -761,37 +1472,69 @@ configure_firewall()
         local rule_state=0
         firewalld_link_rule_state || rule_state=$?
         if [ "$rule_state" -eq 0 ]; then
-            write_link_firewall_state none
-            echo "   firewalld already allows UDP 20808; leaving the foreign/pre-existing rule alone"
+            write_link_firewall_state none || {
+                echo "!! Ableton Link could not save that the existing firewalld rule was left unchanged" >&2
+                return 1
+            }
+            echo "   firewalld already allows UDP 20808; leaving the existing rule unchanged"
+            rule_state=0
+            firewalld_runtime_link_rule_state || rule_state=$?
+            if [ "$rule_state" -ne 0 ]; then
+                ableton_sudo_run_bounded 120 firewall-cmd --reload || true
+                rule_state=0
+                firewalld_runtime_link_rule_state || rule_state=$?
+                [ "$rule_state" -eq 0 ] || {
+                    echo "!! The existing firewalld rule for Link is not active" >&2
+                    return 1
+                }
+            fi
         elif [ "$rule_state" -eq 1 ]; then
-            echo "   firewalld is active: adding UDP 20808 (sudo, each step bounded to two minutes)"
-            write_link_firewall_state firewalld-added
+            echo "   firewalld is active: opening UDP 20808 for Ableton Link"
+            write_link_firewall_state firewalld-added || {
+                echo "!! Ableton Link cannot safely track a new firewalld rule" >&2
+                return 1
+            }
             ableton_sudo_run_bounded 120 \
-                firewall-cmd --permanent --add-port=20808/udp || return $?
-            # Ownership is already recorded before reload. If reload fails, the
-            # caller's rollback can still remove the persistent rule.
-            ableton_sudo_run_bounded 120 firewall-cmd --reload || return $?
+                firewall-cmd --permanent --add-port=20808/udp || true
+            ableton_sudo_run_bounded 120 firewall-cmd --reload || true
+            rule_state=0
+            firewalld_link_rule_state || rule_state=$?
+            [ "$rule_state" -eq 0 ] || return 1
+            rule_state=0
+            firewalld_runtime_link_rule_state || rule_state=$?
+            [ "$rule_state" -eq 0 ] || {
+                echo "!! firewalld did not open UDP 20808 for Ableton Link" >&2
+                return 1
+            }
         else
             echo "!! could not inspect the active firewalld rules" >&2
             return 1
         fi
     else
-        write_link_firewall_state none
-        echo "   no active ufw/firewalld; no firewall mutation"
+        write_link_firewall_state none || {
+            echo "!! Ableton Link could not save its firewall status" >&2
+            return 1
+        }
+        echo "   No active ufw or firewalld; the firewall is unchanged"
     fi
 }
 
 restore_firewall_record()
 {
     local prior="$1" rc=0 rule_state=0
-    ableton_mark_state_home
+    ableton_mark_state_home || return 1
     case "$prior" in
         ufw-added)
             ufw_link_rule_state || rule_state=$?
             if [ "$rule_state" -eq 1 ]; then
-                ableton_sudo_run_bounded 120 ufw allow 20808/udp || rc=$?
+                ableton_sudo_run_bounded 120 ufw allow 20808/udp || true
             elif [ "$rule_state" -ne 0 ]; then
                 rc=1
+            fi
+            if [ "$rc" -eq 0 ]; then
+                rule_state=0
+                ufw_link_rule_state || rule_state=$?
+                [ "$rule_state" -eq 0 ] || rc=1
             fi ;;
         firewalld-added)
             if command -v firewall-cmd >/dev/null 2>&1 \
@@ -799,19 +1542,34 @@ restore_firewall_record()
                 rule_state=0
                 firewalld_link_rule_state || rule_state=$?
                 if [ "$rule_state" -eq 1 ]; then
-                    ableton_sudo_run_bounded 120 firewall-cmd --permanent --add-port=20808/udp || rc=$?
-                    [ "$rc" -ne 0 ] || ableton_sudo_run_bounded 120 firewall-cmd --reload || rc=$?
+                    ableton_sudo_run_bounded 120 firewall-cmd --permanent --add-port=20808/udp || true
+                    ableton_sudo_run_bounded 120 firewall-cmd --reload || true
                 elif [ "$rule_state" -ne 0 ]; then
                     rc=1
+                fi
+                if [ "$rc" -eq 0 ]; then
+                    rule_state=0
+                    firewalld_link_rule_state || rule_state=$?
+                    [ "$rule_state" -eq 0 ] || rc=1
+                fi
+                if [ "$rc" -eq 0 ]; then
+                    rule_state=0
+                    firewalld_runtime_link_rule_state || rule_state=$?
+                    [ "$rule_state" -eq 0 ] || rc=1
                 fi
             elif command -v firewall-offline-cmd >/dev/null 2>&1; then
                 rule_state=0
                 firewalld_offline_link_rule_state || rule_state=$?
                 if [ "$rule_state" -eq 1 ]; then
                     ableton_sudo_run_bounded 120 \
-                        firewall-offline-cmd --add-port=20808/udp || rc=$?
+                        firewall-offline-cmd --add-port=20808/udp || true
                 elif [ "$rule_state" -ne 0 ]; then
                     rc=1
+                fi
+                if [ "$rc" -eq 0 ]; then
+                    rule_state=0
+                    firewalld_offline_link_rule_state || rule_state=$?
+                    [ "$rule_state" -eq 0 ] || rc=1
                 fi
             else
                 rc=127
@@ -825,121 +1583,49 @@ restore_firewall_record()
 
 populate_link_transaction_snapshot()
 {
-    local snap="$1" pids asset label manifest
+    local snap="$1"
+    printf '3\n' > "$snap/format" || return 1
     printf '%s\n' "$ABLETON_LINK_MODE" > "$snap/policy" || return 1
-    if [ -f "$state_file" ] && [ ! -L "$state_file" ]; then
-        cp -a -- "$state_file" "$snap/firewall" || return 1
-    else
-        : > "$snap/firewall.absent" || return 1
-    fi
+    snapshot_link_firewall_state "$snap/firewall" || return 1
     snapshot_legacy_network "$snap/legacy" || return 1
-    if [ -f "$unit_file" ] && [ ! -L "$unit_file" ]; then
-        cp -a -- "$unit_file" "$snap/unit" || return 1
-    else
-        [ ! -e "$unit_file" ] && [ ! -L "$unit_file" ] || {
-            echo "!! unsafe or foreign Link unit cannot be snapshotted: $unit_file" >&2
-            return 1
-        }
-        : > "$snap/unit.absent" || return 1
-    fi
-    label=0
-    for asset in "$ABLETON_DATA_HOME/ableton-linkd" "$data_unit" "$linkctl" "$ABLETON_DATA_HOME/setup-link.sh"; do
-        printf '%s\n' "$asset" > "$snap/asset-$label.path" || return 1
-        if [ -f "$asset" ] || [ -L "$asset" ]; then
-            cp -a -- "$asset" "$snap/asset-$label.file" || return 1
-        else
-            [ ! -e "$asset" ] || {
-                echo "!! unsafe Link asset cannot be snapshotted: $asset" >&2
-                return 1
-            }
-            : > "$snap/asset-$label.absent" || return 1
-        fi
-        label=$((label + 1))
-    done
-    manifest="$ABLETON_STATE_HOME/install-manifest.tsv"
-    if [ -f "$manifest" ] && [ ! -L "$manifest" ]; then
-        cp -a -- "$manifest" "$snap/manifest" || return 1
-    else
-        [ ! -e "$manifest" ] && [ ! -L "$manifest" ] || {
-            echo "!! unsafe Link ownership snapshot" >&2
-            return 1
-        }
-        : > "$snap/manifest.absent" || return 1
-    fi
-    if [ -e "$ABLETON_STATE_HOME/install-prestate.tsv" ]; then
-        cp -a -- "$ABLETON_STATE_HOME/install-prestate.tsv" \
-            "$snap/prestate.tsv" || return 1
-    else
-        : > "$snap/prestate.absent" || return 1
-    fi
-    if [ -d "$ABLETON_STATE_HOME/install-prestate" ] \
-       && [ ! -L "$ABLETON_STATE_HOME/install-prestate" ]; then
-        cp -a -- "$ABLETON_STATE_HOME/install-prestate" \
-            "$snap/prestate-dir" || return 1
-    elif [ -e "$ABLETON_STATE_HOME/install-prestate" ] \
-         || [ -L "$ABLETON_STATE_HOME/install-prestate" ]; then
-        echo "!! unsafe Link pre-install snapshot directory" >&2
-        return 1
-    else
-        : > "$snap/prestate-dir.absent" || return 1
-    fi
-    if unit_is_owned && command -v systemctl >/dev/null 2>&1; then
-        if ableton_run_bounded 20 systemctl --user is-enabled --quiet \
-            ableton-linkd.service 2>/dev/null; then
-            : > "$snap/enabled" || return 1
-        else
-            : > "$snap/enabled.absent" || return 1
-        fi
-        if loaded_unit_is_owned \
-           && ableton_run_bounded 20 systemctl --user is-active --quiet \
-                ableton-linkd.service 2>/dev/null; then
-            : > "$snap/active" || return 1
-        else
-            : > "$snap/active.absent" || return 1
-        fi
-    else
-        : > "$snap/enabled.absent" || return 1
-        : > "$snap/active.absent" || return 1
-    fi
-    pids="$(owned_link_pids | head -n 1)" || return 1
-    if [ -z "$pids" ]; then
-        : > "$snap/detached-active.absent" || return 1
-    else
-        : > "$snap/detached-active" || return 1
-    fi
+    snapshot_link_service_state "$snap" || return 1
     : > "$snap/ready" || return 1
 }
 
 snapshot_link_transaction()
 {
-    local snap="$transaction_dir/link" build=""
+    local snap="$transaction_dir/link" build="" entries=""
     ableton_txn_init || return 1
-    validate_link_firewall_state || {
-        echo "!! unsafe Link firewall ownership record: $state_file" >&2
-        return 1
-    }
     if [ -e "$snap" ] || [ -L "$snap" ]; then
         [ -d "$snap" ] && [ ! -L "$snap" ] || {
             echo "!! Link transaction snapshot path is unsafe" >&2
             return 1
         }
-        if find "$snap" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
-            validate_link_transaction_snapshot || return 1
-            return 0
+        entries="$(find "$snap" -mindepth 1 -maxdepth 1 -print -quit)" || return 1
+        if [ -n "$entries" ]; then
+            if validate_link_transaction_snapshot; then
+                return 0
+            fi
+            # This directory is generated by this helper inside the caller's
+            # new work area. Rebuild it instead of making stale local data a gate.
+            rm -rf -- "$snap" 2>/dev/null || true
+            [ ! -e "$snap" ] && [ ! -L "$snap" ] || return 1
+        else
+            rmdir -- "$snap" 2>/dev/null || true
+            [ ! -e "$snap" ] && [ ! -L "$snap" ] || return 1
         fi
-        rmdir -- "$snap" || return 1
     fi
     build="$(mktemp -d "$transaction_dir/.link-snapshot.XXXXXX")" || return 1
     if ! populate_link_transaction_snapshot "$build"; then
-        rm -rf -- "$build" || {
-            echo "!! failed to remove incomplete Link transaction snapshot: $build" >&2
-        }
+        rm -rf -- "$build" 2>/dev/null || true
+        [ ! -e "$build" ] && [ ! -L "$build" ] || \
+            echo "!! Temporary Link recovery files could not be removed: $build" >&2
         return 1
     fi
     if ! mv -T -n -- "$build" "$snap" \
        || [ -e "$build" ] || [ ! -d "$snap" ] || [ -L "$snap" ]; then
         [ ! -e "$build" ] || rm -rf -- "$build"
-        echo "!! could not publish the complete Link transaction snapshot" >&2
+        echo "!! Ableton Link could not save the current firewall and service settings" >&2
         return 1
     fi
     validate_link_transaction_snapshot
@@ -971,39 +1657,40 @@ link_snapshot_pair_valid()
 
 validate_link_transaction_snapshot()
 {
-    local snap="$transaction_dir/link" prior label path expected saved count=0 names_count=0
-    local status p backup extra digest slot name
-    local -A seen=() prestate_seen=() prestate_slots=()
+    local snap="$transaction_dir/link" prior name names_count=0 members=""
     [ ! -e "$snap" ] && [ ! -L "$snap" ] && return 0
     [ -d "$snap" ] && [ ! -L "$snap" ] || {
         echo "!! Link transaction snapshot is unsafe" >&2; return 1; }
     [ -f "$snap/ready" ] && [ ! -L "$snap/ready" ] && [ ! -s "$snap/ready" ] || {
         echo "!! Link transaction ready marker is invalid" >&2; return 1; }
+    [ -f "$snap/format" ] && [ ! -L "$snap/format" ] \
+        && [ "$(sed -n '1p' "$snap/format")" = 3 ] \
+        && [ "$(wc -l < "$snap/format")" -eq 1 ] || {
+        echo "!! Link transaction snapshot format is invalid" >&2; return 1; }
     [ -f "$snap/policy" ] && [ ! -L "$snap/policy" ] \
         && ableton_file_has_no_nul "$snap/policy" \
         && [ "$(wc -l < "$snap/policy")" -eq 1 ] || {
         echo "!! Link transaction policy is invalid" >&2; return 1; }
     prior="$(sed -n '1p' "$snap/policy")"
     case "$prior" in off|session|always) ;; *) echo "!! Link transaction policy is invalid" >&2; return 1 ;; esac
-    while IFS= read -r -d '' name; do
-        name="${name##*/}"; names_count=$((names_count + 1))
+    members="$(find "$snap" -mindepth 1 -maxdepth 1 -printf '%f\n')" || return 1
+    while IFS= read -r name; do
+        [ -n "$name" ] || continue
+        names_count=$((names_count + 1))
         case "$name" in
-            ready|policy|firewall|firewall.absent|unit|unit.absent|manifest|manifest.absent|\
-            prestate.tsv|prestate.absent|prestate-dir|prestate-dir.absent|\
+            ready|format|policy|firewall|firewall.absent|manager|manager.absent|\
             enabled|enabled.absent|active|active.absent|\
             detached-active|detached-active.absent|legacy.hook|legacy.hook.absent|\
-            legacy.route|legacy.route.absent|\
-            asset-[0-3].path|asset-[0-3].file|asset-[0-3].absent) ;;
+            legacy.route|legacy.route.absent) ;;
             *) echo "!! Link transaction snapshot has an unknown member: $name" >&2; return 1 ;;
         esac
-    done < <(find "$snap" -mindepth 1 -maxdepth 1 -print0)
-    [ "$names_count" -eq 20 ] || {
+    done <<< "$members"
+    # format/ready/policy plus exactly one member from each of seven evidence
+    # pairs below.
+    [ "$names_count" -eq 10 ] || {
         echo "!! Link transaction snapshot inventory is incomplete" >&2; return 1; }
     if ! { link_snapshot_pair_valid "$snap/firewall" regular \
-           && link_snapshot_pair_valid "$snap/unit" regular \
-           && link_snapshot_pair_valid "$snap/manifest" regular \
-           && link_snapshot_pair_valid "$snap/prestate.tsv" regular "$snap/prestate.absent" \
-           && link_snapshot_pair_valid "$snap/prestate-dir" directory \
+           && link_snapshot_pair_valid "$snap/manager" marker \
            && link_snapshot_pair_valid "$snap/enabled" marker \
            && link_snapshot_pair_valid "$snap/active" marker \
            && link_snapshot_pair_valid "$snap/detached-active" marker \
@@ -1016,272 +1703,114 @@ validate_link_transaction_snapshot()
         echo "!! Link firewall snapshot is invalid" >&2; return 1; }
     [ ! -e "$snap/legacy.hook" ] || {
         grep -qxF '#!/bin/sh' "$snap/legacy.hook" \
-            && grep -qF '[ "$2" = "up" ] || exit 0' "$snap/legacy.hook" \
+            && grep -qF "[ \"\$2\" = \"up\" ] || exit 0" "$snap/legacy.hook" \
             && grep -qF 'ip route replace 224.0.0.0/4' "$snap/legacy.hook"; } || {
         echo "!! Link legacy-hook snapshot is invalid" >&2; return 1; }
     if [ -e "$snap/legacy.route" ]; then
         case "$(sed -n '1p' "$snap/legacy.route")" in 224.0.0.0/4\ *) ;; *)
             echo "!! Link legacy-route snapshot is invalid" >&2; return 1 ;; esac
     fi
-    [ ! -e "$snap/manifest" ] || ableton_validate_ownership_manifest "$snap/manifest" || return 1
-    if [ -e "$snap/prestate.tsv" ]; then
-        while IFS=$'\t' read -r status p backup extra || [ -n "$status$p$backup$extra" ]; do
-            [ -z "$extra" ] && [ "$status" = present ] \
-                && ableton_manifest_path_ok "$p" \
-                && [ -z "${prestate_seen[$p]+x}" ] \
-                && { ableton_managed_path_allowed file "$p" \
-                     || ableton_managed_path_allowed config "$p" \
-                     || ableton_managed_path_allowed symlink "$p"; } || return 1
-            expected="$ABLETON_STATE_HOME/install-prestate/$(printf '%s' "$p" | sha256sum | awk '{print $1}')"
-            [ "$backup" = "$expected" ] || return 1
-            backup="$snap/prestate-dir/${backup##*/}"
-            { [ -f "$backup" ] || [ -L "$backup" ]; } || return 1
-            digest="$(ableton_manifest_digest "$backup" 2>/dev/null || true)"
-            [ -n "$digest" ] || return 1
-            prestate_seen["$p"]=1
-            prestate_slots["${backup##*/}"]=1
-        done < "$snap/prestate.tsv"
-    fi
-    if [ -d "$snap/prestate-dir" ]; then
-        while IFS= read -r -d '' slot; do
-            name="${slot##*/}"
-            if ! { [[ "$name" =~ ^[0-9a-f]{64}$ ]] \
-                   && { [ -f "$slot" ] || [ -L "$slot" ]; } \
-                   && [ -n "$(ableton_manifest_digest "$slot" 2>/dev/null || true)" ] \
-                   && { [ ! -e "$snap/prestate.tsv" ] \
-                        || [ -n "${prestate_slots[$name]+x}" ]; }; }; then
-                echo "!! Link prestate snapshot contains an unindexed object" >&2
-                return 1
-            fi
-        done < <(find "$snap/prestate-dir" -mindepth 1 -maxdepth 1 -print0)
-    fi
-    for label in 0 1 2 3; do
-        saved="$snap/asset-$label.path"
-        [ -f "$saved" ] && [ ! -L "$saved" ] && [ -r "$saved" ] \
-            && ableton_file_has_no_nul "$saved" \
-            && [ "$(wc -l < "$saved")" -eq 1 ] || return 1
-        label="${saved##*/asset-}"; label="${label%.path}"
-        case "$label" in 0|1|2|3) ;; *) echo "!! Link asset snapshot label is invalid" >&2; return 1 ;; esac
-        path="$(sed -n '1p' "$saved")"
-        case "$label" in
-            0) expected="$ABLETON_DATA_HOME/ableton-linkd" ;;
-            1) expected="$data_unit" ;;
-            2) expected="$linkctl" ;;
-            3) expected="$ABLETON_DATA_HOME/setup-link.sh" ;;
-        esac
-        [ "$path" = "$expected" ] && [ -z "${seen[$path]+x}" ] || {
-            echo "!! Link asset snapshot path is invalid" >&2; return 1; }
-        seen["$path"]=1; count=$((count + 1))
-        link_snapshot_pair_valid "${saved%.path}.file" object "${saved%.path}.absent" || {
-            echo "!! Link asset snapshot object is unsafe" >&2; return 1; }
-    done
-    [ "$count" -eq 4 ] || { echo "!! Link asset snapshot set is incomplete" >&2; return 1; }
-
 }
 
 preflight_link_transaction()
 {
-    local path snap="$transaction_dir/link" saved current prior expected
+    local snap="$transaction_dir/link"
     validate_link_transaction_snapshot || return 1
-    if [ -e "$transaction_dir/files.tsv" ] || [ -L "$transaction_dir/files.tsv" ]; then
-        ableton_txn_preflight_rollback_files "$transaction_dir" || return 1
-    fi
-    # Rollback removes or replaces these exact destinations. Refuse a changed
-    # directory/special object before an outer transaction restores any other
-    # component, and require existing Link paths to remain project-owned.
-    for path in "$unit_file" "$ABLETON_DATA_HOME/ableton-linkd" "$data_unit" \
-                "$linkctl" "$ABLETON_DATA_HOME/setup-link.sh" \
-                "$ABLETON_STATE_HOME/install-manifest.tsv" \
-                "$ABLETON_STATE_HOME/install-prestate.tsv"; do
-        [ ! -e "$path" ] && [ ! -L "$path" ] && continue
-        { [ -f "$path" ] || [ -L "$path" ]; } && [ ! -d "$path" ] || {
-            echo "!! Link rollback destination is unsafe: $path" >&2; return 1; }
-    done
-    if [ -e "$ABLETON_STATE_HOME/install-prestate" ] \
-       || [ -L "$ABLETON_STATE_HOME/install-prestate" ]; then
-        [ -d "$ABLETON_STATE_HOME/install-prestate" ] \
-            && [ ! -L "$ABLETON_STATE_HOME/install-prestate" ] || {
-            echo "!! Link rollback prestate destination is unsafe" >&2; return 1; }
-    fi
-
-    # Do not overwrite a user edit made after the snapshot. A live destination
-    # must still be the snapshotted object or a replacement claimed by the
-    # current project manifest.
-    current="$(ableton_object_token "$unit_file" 2>/dev/null || true)"
-    prior=absent
-    [ ! -e "$snap/unit" ] \
-        || prior="$(ableton_object_token "$snap/unit" 2>/dev/null || true)"
-    if [ -z "$current" ] \
-       || { [ "$current" != "$prior" ] && ! unit_is_owned; }; then
-            echo "!! Link unit changed while rollback was pending: $unit_file" >&2
-            return 1
-    fi
-    for saved in "$snap"/asset-[0-3].path; do
-        path="$(sed -n '1p' "$saved")"
-        current="$(ableton_object_token "$path" 2>/dev/null || true)"
-        prior=absent
-        [ ! -e "${saved%.path}.file" ] \
-            || prior="$(ableton_object_token "${saved%.path}.file" 2>/dev/null || true)"
-        expected="$(manifest_digest_for "$path" 2>/dev/null || true)"
-        [ -z "$expected" ] || expected="file:$expected"
-        if [ -z "$current" ] \
-           || { [ "$current" != "$prior" ] && [ "$current" != "$expected" ]; }; then
-            echo "!! Link asset changed while rollback was pending: $path" >&2
-            return 1
-        fi
-    done
-    if [ -e "$ABLETON_STATE_HOME/install-manifest.tsv" ]; then
-        ableton_validate_ownership_manifest "$ABLETON_STATE_HOME/install-manifest.tsv" || return 1
-    fi
-    if [ -e "$ABLETON_STATE_HOME/install-prestate.tsv" ]; then
-        ableton_validate_prestate_index \
-            "$ABLETON_STATE_HOME/install-prestate.tsv" \
-            "$ABLETON_STATE_HOME/install-prestate" || return 1
-    fi
+    validate_link_firewall_state || {
+        echo "!! Link firewall information changed before the previous system settings could be restored" >&2
+        return 1
+    }
+    legacy_network_safe_for_restore "$snap/legacy" || {
+        echo "!! The old multicast route changed before it could be restored" >&2
+        return 1
+    }
 }
 
 preflight_link_commit_transaction()
 {
-    validate_link_transaction_snapshot || return 1
-    if [ -e "$transaction_dir/files.tsv" ] || [ -L "$transaction_dir/files.tsv" ]; then
-        ableton_txn_preflight_commit_files "$transaction_dir" || return 1
-    fi
+    # Successful Link actions do not depend on disposable recovery files.
+    return 0
 }
 
 rollback_link_transaction()
 {
-    local snap="$transaction_dir/link" prior rc=0 ctl path saved manifest
+    local snap="$transaction_dir/link" rc=0
     preflight_link_transaction || return 1
     [ -e "$snap/ready" ] || return 0
-    prior="$(sed -n '1p' "$snap/policy")"
-    stop_owned_service || return $?
-    stop_owned_detached_link_daemons || rc=$?
-    ctl="$here/ableton-linkctl"; [ -x "$ctl" ] || ctl="$linkctl"
-    restore_firewall_snapshot "$snap/firewall" || rc=$?
-    restore_legacy_network "$snap/legacy" || rc=$?
-    if [ -e "$snap/unit" ]; then
-        ableton_atomic_restore_object "$snap/unit" "$unit_file" || rc=1
-    elif unit_is_owned; then
-        rm -f -- "$unit_file"
-    fi
-    for saved in "$snap"/asset-*.path; do
-        [ -f "$saved" ] || continue
-        path="$(sed -n '1p' "$saved")"
-        saved="${saved%.path}.file"
-        if [ -e "$saved" ] || [ -L "$saved" ]; then
-            ableton_atomic_restore_object "$saved" "$path" || rc=1
-        elif [ -e "$path" ] || [ -L "$path" ]; then
-            if legacy_link_file_is_owned "$path"; then
-                rm -f -- "$path"
-            else
-                echo "!! Link asset changed while rollback was pending: $path" >&2
-                rc=1
-            fi
-        fi
-    done
-    manifest="$ABLETON_STATE_HOME/install-manifest.tsv"
-    if [ -e "$snap/manifest" ]; then
-        ableton_mark_state_home
-        ableton_atomic_restore_object "$snap/manifest" "$manifest" || rc=1
-    elif [ -e "$manifest" ] || [ -L "$manifest" ]; then
-        if ableton_validate_ownership_manifest "$manifest"; then
-            rm -f -- "$manifest"
-        else
-            rc=1
-        fi
-    fi
-    rm -f -- "$ABLETON_STATE_HOME/install-prestate.tsv"
-    rm -rf -- "$ABLETON_STATE_HOME/install-prestate"
-    if [ -e "$snap/prestate.tsv" ]; then
-        ableton_atomic_restore_object "$snap/prestate.tsv" \
-            "$ABLETON_STATE_HOME/install-prestate.tsv" || rc=1
-    fi
-    if [ -d "$snap/prestate-dir" ]; then
-        cp -a -- "$snap/prestate-dir" "$ABLETON_STATE_HOME/install-prestate"
-    fi
-    # With no reachable user manager there is no unit state to put back, so the
-    # rollback is complete without this block.
-    if systemd_user_available; then
-        ableton_run_bounded 20 systemctl --user daemon-reload >/dev/null 2>&1 || rc=$?
-        if [ -e "$snap/enabled" ]; then
-            ableton_run_bounded 20 systemctl --user enable ableton-linkd.service >/dev/null 2>&1 || rc=$?
-        elif unit_is_owned; then
-            ableton_run_bounded 20 systemctl --user disable ableton-linkd.service >/dev/null 2>&1 || true
-        fi
-        if [ -e "$snap/active" ]; then
-            ableton_run_bounded 20 systemctl --user start ableton-linkd.service >/dev/null 2>&1 || rc=$?
-        fi
-    elif [ -e "$snap/enabled" ] || [ -e "$snap/active" ]; then
-        # The snapshot recorded live unit state, so a reachable manager put it
-        # there. Reporting success now would hide an unfinished rollback.
-        echo "!! no systemd user manager is reachable to restore the Link unit state" >&2
-        rc=1
-    fi
-    if [ -e "$snap/detached-active" ] && [ "$prior" = session ] && [ -x "$ctl" ]; then
-        ABLETON_LINK_MODE=session "$ctl" start || rc=$?
-    fi
-    [ "$rc" -eq 0 ] || { echo "!! Link pre-state could not be fully restored" >&2; return "$rc"; }
-    rm -rf -- "$snap"
+    quiesce_link_process_state_for_restore "$snap" || rc=$?
+    [ "$rc" -ne 0 ] || restore_firewall_snapshot "$snap/firewall" || rc=$?
+    [ "$rc" -ne 0 ] || restore_legacy_network "$snap/legacy" || rc=$?
+    [ "$rc" -ne 0 ] || restore_link_process_state "$snap" || rc=$?
+    [ "$rc" -ne 0 ] || firewall_matches_snapshot "$snap/firewall" || rc=1
+    [ "$rc" -ne 0 ] || legacy_network_matches_snapshot "$snap/legacy" || rc=1
+    [ "$rc" -eq 0 ] || {
+        echo "!! The previous Link firewall or service settings could not be fully restored" >&2
+        return "$rc"
+    }
+    rm -rf -- "$snap" 2>/dev/null || true
+    [ ! -e "$snap" ] && [ ! -L "$snap" ] || \
+        echo "!! Temporary Link recovery files could not be removed: $snap" >&2 || true
+    return 0
 }
 
 commit_link_transaction()
 {
-    local snap="$transaction_dir/link" ctl
-    [ -e "$snap/ready" ] || return 0
-    preflight_link_commit_transaction || return 1
-    ctl="$here/ableton-linkctl"; [ -x "$ctl" ] || ctl="$linkctl"
-    if [ -e "$snap/detached-active" ] && [ "$ABLETON_LINK_MODE" = session ] && [ -x "$ctl" ]; then
-        "$ctl" start
+    local snap="$transaction_dir/link"
+    [ -e "$snap" ] || [ -L "$snap" ] || return 0
+    if [ -d "$snap" ] && [ ! -L "$snap" ]; then
+        rm -rf -- "$snap" 2>/dev/null || true
+        [ ! -e "$snap" ] && [ ! -L "$snap" ] || \
+            echo "!! Temporary Link recovery files could not be removed: $snap" >&2 || true
+    else
+        echo "!! Temporary Link recovery files could not be removed: $snap" >&2 || true
     fi
-    rm -rf -- "$snap"
+    return 0
 }
 
 plan_link()
 {
     local output=""
-    echo "PLAN: Ableton Link"
     if [ "$action" = plan-disable ]; then
-        printf '  set persistent policy off: %s\n' "$ABLETON_CONFIG_FILE"
-        printf '  stop only daemon PIDs whose executable is: %s\n' "$ABLETON_LINKD"
-        unit_is_owned && printf '  disable/stop and remove owned unit: %s\n' "$unit_file"
-        [ ! -r "$state_file" ] || printf '  reverse recorded firewall state (%s): %s\n' "$(sed -n '1p' "$state_file")" "$state_file"
-        [ ! -e "$legacy_hook" ] || printf '  remove recognisable legacy hook/route: %s\n' "$legacy_hook"
-        printf '  remove manifest-owned Link assets: %s, %s/{ableton-linkctl,setup-link.sh,ableton-linkd.service}\n' \
-            "$ABLETON_DATA_HOME/ableton-linkd" "$ABLETON_DATA_HOME"
+        echo "PLAN: Turn off Ableton Link"
+        echo '  Stop the Ableton Link service and helper'
+        [ ! -r "$state_file" ] || echo '  Remove the firewall rule added for Link'
+        [ ! -e "$legacy_hook" ] || echo '  Remove the old Link multicast route'
+        echo '  Remove generated Link files and save Link as off'
         return 0
     fi
-    printf '  set persistent policy %s: %s\n' "$mode" "$ABLETON_CONFIG_FILE"
-    [ ! -e "$legacy_hook" ] || printf '  remove recognisable legacy hook/route: %s\n' "$legacy_hook"
+    echo "PLAN: Enable Ableton Link"
+    [ ! -e "$legacy_hook" ] || echo '  Remove the old Link multicast route'
     if command -v ufw >/dev/null 2>&1 && grep -qsi '^ENABLED=yes' /etc/ufw/ufw.conf; then
         if output="$(ableton_run_bounded 20 ufw status 2>/dev/null)"; then
-            if printf '%s\n' "$output" \
-                | grep -Eq '(^|[[:space:]])20808/udp([[:space:]]|$)'; then
-                echo '  keep pre-existing UFW UDP 20808 rule; record no ownership'
+            if grep -Eq '(^|[[:space:]])20808/udp([[:space:]]|$)' \
+                <<< "$output"; then
+                echo '  Keep the existing UFW rule for UDP 20808'
             else
-                echo '  add UFW UDP 20808 rule; record project ownership'
+                echo '  Open UDP 20808 with UFW'
             fi
         else
-            echo '  inspect UFW UDP 20808 with sudo; add it only when absent'
+            echo '  Check UFW and open UDP 20808 if needed'
         fi
     elif command -v firewall-cmd >/dev/null 2>&1 \
          && ableton_run_bounded 20 firewall-cmd --state >/dev/null 2>&1; then
         if output="$(ableton_run_bounded 20 firewall-cmd --permanent --list-ports 2>/dev/null)"; then
-            if printf '%s\n' "$output" | tr ' ' '\n' | grep -qxF 20808/udp; then
-                echo '  keep pre-existing firewalld UDP 20808 rule; record no ownership'
+            if grep -Eq '(^|[[:space:]])20808/udp([[:space:]]|$)' \
+                <<< "$output"; then
+                echo '  Keep the existing firewalld rule for UDP 20808'
             else
-                echo '  add/reload firewalld UDP 20808 rule; record project ownership'
+                echo '  Open UDP 20808 with firewalld'
             fi
         else
-            echo '  inspect firewalld UDP 20808 with sudo; add it only when absent'
+            echo '  Check firewalld and open UDP 20808 if needed'
         fi
     else
-        echo '  no active UFW/firewalld mutation'
+        echo '  Leave the firewall unchanged'
     fi
-    printf '  write ownership-marked user unit with ExecStart=%s: %s\n' "$ABLETON_LINKD" "$unit_file"
     case "$mode" in
-        session) echo '  disable/stop the owned always-on unit; launchers start session daemon' ;;
-        always) echo '  enable/start the owned user unit' ;;
+        session) echo '  Start Link only while Ableton Live is running' ;;
+        always) echo '  Start Link in the background with your user session' ;;
     esac
+    echo '  Save the Link setting'
 }
 
 ABLETON_LINK_ENABLE_RECOVERY_ERROR=""
@@ -1290,47 +1819,20 @@ link_enable_recovery_error()
     ABLETON_LINK_ENABLE_RECOVERY_ERROR="${ABLETON_LINK_ENABLE_RECOVERY_ERROR}${ABLETON_LINK_ENABLE_RECOVERY_ERROR:+; }$1"
 }
 
-link_enable_record_post()
-{
-    local snapshot="$1" label="$2" target="$3" token
-    token="$(ableton_object_token "$target" 2>/dev/null || true)"
-    [ -n "$token" ] || return 1
-    printf '%s\n' "$token" > "$snapshot/$label.post"
-    chmod 600 "$snapshot/$label.post"
-}
-
-link_enable_target_safe_for_restore()
-{
-    local snapshot="$1" label="$2" target="$3" existed="$4"
-    local current prior=absent post=""
-    current="$(ableton_object_token "$target" 2>/dev/null || true)"
-    [ -n "$current" ] || return 1
-    if [ "$existed" -eq 1 ]; then
-        prior="$(ableton_object_token "$snapshot/$label" 2>/dev/null || true)"
-        [ -n "$prior" ] || return 1
-    fi
-    [ ! -e "$snapshot/$label.post" ] \
-        || post="$(sed -n '1p' "$snapshot/$label.post")"
-    [ "$current" = absent ] || [ "$current" = "$prior" ] \
-        || { [ -n "$post" ] && [ "$current" = "$post" ]; }
-}
-
 populate_link_enable_snapshot()
 {
     local snapshot="$1"
-    if [ -e "$state_file" ]; then
-        cp -a -- "$state_file" "$snapshot/firewall" || return 1
-    fi
+    printf '3\n' > "$snapshot/format" || return 1
+    : > "$snapshot/local-recovery" || return 1
+    snapshot_link_firewall_state "$snapshot/firewall" || return 1
     snapshot_legacy_network "$snapshot/legacy" || return 1
-    if [ -e "$unit_file" ] || [ -L "$unit_file" ]; then
-        cp -a -- "$unit_file" "$snapshot/unit" || return 1
-    fi
-    if [ -e "$ABLETON_CONFIG_FILE" ] || [ -L "$ABLETON_CONFIG_FILE" ]; then
-        cp -a -- "$ABLETON_CONFIG_FILE" "$snapshot/config" || return 1
-    fi
+    snapshot_link_service_state "$snapshot" || return 1
+    : > "$snapshot/ready" || return 1
 }
 
 LINK_ENABLE_UNSTARTED_SNAPSHOT=""
+LINK_ENABLE_ACTIVE_SNAPSHOT=""
+LINK_ENABLE_COMMITTED=0
 # ShellCheck does not follow function names stored in traps.
 # shellcheck disable=SC2329
 cleanup_unstarted_link_enable_snapshot()
@@ -1340,228 +1842,303 @@ cleanup_unstarted_link_enable_snapshot()
     case "$LINK_ENABLE_UNSTARTED_SNAPSHOT" in
         "$ABLETON_STATE_HOME"/.link-enable.*)
             if [ -d "$LINK_ENABLE_UNSTARTED_SNAPSHOT" ] \
-               && [ ! -L "$LINK_ENABLE_UNSTARTED_SNAPSHOT" ] \
-               && ! rm -rf -- "$LINK_ENABLE_UNSTARTED_SNAPSHOT"; then
-                echo "!! failed to remove unstarted Link recovery snapshot: $LINK_ENABLE_UNSTARTED_SNAPSHOT" >&2
+               && [ ! -L "$LINK_ENABLE_UNSTARTED_SNAPSHOT" ]; then
+                rm -rf -- "$LINK_ENABLE_UNSTARTED_SNAPSHOT" 2>/dev/null || true
+                [ ! -e "$LINK_ENABLE_UNSTARTED_SNAPSHOT" ] \
+                    && [ ! -L "$LINK_ENABLE_UNSTARTED_SNAPSHOT" ] || \
+                    echo "!! Temporary Link recovery files could not be removed: $LINK_ENABLE_UNSTARTED_SNAPSHOT" >&2
             fi ;;
     esac
     exit "$rc"
 }
 
+validate_link_enable_snapshot()
+{
+    local snapshot="$1" name members
+    [ -d "$snapshot" ] && [ ! -L "$snapshot" ] || return 1
+    [ -f "$snapshot/format" ] && [ "$(sed -n '1p' "$snapshot/format")" = 3 ] \
+        && [ -f "$snapshot/ready" ] && [ ! -s "$snapshot/ready" ] \
+        && [ -f "$snapshot/local-recovery" ] && [ ! -s "$snapshot/local-recovery" ] \
+        || return 1
+    members="$(find "$snapshot" -mindepth 1 -maxdepth 1 -printf '%f\n')" || return 1
+    while IFS= read -r name; do
+        [ -n "$name" ] || continue
+        case "$name" in
+            format|ready|local-recovery|firewall|firewall.absent|\
+            manager|manager.absent|enabled|enabled.absent|active|active.absent|\
+            detached-active|detached-active.absent|legacy.hook|legacy.hook.absent|\
+            legacy.route|legacy.route.absent|\
+            service-mutating|detached-mutating|FAILURE) ;;
+            *) return 1 ;;
+        esac
+    done <<< "$members"
+    link_snapshot_pair_valid "$snapshot/firewall" regular \
+        && link_snapshot_pair_valid "$snapshot/manager" marker \
+        && link_snapshot_pair_valid "$snapshot/enabled" marker \
+        && link_snapshot_pair_valid "$snapshot/active" marker \
+        && link_snapshot_pair_valid "$snapshot/detached-active" marker \
+        && link_snapshot_pair_valid "$snapshot/legacy.hook" regular \
+        && link_snapshot_pair_valid "$snapshot/legacy.route" regular || return 1
+    [ ! -e "$snapshot/firewall" ] || link_firewall_record_valid "$snapshot/firewall" || return 1
+    for name in service-mutating detached-mutating; do
+        [ ! -e "$snapshot/$name" ] \
+            || { [ -f "$snapshot/$name" ] && [ ! -L "$snapshot/$name" ] \
+                 && [ ! -s "$snapshot/$name" ]; } || return 1
+    done
+}
+
+write_link_enable_failure()
+{
+    local snapshot="$1" operation_rc="$2"
+    printf 'operation=enable\noperation_exit=%s\nrestoration_complete=no\nrestoration_error=%s\n' \
+        "$operation_rc" "$ABLETON_LINK_ENABLE_RECOVERY_ERROR" \
+        > "$snapshot/FAILURE" 2>/dev/null || true
+}
+
 restore_link_enable_snapshot()
 {
-    local snapshot="$1" unit_existed="$2" config_existed="$3"
-    local restore_config="$4" operation_rc="$5" recovery_rc=0
+    local snapshot="$1" operation_rc="$2" recovery_rc=0
     ABLETON_LINK_ENABLE_RECOVERY_ERROR=""
-    if ! link_enable_target_safe_for_restore "$snapshot" unit "$unit_file" "$unit_existed"; then
-        link_enable_recovery_error "Link unit changed during recovery"
-        recovery_rc=1
-    fi
-    if [ "$restore_config" -eq 1 ] \
-       && ! link_enable_target_safe_for_restore \
-            "$snapshot" config "$ABLETON_CONFIG_FILE" "$config_existed"; then
-        link_enable_recovery_error "Link configuration changed during recovery"
-        recovery_rc=1
-    fi
-    [ "$recovery_rc" -eq 0 ] || {
-        printf 'operation=enable\noperation_exit=%s\nrestoration_complete=no\nrestoration_error=%s\n' \
-            "$operation_rc" "$ABLETON_LINK_ENABLE_RECOVERY_ERROR" > "$snapshot/FAILURE" 2>/dev/null || true
+    validate_link_enable_snapshot "$snapshot" || {
+        ABLETON_LINK_ENABLE_RECOVERY_ERROR="the saved firewall or service state is incomplete"
+        write_link_enable_failure "$snapshot" "$operation_rc"
         return 1
     }
-    # Recheck all local destinations immediately before any restoration.  A
-    # user edit made during a sudo/systemctl window must not be overwritten.
-    if ! link_enable_target_safe_for_restore "$snapshot" unit "$unit_file" "$unit_existed"; then
-        link_enable_recovery_error "Link unit changed during recovery"; recovery_rc=1
-    fi
-    if [ "$restore_config" -eq 1 ] \
-       && ! link_enable_target_safe_for_restore \
-            "$snapshot" config "$ABLETON_CONFIG_FILE" "$config_existed"; then
-        link_enable_recovery_error "Link configuration changed during recovery"; recovery_rc=1
+    legacy_network_safe_for_restore "$snapshot/legacy" || {
+        link_enable_recovery_error "the old multicast route changed"
+        recovery_rc=1
+    }
+    [ "$recovery_rc" -eq 0 ] || {
+        write_link_enable_failure "$snapshot" "$operation_rc"
+        return 1
+    }
+    if [ "$recovery_rc" -eq 0 ] \
+       && ! quiesce_link_process_state_for_restore "$snapshot"; then
+        link_enable_recovery_error "the Link service could not be stopped"
+        recovery_rc=1
     fi
     if [ "$recovery_rc" -eq 0 ] && ! restore_firewall_snapshot "$snapshot/firewall"; then
-        link_enable_recovery_error "firewall restoration failed"; recovery_rc=1
+        link_enable_recovery_error "the previous firewall setting could not be restored"; recovery_rc=1
     fi
     if [ "$recovery_rc" -eq 0 ] && ! restore_legacy_network "$snapshot/legacy"; then
-        link_enable_recovery_error "legacy network restoration failed"; recovery_rc=1
+        link_enable_recovery_error "the previous multicast route could not be restored"; recovery_rc=1
     fi
-    if [ "$recovery_rc" -eq 0 ] && [ "$unit_existed" -eq 1 ]; then
-        if ! ableton_atomic_restore_object "$snapshot/unit" "$unit_file"; then
-            link_enable_recovery_error "Link unit restoration failed"; recovery_rc=1
-        fi
-    elif [ "$recovery_rc" -eq 0 ] \
-         && { [ -e "$unit_file" ] || [ -L "$unit_file" ]; }; then
-        if unit_is_owned; then
-            if ! rm -f -- "$unit_file"; then
-                link_enable_recovery_error "Link unit cleanup failed"; recovery_rc=1
-            fi
-        else
-            link_enable_recovery_error "Link unit changed during recovery"; recovery_rc=1
-        fi
-    fi
-    if [ "$recovery_rc" -eq 0 ] && [ "$restore_config" -eq 1 ]; then
-        if [ "$config_existed" -eq 1 ]; then
-            if ! ableton_atomic_restore_object "$snapshot/config" "$ABLETON_CONFIG_FILE"; then
-                link_enable_recovery_error "Link configuration restoration failed"; recovery_rc=1
-            fi
-        elif ! rm -f -- "$ABLETON_CONFIG_FILE"; then
-            link_enable_recovery_error "Link configuration cleanup failed"; recovery_rc=1
-        fi
+    if [ "$recovery_rc" -eq 0 ] && ! restore_link_process_state "$snapshot"; then
+        link_enable_recovery_error "the previous Link service state could not be restored"
+        recovery_rc=1
     fi
     if [ "$recovery_rc" -eq 0 ]; then
-        if rm -rf -- "$snapshot"; then
-            return 0
-        fi
-        link_enable_recovery_error "recovery snapshot cleanup failed"; recovery_rc=1
+        firewall_matches_snapshot "$snapshot/firewall" || recovery_rc=1
+        legacy_network_matches_snapshot "$snapshot/legacy" || recovery_rc=1
+        [ "$recovery_rc" -eq 0 ] \
+            || link_enable_recovery_error "the restored firewall or service setting could not be verified"
     fi
-    printf 'operation=enable\noperation_exit=%s\nrestoration_complete=no\nrestoration_error=%s\n' \
-        "$operation_rc" "$ABLETON_LINK_ENABLE_RECOVERY_ERROR" > "$snapshot/FAILURE" 2>/dev/null || true
+    if [ "$recovery_rc" -eq 0 ]; then
+        rm -rf -- "$snapshot" 2>/dev/null || true
+        [ ! -e "$snapshot" ] && [ ! -L "$snapshot" ] || \
+            echo "!! Temporary Link recovery files could not be removed: $snapshot" >&2
+        return 0
+    fi
+    write_link_enable_failure "$snapshot" "$operation_rc"
     return "$recovery_rc"
+}
+
+finish_link_enable_recovery()
+{
+    local snapshot="$1" operation_rc="$2"
+    trap - EXIT
+    # Once restoration starts, a second Ctrl-C/TERM must not interrupt the
+    # recovery that the first signal requested. Every external step remains
+    # bounded, so ignoring those signals here cannot hang indefinitely.
+    trap '' INT TERM
+    LINK_ENABLE_ACTIVE_SNAPSHOT=""
+    if restore_link_enable_snapshot "$snapshot" "$operation_rc"; then
+        echo "!! Ableton Link could not be enabled. The previous firewall and service settings were restored." >&2
+        trap - INT TERM
+        return "$LINK_ENABLE_RECOVERED_STATUS"
+    fi
+    echo "!! Ableton Link could not be enabled, and the previous system settings were not fully restored: $ABLETON_LINK_ENABLE_RECOVERY_ERROR" >&2
+    echo "!! Recovery details were kept at $snapshot" >&2
+    trap - INT TERM
+    return "$LINK_ENABLE_INCOMPLETE_STATUS"
+}
+
+# ShellCheck does not follow function names stored in traps.
+# shellcheck disable=SC2329
+link_enable_recovery_trap()
+{
+    local operation_rc="$1" outcome=0 snapshot="$LINK_ENABLE_ACTIVE_SNAPSHOT"
+    trap - EXIT
+    trap '' INT TERM
+    set +e
+    [ "$LINK_ENABLE_COMMITTED" -ne 1 ] || exit 0
+    if [ -n "$snapshot" ]; then
+        finish_link_enable_recovery "$snapshot" "$operation_rc" || outcome=$?
+    else
+        outcome="$operation_rc"
+    fi
+    exit "$outcome"
 }
 
 enable_link()
 {
     # Availability check only, against a local: a packaged install stages
-    # ableton-linkctl beside this script and populates no $ABLETON_DATA_HOME,
-    # so testing just the latter refuses to run and names assets no packaged
-    # install provides. $linkctl itself must not move - restore_link_snapshot
-    # and the ownership manifest address the $ABLETON_DATA_HOME path by name,
-    # and pointing those at the store would record an asset this project does
-    # not own and cannot restore. Same shape as plan_link and the restore path.
+    # Packaged installs place the controller beside this script; repository
+    # installs also keep a copy in the generated data directory.
     local ctl="$here/ableton-linkctl"
     [ -x "$ctl" ] || ctl="$linkctl"
-    [ -x "$ctl" ] || { echo "!! ableton-linkctl is missing at $ctl; install Link assets first" >&2; return 1; }
-    echo "== enable Ableton Link ($mode) =="
-    local snapshot unit_existed=0 config_existed=0 rc=0 stop_rc=0
-    validate_link_firewall_state || {
-        echo "!! unsafe Link firewall ownership record: $state_file" >&2
+    [ -x "$ctl" ] || {
+        echo "!! The Ableton Link controller is missing. Re-run the installer to restore it." >&2
         return 1
     }
-    # Refuse unsafe live objects before claiming state or creating a recovery
-    # directory.  A dangling/foreign unit or unsafe config is not pre-state we
-    # can later restore safely.
-    if [ -e "$unit_file" ] || [ -L "$unit_file" ]; then
-        [ -f "$unit_file" ] && [ ! -L "$unit_file" ] || {
-            echo "!! unsafe or foreign Link unit cannot be snapshotted: $unit_file" >&2
-            return 1
-        }
-    fi
-    if [ -e "$ABLETON_CONFIG_FILE" ] || [ -L "$ABLETON_CONFIG_FILE" ]; then
-        if ! { [ -f "$ABLETON_CONFIG_FILE" ] && [ ! -L "$ABLETON_CONFIG_FILE" ] \
-               && ableton_managed_config_valid "$ABLETON_CONFIG_FILE"; }; then
-            echo "!! unsafe installer configuration cannot be snapshotted" >&2
-            return 1
-        fi
-    fi
-    ableton_mark_state_home
-    snapshot="$(mktemp -d "$ABLETON_STATE_HOME/.link-enable.XXXXXX")"
-    LINK_ENABLE_UNSTARTED_SNAPSHOT="$snapshot"
-    trap cleanup_unstarted_link_enable_snapshot EXIT
-    if ! populate_link_enable_snapshot "$snapshot"; then
-        if ! rm -rf -- "$snapshot"; then
-            echo "!! failed to remove unstarted Link recovery snapshot: $snapshot" >&2
-        fi
-        LINK_ENABLE_UNSTARTED_SNAPSHOT=""
-        trap - EXIT
+    [ -x "$ABLETON_LINKD" ] || {
+        echo "!! The Ableton Link helper is missing. Re-run the installer to restore it." >&2
         return 1
+    }
+    echo "== enable Ableton Link =="
+    local snapshot rc=0 outcome=0 enabled_status=0 active_status=0
+    if [ "$mode" = always ] && ! systemd_user_available; then
+        echo "!! Background Link mode needs a running systemd user session" >&2
+        return 127
     fi
-    if [ -e "$unit_file" ] || [ -L "$unit_file" ]; then
-        unit_existed=1
-    fi
-    if [ -e "$ABLETON_CONFIG_FILE" ] || [ -L "$ABLETON_CONFIG_FILE" ]; then
-        config_existed=1
-    fi
-    LINK_ENABLE_UNSTARTED_SNAPSHOT=""
-    trap - EXIT
-    remove_owned_legacy_hook || rc=$?
-    if [ "$rc" -eq 0 ]; then configure_firewall || rc=$?; fi
-    if [ "$rc" -eq 0 ]; then
-        install_unit || rc=$?
-        [ ! -e "$unit_file" ] || link_enable_record_post "$snapshot" unit "$unit_file" || rc=1
-    fi
-    if [ "$rc" -ne 0 ]; then
-        if restore_link_enable_snapshot "$snapshot" "$unit_existed" "$config_existed" 0 "$rc"; then
-            echo "!! Link enable failed; the previous Link state was restored" >&2
-        else
-            echo "!! Link enable failed and automatic restoration is incomplete: $ABLETON_LINK_ENABLE_RECOVERY_ERROR" >&2
-            echo "!! recovery snapshot kept at $snapshot" >&2
+    # Publish a complete salvaged project configuration before the first host
+    # mutation. The requested mode is saved separately after it is achieved.
+    if [ "${ABLETON_CONFIG_REPAIR_NEEDED:-0}" = 1 ]; then
+        if ! save_link_mode; then
+            echo "!! Installer settings could not be repaired yet; continuing with the Link change" >&2
         fi
-        return "$rc"
     fi
     ABLETON_LINK_MODE="$mode"
     export ABLETON_LINK_MODE
-    ableton_write_config || rc=$?
-    if [ -e "$ABLETON_CONFIG_FILE" ] && ableton_managed_config_valid "$ABLETON_CONFIG_FILE"; then
-        link_enable_record_post "$snapshot" config "$ABLETON_CONFIG_FILE" || rc=1
-    fi
-    if [ "$rc" -eq 0 ]; then
-        case "$mode" in
-            session)
-                # Registration is harmless, but session policy must never leave the
-                # always-on unit enabled or running where it could actually run.
-                # A manager that answers and then fails is still an error.
-                if systemd_user_available; then
-                    ableton_run_bounded 20 systemctl --user disable --now \
-                        ableton-linkd.service >/dev/null 2>&1 || rc=$?
-                elif [ -L "$unit_dir/default.target.wants/ableton-linkd.service" ]; then
-                    # systemd keeps the enablement on disk, so it outlives the
-                    # current bus. This link survives to the next login, and the
-                    # daemon would start there.
-                    echo "!! the always-on Link unit is still enabled, and no systemd user manager is reachable to turn it off" >&2
-                    echo "   Run 'systemctl --user disable --now ableton-linkd.service' in a desktop session, then enable Link again." >&2
-                    rc=1
-                fi ;;
-            always)
-                if ! systemd_user_available; then
-                    echo "!! always-on Link policy needs a running systemd user manager" >&2
-                    rc=127
-                else
-                    ableton_run_bounded 20 systemctl --user enable --now \
-                        ableton-linkd.service || rc=$?
-                fi ;;
-        esac
-    fi
-    if [ "$rc" -ne 0 ]; then
-        stop_owned_service || stop_rc=$?
-        if [ "$stop_rc" -ne 0 ]; then
-            ABLETON_LINK_ENABLE_RECOVERY_ERROR="Link service could not be stopped"
-            printf 'operation=enable\noperation_exit=%s\nrestoration_complete=no\nrestoration_error=%s\n' \
-                "$rc" "$ABLETON_LINK_ENABLE_RECOVERY_ERROR" \
-                > "$snapshot/FAILURE" 2>/dev/null || true
-            echo "!! Link enable failed and automatic restoration is incomplete: $ABLETON_LINK_ENABLE_RECOVERY_ERROR" >&2
-            echo "!! recovery snapshot kept at $snapshot" >&2
-            return "$rc"
-        fi
-        if restore_link_enable_snapshot "$snapshot" "$unit_existed" "$config_existed" 1 "$rc"; then
-            echo "!! Link enable failed; the previous Link state was restored" >&2
-        else
-            echo "!! Link enable failed and automatic restoration is incomplete: $ABLETON_LINK_ENABLE_RECOVERY_ERROR" >&2
-            echo "!! recovery snapshot kept at $snapshot" >&2
-        fi
-        return "$rc"
-    fi
-    if ! rm -f -- "$ABLETON_DATA_HOME/link-configured" \
-       || ! rm -rf -- "$snapshot"; then
-        echo "!! Link is enabled, but its recovery snapshot could not be retired: $snapshot" >&2
+    ableton_mark_state_home || {
+        echo "!! Ableton Link cannot safely save the firewall changes it may need to undo" >&2
+        return 1
+    }
+    prepare_link_firewall_state_for_enable || return 1
+    snapshot="$(mktemp -d "$ABLETON_STATE_HOME/.link-enable.XXXXXX")" || {
+        echo "!! Ableton Link cannot save the current firewall and service settings, so nothing was changed" >&2
+        return 1
+    }
+    LINK_ENABLE_UNSTARTED_SNAPSHOT="$snapshot"
+    trap cleanup_unstarted_link_enable_snapshot EXIT
+    if ! populate_link_enable_snapshot "$snapshot"; then
+        rm -rf -- "$snapshot" 2>/dev/null || true
+        [ ! -e "$snapshot" ] && [ ! -L "$snapshot" ] || \
+            echo "!! Temporary Link recovery files could not be removed: $snapshot" >&2
+        LINK_ENABLE_UNSTARTED_SNAPSHOT=""
+        trap - EXIT
+        echo "!! Ableton Link cannot save the current firewall and service settings, so nothing was changed" >&2
         return 1
     fi
-    echo "OK: Link policy is $mode"
+    if [ "$mode" = always ] && [ ! -e "$snapshot/manager" ]; then
+        rm -rf -- "$snapshot" 2>/dev/null || true
+        [ ! -e "$snapshot" ] && [ ! -L "$snapshot" ] || \
+            echo "!! Temporary Link recovery files could not be removed: $snapshot" >&2
+        LINK_ENABLE_UNSTARTED_SNAPSHOT=""
+        trap - EXIT
+        echo "!! Background Link mode needs a running systemd user session" >&2
+        return 127
+    fi
+    LINK_ENABLE_UNSTARTED_SNAPSHOT=""
+    trap - EXIT
+    LINK_ENABLE_ACTIVE_SNAPSHOT="$snapshot"
+    trap 'link_enable_recovery_trap $?' EXIT
+    trap 'link_enable_recovery_trap 130' INT
+    trap 'link_enable_recovery_trap 143' TERM
+    remove_owned_legacy_hook || rc=$?
+    if [ "$rc" -eq 0 ]; then configure_firewall || rc=$?; fi
+    if [ "$rc" -eq 0 ] && [ "$mode" = always ]; then
+        if ! systemd_user_available; then
+            echo "!! Background Link mode needs a running systemd user session" >&2
+            rc=127
+        else
+            : > "$snapshot/service-mutating"
+            stop_canonical_link_service || rc=$?
+        fi
+    fi
+    if [ "$rc" -eq 0 ] && ! install_unit; then
+        if [ "$mode" = always ]; then
+            rc=1
+        else
+            link_cleanup_warning "The optional background Link service could not be prepared; Link will still run with Ableton Live"
+        fi
+    fi
+    if [ "$rc" -ne 0 ]; then
+        finish_link_enable_recovery "$snapshot" "$rc" || outcome=$?
+        return "$outcome"
+    fi
+    case "$mode" in
+        session)
+            if systemd_user_available; then
+                : > "$snapshot/service-mutating"
+            fi
+            stop_canonical_link_service || rc=$? ;;
+        always)
+            : > "$snapshot/detached-mutating"
+            stop_owned_detached_link_daemons || rc=$?
+            [ "$rc" -ne 0 ] || \
+                ableton_run_bounded 20 systemctl --user enable --now \
+                    ableton-linkd.service || true ;;
+    esac
+    if [ "$rc" -ne 0 ]; then
+        finish_link_enable_recovery "$snapshot" "$rc" || outcome=$?
+        return "$outcome"
+    fi
+    if [ "$mode" = always ]; then
+        ableton_run_bounded 20 systemctl --user is-enabled --quiet \
+            ableton-linkd.service 2>/dev/null || enabled_status=$?
+        ableton_run_bounded 20 systemctl --user is-active --quiet \
+            ableton-linkd.service 2>/dev/null || active_status=$?
+        [ "$enabled_status" -eq 0 ] && [ "$active_status" -eq 0 ] || rc=1
+        [ -z "$(first_owned_link_pid)" ] || rc=1
+    fi
+    if [ "$rc" -ne 0 ]; then
+        finish_link_enable_recovery "$snapshot" "$rc" || outcome=$?
+        return "$outcome"
+    fi
+    if ! save_link_mode; then
+        LINK_SETTING_SAVED=0
+        echo "!! Ableton Link system changes completed, but its saved preference could not be updated" >&2
+    fi
+    LINK_ENABLE_COMMITTED=1
+    LINK_ENABLE_ACTIVE_SNAPSHOT=""
+    trap - EXIT
+    trap '' INT TERM PIPE
+    # The requested firewall/service state is now complete. Preference failure
+    # was already reported and everything below is disposable cleanup/reporting.
+    set +e
+    remove_legacy_policy_file
+    rm -rf -- "$snapshot" 2>/dev/null || true
+    [ ! -e "$snapshot" ] && [ ! -L "$snapshot" ] || \
+        echo "!! Ableton Link is enabled, but temporary recovery files could not be removed: $snapshot" >&2
+    if [ "$LINK_COORDINATED_ACTION" -ne 1 ]; then
+        if [ "$LINK_SETTING_SAVED" -ne 1 ]; then
+            echo "OK: Ableton Link system changes finished; run the installer again to save the preference"
+        else
+            case "$mode" in
+                session) echo "OK: Ableton Link is enabled when Ableton Live is running" ;;
+                always) echo "OK: Ableton Link is enabled in the background" ;;
+            esac
+        fi
+    fi
+    return 0
 }
 
 case "$action" in
     enable) enable_link ;;
     disable) disable_link ;;
     status)
-        validate_link_firewall_state || {
-            echo "!! unsafe Link firewall ownership record: $state_file" >&2
-            exit 1
-        }
-        printf 'policy: %s\n' "$ABLETON_LINK_MODE"
+        case "$ABLETON_LINK_MODE" in
+            off) echo 'mode: off' ;;
+            session) echo 'mode: session (while Ableton Live is running)' ;;
+            always) echo 'mode: always (background)' ;;
+        esac
         status_pid=""
         if [ "$ABLETON_LINK_MODE" = always ] && loaded_unit_is_owned \
            && ableton_run_bounded 20 systemctl --user is-active --quiet \
                 ableton-linkd.service 2>/dev/null; then
             echo 'state: running (systemd)'
-        elif status_pid="$(owned_link_pids | head -n 1)" \
+        elif status_pid="$(first_owned_link_pid)" \
              && [ -n "$status_pid" ]; then
             printf 'state: running (pid %s)\n' "$status_pid"
         elif [ -x "$ABLETON_LINKD" ]; then
@@ -1569,7 +2146,17 @@ case "$action" in
         else
             echo 'state: not installed'
         fi
-        [ -r "$state_file" ] && printf 'firewall: %s\n' "$(sed -n '1p' "$state_file")" || echo 'firewall: unrecorded'
+        if ! validate_link_firewall_state; then
+            echo 'firewall: unknown (the saved Link firewall information is unreadable)'
+        elif [ ! -r "$state_file" ]; then
+            echo 'firewall: unchanged'
+        else
+            case "$(sed -n '1p' "$state_file")" in
+                ufw-added) echo 'firewall: UDP 20808 opened with ufw' ;;
+                firewalld-added) echo 'firewall: UDP 20808 opened with firewalld' ;;
+                none) echo 'firewall: unchanged' ;;
+            esac
+        fi
         ;;
     snapshot) snapshot_link_transaction ;;
     preflight-rollback) preflight_link_transaction ;;

--- a/scripts/setup-prefix.sh
+++ b/scripts/setup-prefix.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # End-user step 2: create or refresh the Ableton Wine prefix. Idempotent.
-# Ships no Ableton Live payload and no license; step [6/6] can run the user's
-# own ableton_live*.zip download (~/Proprietary by default) - strictly opt-in
+# Ships no Ableton Live payload and no license; standalone setup can run the
+# user's own ableton_live*.zip download (~/Proprietary by default) - strictly opt-in
 # via ABLETON_LIVE_AUTOINSTALL=1, otherwise the manual steps are printed.
 # --refresh: maintenance pass on an EXISTING prefix (used by the .run's update
 # mode): re-applies registry policy and heals runtime DLLs, but skips the slow
@@ -12,13 +12,28 @@
 # ABLETON_LIVE_VERSION=11|12 pins the winetricks recipe; unpinned, an opted-in
 # auto-install derives it from the chosen zip's filename (default 12).
 set -euo pipefail
+
+# Terminal output is informational. A closed terminal, full log, or broken
+# pipe must never change the result of prefix setup or recovery.
+prefix_note()
+{
+    printf '%s\n' "$*" 2>/dev/null || true
+    return 0
+}
+
+prefix_warn()
+{
+    printf '%s\n' "$*" >&2 2>/dev/null || true
+    return 0
+}
+
 here="$(cd "$(dirname "$0")" && pwd)"
 for config_lib in "$here/lib/config.sh" "$here/config.sh" \
                   "${XDG_DATA_HOME:-$HOME/.local/share}/ableton-wine/lib/config.sh"; do
     if [ -r "$config_lib" ]; then . "$config_lib"; break; fi
 done
-declare -F ableton_config_init >/dev/null 2>&1 || { echo "!! setup-prefix: config helper is missing" >&2; exit 1; }
-ableton_config_init
+declare -F ableton_config_init >/dev/null 2>&1 \
+    || { prefix_warn "!! Setup support files are incomplete. Run the latest installer again."; exit 1; }
 . "$here/lib/manifest.sh"
 . "$here/lib/pipeasio.sh"
 
@@ -41,13 +56,16 @@ kit_root() {
 }
 kit_root_or_die() {
     kit_root && return 0
-    echo "!! cannot locate vendor/winetricks (looked in $here/.. and $here)" >&2
-    echo "!! prefix maintenance must run from the installer kit: either:" >&2
-    echo "!!     sh install-ableton-latest.run update" >&2
-    echo "!!   or extract the kit and run it from there:" >&2
-    echo "!!     sh install-ableton-latest.run extract /tmp/ableton-kit" >&2
-    echo "!!     bash /tmp/ableton-kit/scripts/installer.sh prefix update" >&2
+    prefix_warn "!! The Windows support files for Live are missing."
+    prefix_warn "!! Run: sh install-ableton-latest.run update"
+    prefix_warn "!! Or extract the kit and run prefix setup from there."
     exit 1
+}
+
+report_existing_prefix()
+{
+    printf ':: Using the existing Wine prefix: %s\n' "$1" 2>/dev/null || true
+    return 0
 }
 
 refresh=0
@@ -61,28 +79,41 @@ while [ $# -gt 0 ]; do
         --post-first-run) post_first_run=1 ;;
         --validate) validate_only=1 ;;
         --transaction-dir)
-            [ $# -ge 2 ] || { echo "!! --transaction-dir needs a directory" >&2; exit 2; }
+            [ $# -ge 2 ] || { prefix_warn "!! --transaction-dir needs a directory"; exit 2; }
             transaction_dir="$2"; shift ;;
         --rollback)
-            [ $# -ge 2 ] || { echo "!! --rollback needs a transaction directory" >&2; exit 2; }
+            [ $# -ge 2 ] || { prefix_warn "!! --rollback needs a directory"; exit 2; }
             operation=rollback; transaction_dir="$2"; shift ;;
         --preflight-rollback)
-            [ $# -ge 2 ] || { echo "!! --preflight-rollback needs a transaction directory" >&2; exit 2; }
+            [ $# -ge 2 ] || { prefix_warn "!! --preflight-rollback needs a directory"; exit 2; }
             operation=preflight-rollback; transaction_dir="$2"; shift ;;
         --preflight-commit)
-            [ $# -ge 2 ] || { echo "!! --preflight-commit needs a transaction directory" >&2; exit 2; }
+            [ $# -ge 2 ] || { prefix_warn "!! --preflight-commit needs a directory"; exit 2; }
             operation=preflight-commit; transaction_dir="$2"; shift ;;
         --commit)
-            [ $# -ge 2 ] || { echo "!! --commit needs a transaction directory" >&2; exit 2; }
+            [ $# -ge 2 ] || { prefix_warn "!! --commit needs a directory"; exit 2; }
             operation=commit; transaction_dir="$2"; shift ;;
-        *) echo "!! unknown option: $1" >&2; exit 2 ;;
+        *) prefix_warn "!! Unknown option: $1"; exit 2 ;;
     esac
     shift
 done
 
+if [ "$operation" != setup ] || [ "$validate_only" -eq 1 ]; then
+    # Recovery/preflight validates any recorded prefix target itself; a domain
+    # with no prefix record is a successful no-op even if an unrelated prefix
+    # path currently has a foreign shape.
+    ABLETON_CONFIG_LAYOUT_ROOTS=none
+elif [ "$post_first_run" -eq 1 ]; then
+    ABLETON_CONFIG_LAYOUT_ROOTS=prefix
+else
+    ABLETON_CONFIG_LAYOUT_ROOTS='runtime prefix state'
+fi
+export ABLETON_CONFIG_LAYOUT_ROOTS
+ableton_config_init repair
+
 case "${ABLETON_LIVE_VERSION:-12}" in
     11|12) ;;
-    *) echo "!! ABLETON_LIVE_VERSION must be 11 or 12 (got '$ABLETON_LIVE_VERSION')" >&2; exit 2 ;;
+    *) prefix_warn "!! ABLETON_LIVE_VERSION must be 11 or 12 (got '$ABLETON_LIVE_VERSION')"; exit 2 ;;
 esac
 
 caller_winedlloverrides="${WINEDLLOVERRIDES:-}"
@@ -109,49 +140,50 @@ prefix_transaction_preflight()
         [ -f "$record" ] && [ ! -L "$record" ] && [ -r "$record" ] \
             && ableton_file_has_no_nul "$record" \
             && [ "$(wc -l < "$record")" -eq 1 ] || {
-            echo "!! prefix rollback record is unsafe or invalid" >&2; return 1; }
-        IFS=$'\t' read -r target backup extra < "$record"
+            prefix_warn "!! The saved Wine prefix recovery data is unsafe or invalid."; return 1; }
+        IFS=$'\t' read -r target backup extra < "$record" || {
+            prefix_warn "!! The saved Wine prefix recovery data could not be read."; return 1; }
         [ -z "$extra" ] && [ -n "$target" ] && [ -n "$backup" ] || {
-            echo "!! prefix rollback record is malformed" >&2; return 1; }
+            prefix_warn "!! The saved Wine prefix recovery data is malformed."; return 1; }
         safe="$(ableton_path_is_safe_delete_target "$target")" || {
-            echo "!! unsafe prefix rollback target: $target" >&2; return 1; }
+            prefix_warn "!! The saved Wine prefix path is unsafe: $target"; return 1; }
         [ "$target" = "$safe" ] \
             && [ "$safe" = "$(ableton_realpath_m "$ABLETON_WINEPREFIX")" ] || {
-            echo "!! prefix rollback target does not match this installation: $target" >&2
+            prefix_warn "!! The saved Wine prefix does not match this installation: $target"
             return 1
         }
         if [ -e "$safe" ] || [ -L "$safe" ]; then
             if ! { [ -d "$safe" ] && [ ! -L "$safe" ] \
                    && ableton_prefix_marker_valid "$safe" "$safe"; }; then
-                echo "!! prefix rollback target is unrecognised: $safe" >&2
+                prefix_warn "!! The Wine prefix selected for recovery is not recognized: $safe"
                 return 1
             fi
         fi
         if [ "$backup" != absent ]; then
             expected_backup="$safe.transaction-${txn##*/}"
             backup_safe="$(ableton_path_is_safe_delete_target "$backup")" || {
-                echo "!! unsafe prefix rollback backup: $backup" >&2; return 1; }
+                prefix_warn "!! The saved previous Wine prefix path is unsafe: $backup"; return 1; }
             [ "$backup" = "$expected_backup" ] && [ "$backup" = "$backup_safe" ] || {
-                echo "!! prefix rollback backup is misplaced: $backup" >&2; return 1; }
+                prefix_warn "!! The saved previous Wine prefix is in the wrong place: $backup"; return 1; }
             if [ -e "$backup" ] || [ -L "$backup" ]; then
                 if ! { [ -d "$backup" ] && [ ! -L "$backup" ] \
                        && ableton_prefix_marker_valid "$backup" "$safe"; }; then
-                    echo "!! prefix rollback backup is unrecognised: $backup" >&2
+                    prefix_warn "!! The saved previous Wine prefix is not recognized: $backup"
                     return 1
                 fi
             elif [ "$mode" != commit ]; then
-                echo "!! prefix rollback backup is missing: $backup" >&2
+                prefix_warn "!! The saved previous Wine prefix is missing: $backup"
                 return 1
             fi
         fi
     fi
+    # Older releases stored host-file recovery beside the prefix record. New
+    # setup runs do not create that journal, but retained old recovery remains
+    # readable so an interrupted older install can still be restored safely.
     if [ -e "$txn/prefix-host" ] || [ -L "$txn/prefix-host" ]; then
         [ -d "$txn/prefix-host" ] && [ ! -L "$txn/prefix-host" ] || {
-            echo "!! prefix host transaction is unsafe" >&2; return 1; }
+            prefix_warn "!! Saved support-file recovery data is unsafe."; return 1; }
         ableton_txn_preflight_rollback_files "$txn/prefix-host" || return 1
-    elif [ -e "$record" ]; then
-        echo "!! prefix host transaction is missing" >&2
-        return 1
     fi
 }
 
@@ -161,8 +193,6 @@ prefix_transaction_commit_preflight()
     prefix_transaction_preflight "$txn" commit || return 1
     if [ -e "$txn/prefix-host" ]; then
         ableton_txn_preflight_commit_files "$txn/prefix-host" || return 1
-    elif [ -e "$record" ]; then
-        return 1
     fi
 }
 
@@ -172,13 +202,16 @@ prefix_transaction_rollback()
     local rc=0 layout_ok=1
     prefix_transaction_preflight "$txn" || return 1
     if [ -r "$txn/prefix.tsv" ]; then
-        IFS=$'\t' read -r target backup < "$txn/prefix.tsv"
+        IFS=$'\t' read -r target backup < "$txn/prefix.tsv" || {
+            prefix_warn "!! The saved Wine prefix recovery data could not be read."
+            return 1
+        }
         if ! safe="$(ableton_path_is_safe_delete_target "$target")"; then
-            echo "!! unsafe prefix rollback target: $target" >&2
+            prefix_warn "!! The saved Wine prefix path is unsafe: $target"
             rc=1; layout_ok=0
         elif [ "$target" != "$safe" ] \
              || [ "$safe" != "$(ableton_realpath_m "$ABLETON_WINEPREFIX")" ]; then
-            echo "!! prefix rollback target does not match this installation: $target" >&2
+            prefix_warn "!! The saved Wine prefix does not match this installation: $target"
             rc=1; layout_ok=0
         fi
         if [ "$layout_ok" -eq 1 ] && [ "$backup" != absent ]; then
@@ -187,16 +220,16 @@ prefix_transaction_rollback()
                || [ "$backup" != "$expected_backup" ] || [ "$backup" != "$backup_safe" ] \
                || [ ! -d "$backup" ] || [ -L "$backup" ] \
                || ! ableton_prefix_marker_valid "$backup" "$safe"; then
-                echo "!! prefix rollback backup is missing, misplaced, or unrecognised: $backup" >&2
+                prefix_warn "!! The saved previous Wine prefix is missing, misplaced, or not recognized: $backup"
                 rc=1; layout_ok=0
             fi
         fi
         if [ "$layout_ok" -eq 1 ] && [ -e "$safe" ]; then
             if [ -L "$safe" ]; then
-                echo "!! refusing symlink prefix rollback target: $safe" >&2
+                prefix_warn "!! Recovery stopped because the Wine prefix path is a link: $safe"
                 rc=1; layout_ok=0
             elif ! ableton_prefix_marker_valid "$safe" "$safe"; then
-                echo "!! refusing to remove unmarked prefix during rollback: $safe" >&2
+                prefix_warn "!! Recovery stopped because this Wine prefix was not created by Ableton Linux: $safe"
                 rc=1; layout_ok=0
             elif ! rm -rf -- "$safe"; then
                 rc=1; layout_ok=0
@@ -213,9 +246,11 @@ prefix_transaction_rollback()
             rm -f -- "$txn/prefix.tsv" || rc=1
         fi
     fi
-    ableton_txn_rollback_files "$txn/prefix-host" || rc=1
-    if [ "$rc" -eq 0 ]; then
-        rm -f -- "$txn/prefix-host/active" || rc=1
+    if [ -d "$txn/prefix-host" ] && [ ! -L "$txn/prefix-host" ]; then
+        ableton_txn_rollback_files "$txn/prefix-host" || rc=1
+        if [ "$rc" -eq 0 ]; then
+            rm -f -- "$txn/prefix-host/active" || rc=1
+        fi
     fi
     update-desktop-database "${XDG_DATA_HOME:-$HOME/.local/share}/applications" >/dev/null 2>&1 || true
     return "$rc"
@@ -226,12 +261,15 @@ prefix_transaction_commit()
     local txn="$1" target backup safe
     prefix_transaction_commit_preflight "$txn" || return 1
     [ -r "$txn/prefix.tsv" ] || return 0
-    IFS=$'\t' read -r target backup < "$txn/prefix.tsv"
+    IFS=$'\t' read -r target backup < "$txn/prefix.tsv" || {
+        prefix_warn "!! The saved Wine prefix cleanup data could not be read."
+        return 1
+    }
     if [ "$backup" != absent ] && [ -e "$backup" ]; then
-        safe="$(ableton_path_is_safe_delete_target "$backup")" || { echo "!! unsafe prefix backup: $backup" >&2; return 1; }
-        [ ! -L "$safe" ] || { echo "!! refusing symlink prefix backup: $safe" >&2; return 1; }
+        safe="$(ableton_path_is_safe_delete_target "$backup")" || { prefix_warn "!! The saved previous Wine prefix path is unsafe: $backup"; return 1; }
+        [ ! -L "$safe" ] || { prefix_warn "!! Cleanup stopped because the saved previous Wine prefix is a link: $safe"; return 1; }
         ableton_prefix_marker_valid "$safe" "$target" || {
-            echo "!! refusing prefix backup with an invalid ownership marker: $safe" >&2
+            prefix_warn "!! Cleanup stopped because the saved previous Wine prefix is not recognized: $safe"
             return 1
         }
         prefix_commit_started=1
@@ -240,7 +278,9 @@ prefix_transaction_commit()
     fi
     prefix_commit_started=1
     rm -f -- "$txn/prefix.tsv" || return 1
-    rm -f -- "$txn/prefix-host/active" || return 1
+    if [ -d "$txn/prefix-host" ] && [ ! -L "$txn/prefix-host" ]; then
+        rm -f -- "$txn/prefix-host/active" || return 1
+    fi
 }
 
 if [ "$operation" != setup ]; then
@@ -254,7 +294,7 @@ case "$operation" in
 esac
 
 case "${ABLETON_THEME_MODE:-auto}" in auto|dark|light|preserve) ;;
-    *) echo "!! ABLETON_THEME_MODE must be auto, dark, light, or preserve" >&2; exit 2 ;;
+    *) prefix_warn "!! ABLETON_THEME_MODE must be auto, dark, light, or preserve"; exit 2 ;;
 esac
 
 if [ "$validate_only" -eq 1 ]; then
@@ -263,17 +303,16 @@ if [ "$validate_only" -eq 1 ]; then
     case "$validate_dpi" in
         auto|preserve|100|fractional) ;;
         dpi*|fractional*) ableton_dpi_block_values "$validate_dpi" >/dev/null || {
-            echo "!! invalid ABLETON_DPI_MODE '$validate_dpi'" >&2; exit 2; } ;;
-        *) echo "!! ABLETON_DPI_MODE must be auto, preserve, 100, fractional, dpi<N>, or fractional<N>" >&2; exit 2 ;;
+            prefix_warn "!! Invalid ABLETON_DPI_MODE '$validate_dpi'"; exit 2; } ;;
+        *) prefix_warn "!! ABLETON_DPI_MODE must be auto, preserve, 100, fractional, dpi<N>, or fractional<N>"; exit 2 ;;
     esac
     if [ "${ABLETON_RUNTIME_PENDING:-0}" != 1 ]; then
-        [ -x "$WINE_ROOT/bin/wine" ] || { echo "!! patched Wine not found at $WINE_ROOT" >&2; exit 1; }
+        [ -x "$WINE_ROOT/bin/wine" ] || { prefix_warn "!! Patched Wine was not found at $WINE_ROOT"; exit 1; }
     fi
-    command -v cabextract >/dev/null || { echo "!! cabextract is required for prefix setup" >&2; exit 1; }
     if [ "$refresh" -eq 1 ]; then
-        [ -f "$WINEPREFIX/system.reg" ] || { echo "!! --refresh needs an existing prefix at $WINEPREFIX" >&2; exit 2; }
+        [ -f "$WINEPREFIX/system.reg" ] || { prefix_warn "!! --refresh needs an existing Wine prefix at $WINEPREFIX"; exit 2; }
     fi
-    echo "OK: prefix configuration is valid"
+    prefix_note "-- Wine prefix settings are valid"
     exit 0
 fi
 
@@ -286,39 +325,47 @@ ableton_install_lock_acquire
 if [ "$post_first_run" -eq 1 ]; then
     ableton_install_lock_acquire
     safe_repair_prefix="$(ableton_path_is_safe_delete_target "$WINEPREFIX")" || {
-        echo "!! unsafe Wine prefix path: $WINEPREFIX" >&2; exit 2; }
+        prefix_warn "!! The Wine prefix path is unsafe: $WINEPREFIX"; exit 2; }
     if ! { [ "$safe_repair_prefix" = "$WINEPREFIX" ] && [ ! -L "$WINEPREFIX" ] \
            && ableton_prefix_marker_valid "$WINEPREFIX" "$WINEPREFIX"; }; then
-        echo "!! refusing Live 11 repair for an unrecognised prefix" >&2
+        prefix_warn "!! Live 11 repair stopped because this Wine prefix was not created by Ableton Linux."
         exit 2
     fi
     . "$here/lib/lifecycle.sh"
     if ableton_prefix_busy; then
-        echo "!! Wine clients are running in $WINEPREFIX; close them before Live 11 repair" >&2
+        prefix_warn "!! Close Live, Max, and other Wine programs before running the Live 11 repair."
         exit 1
     fi
-    [ -f "$WINEPREFIX/system.reg" ] || { echo "!! no prefix at $WINEPREFIX: nothing to run --post-first-run against" >&2; exit 2; }
+    [ -f "$WINEPREFIX/system.reg" ] || { prefix_warn "!! No Wine prefix was found at $WINEPREFIX for Live 11 repair."; exit 2; }
     moved=0
+    move_failed=0
     for maxpref in "$WINEPREFIX"/drive_c/users/*/"AppData/Roaming/Cycling '74/Max 8/Settings/maxpreferences.maxpref"; do
         [ -f "$maxpref" ] || continue
         bak="$maxpref.bak-$(date -u +%Y%m%dT%H%M%SZ)"
         [ -e "$bak" ] && bak="$bak.$$"      # same-second re-run: keep both backups
-        mv -v "$maxpref" "$bak"
-        moved=1
+        if mv -- "$maxpref" "$bak"; then
+            moved=$((moved + 1))
+        else
+            printf '!! Max preferences could not be moved aside at %s. Check the file permissions and try again.\n' \
+                "$maxpref" >&2 2>/dev/null || true
+            move_failed=1
+        fi
     done
-    if [ "$moved" -eq 1 ]; then
-        echo "OK: Max preferences moved aside; Max regenerates them on next start"
+    if [ "$move_failed" -eq 1 ]; then
+        printf '!! Live 11 repair did not finish for every user. Files already moved aside were kept safely.\n' >&2 2>/dev/null || true
+        exit 1
+    elif [ "$moved" -gt 0 ]; then
+        printf 'OK: Max preferences moved aside; Max regenerates them on next start\n' 2>/dev/null || true
     else
-        echo "OK: no maxpreferences.maxpref under $WINEPREFIX: nothing to do (Max not run yet?)"
+        printf 'OK: No Live 11 Max preferences needed repair.\n' 2>/dev/null || true
     fi
     exit 0
 fi
 
 [ -x "$WINE_ROOT/bin/wine" ] || {
-    echo "!! patched wine not at $WINE_ROOT: run ./scripts/installer.sh runtime install first"
+    prefix_warn "!! Patched Wine was not found at $WINE_ROOT. Install the Wine runtime first."
     exit 1
 }
-command -v cabextract >/dev/null || { echo "!! cabextract is required for prefix setup" >&2; exit 1; }
 for required in \
     bin/pipewire-version-probe \
     ABLETON-WINE-BUILD-INFO.txt \
@@ -329,7 +376,7 @@ for required in \
     lib/wine/x86_64-windows/pipeasio.dll \
     lib/wine/x86_64-unix/pipeasio64.dll.so \
     lib/wine/x86_64-unix/pipeasio.dll.so; do
-    [ -s "$WINE_ROOT/$required" ] || { echo "!! packaged runtime is missing $required"; exit 1; }
+    [ -s "$WINE_ROOT/$required" ] || { prefix_warn "!! The Wine runtime is incomplete: $required is missing."; exit 1; }
 done
 ableton_pipeasio_validate_runtime "$WINE_ROOT"
 ableton_pipewire_preflight "$WINE_ROOT/bin/pipewire-version-probe" "configuring PipeASIO"
@@ -340,15 +387,15 @@ ableton_pipewire_preflight "$WINE_ROOT/bin/pipewire-version-probe" "configuring 
 # through Live installation, so any later failure can restore the old prefix.
 . "$here/lib/lifecycle.sh"
 if ableton_prefix_busy; then
-    echo "!! Wine clients are running in $WINEPREFIX; close Live, Max, and other prefix programs first" >&2
+    prefix_warn "!! Close Live, Max, and other Wine programs before updating the Wine prefix."
     exit 1
 fi
 final_prefix="$WINEPREFIX"
 final_parent="$(dirname "$final_prefix")"
 final_name="$(basename "$final_prefix")"
 safe_final="$(ableton_path_is_safe_delete_target "$final_prefix")" || {
-    echo "!! unsafe Wine prefix path: $final_prefix" >&2; exit 2; }
-[ ! -L "$final_prefix" ] || { echo "!! refusing symlink Wine prefix: $final_prefix" >&2; exit 2; }
+    prefix_warn "!! The Wine prefix path is unsafe: $final_prefix"; exit 2; }
+[ ! -L "$final_prefix" ] || { prefix_warn "!! The Wine prefix path must not be a link: $final_prefix"; exit 2; }
 if [ -e "$final_prefix" ] && ! ableton_prefix_marker_valid "$final_prefix" "$safe_final"; then
     if ableton_legacy_default_prefix_valid "$final_prefix"; then
         # Adopt it here, before any transaction opens. The run below moves this
@@ -358,9 +405,11 @@ if [ -e "$final_prefix" ] && ! ableton_prefix_marker_valid "$final_prefix" "$saf
         # the commit then fails with the backup unrecognised.
         adopt_marker="$final_prefix/.ableton-linux-prefix"
         [ ! -L "$adopt_marker" ] && [ ! -e "$adopt_marker" ] || {
-            echo "!! existing Wine prefix has an unsafe ownership marker: $adopt_marker" >&2; exit 2; }
+            prefix_warn "!! The existing Wine prefix was left unchanged because its Ableton Linux setup record is not a regular file: $adopt_marker"
+            exit 2
+        }
         adopt_tmp="$(mktemp "$final_prefix/.prefix-marker.XXXXXX")" || {
-            echo "!! cannot write into the existing Wine prefix: $final_prefix" >&2; exit 2; }
+            prefix_warn "!! The existing Wine prefix is not writable: $final_prefix"; exit 2; }
         if ! printf 'format=1\nprefix=%s\n' "$safe_final" > "$adopt_tmp" \
            || ! chmod 600 "$adopt_tmp" \
            || ! mv -T -f -- "$adopt_tmp" "$adopt_marker" \
@@ -369,28 +418,26 @@ if [ -e "$final_prefix" ] && ! ableton_prefix_marker_valid "$final_prefix" "$saf
             # ableton_legacy_default_prefix_valid stops recognising the prefix,
             # so a half-written one would refuse every later run as well.
             rm -f -- "$adopt_tmp" "$adopt_marker"
-            echo "!! could not adopt the existing Wine prefix: $final_prefix" >&2
+            prefix_warn "!! The existing Wine prefix could not be prepared safely: $final_prefix"
             exit 2
         fi
-        echo ":: adopted the existing prefix at $final_prefix (it predates the ownership marker)"
+        report_existing_prefix "$final_prefix"
     else
-        echo "!! refusing to transactionally replace unrecognised custom prefix: $final_prefix" >&2
-        echo "!! create it once with this project's setup so it carries .ableton-linux-prefix" >&2
+        prefix_warn "!! This Wine prefix was left unchanged because the installer could not confirm that it created it: $final_prefix"
+        prefix_warn "!! Choose a different prefix, or move this one aside and run setup again."
         exit 2
     fi
 fi
 mkdir -p -- "$final_parent"
 own_prefix_transaction=0
 if [ -z "$transaction_dir" ]; then
-    ableton_mark_state_home
-    mkdir -p -- "$ABLETON_STATE_HOME/transactions"
+    ableton_prepare_transactions_dir
     transaction_dir="$(mktemp -d "$ABLETON_STATE_HOME/transactions/prefix.XXXXXX")"
     own_prefix_transaction=1
 else
     mkdir -p -- "$transaction_dir"
 fi
-ABLETON_TRANSACTION_DIR="$transaction_dir/prefix-host"
-export ABLETON_TRANSACTION_DIR
+unset ABLETON_TRANSACTION_DIR
 stage_prefix=""
 # ShellCheck does not follow function names stored in traps.
 # shellcheck disable=SC2329
@@ -398,7 +445,7 @@ cleanup_unstarted_prefix_transaction()
 {
     local rc=$? restore_ok=1
     trap - EXIT
-    if [ "$rc" -ne 0 ] && [ -e "$ABLETON_TRANSACTION_DIR/active" ]; then
+    if [ "$rc" -ne 0 ]; then
         prefix_transaction_rollback "$transaction_dir" || restore_ok=0
     fi
     if [ "$rc" -ne 0 ] && [ "$own_prefix_transaction" -eq 1 ] \
@@ -406,32 +453,36 @@ cleanup_unstarted_prefix_transaction()
         rm -rf -- "$transaction_dir" || restore_ok=0
     fi
     if [ "$restore_ok" -ne 1 ]; then
-        echo "!! prefix setup failed before staging and its transaction needs recovery: $transaction_dir" >&2
+        prefix_warn "!! Wine prefix setup failed, and recovery did not finish. Keep the files at $transaction_dir and report the problem."
     fi
     exit "$rc"
 }
 trap cleanup_unstarted_prefix_transaction EXIT
-[ -e "$ABLETON_TRANSACTION_DIR" ] || mkdir -- "$ABLETON_TRANSACTION_DIR"
-ableton_txn_init
-ableton_validate_install_state_journals
 if [ -e "$final_prefix" ]; then
     ableton_adopt_prefix_marker "$final_prefix" "$safe_final" || {
-        echo "!! refusing to update an unrecognised Wine prefix: $final_prefix" >&2
+        prefix_warn "!! This Wine prefix was left unchanged because it was not created by Ableton Linux: $final_prefix"
         exit 2
     }
 fi
 stage_prefix="$(mktemp -d "$final_parent/.${final_name}.prefix-stage.XXXXXX")"
 prefix_promoted=0
+prefix_core_ready=0
 prefix_cleanup()
 {
     local rc=$? restore_error="" restoration_complete=yes
     trap - EXIT
+    # This handler decides the result from the prefix/recovery state below.
+    # A closed terminal or log consumer must not interrupt that decision.
+    set +e
     if [ "$rc" -ne 0 ]; then
-        if [ "$prefix_commit_started" -eq 1 ]; then
+        if [ "$prefix_core_ready" -eq 1 ]; then
+            echo "!! The Wine prefix is ready, but old recovery files may remain at $transaction_dir." >&2 || true
+            rc=0
+        elif [ "$prefix_commit_started" -eq 1 ]; then
             printf 'status=committed-cleanup-incomplete\nprefix=%s\nexit=%s\n' \
                 "$final_prefix" "$rc" > "$transaction_dir/COMMITTED_CLEANUP_FAILURE" 2>/dev/null || true
-            echo "!! prefix update is committed, but cleanup is incomplete" >&2
-            echo "!! inspect $transaction_dir/COMMITTED_CLEANUP_FAILURE before retrying" >&2
+            echo "!! The Wine prefix is ready, but old recovery files remain at $transaction_dir." >&2 || true
+            rc=0
         elif [ "$prefix_promoted" -eq 1 ]; then
             if ! prefix_transaction_rollback "$transaction_dir"; then
                 restore_error="prefix rollback failed"
@@ -441,19 +492,19 @@ prefix_cleanup()
                 restore_error="staged prefix cleanup failed"
             fi
             if ! prefix_transaction_rollback "$transaction_dir"; then
-                restore_error="${restore_error}${restore_error:+; }host-file rollback failed"
+                restore_error="${restore_error}${restore_error:+; }Wine prefix recovery failed"
             fi
         fi
-        if [ "$prefix_commit_started" -ne 1 ]; then
+        if [ "$rc" -ne 0 ] && [ "$prefix_commit_started" -ne 1 ]; then
             [ -z "$restore_error" ] || restoration_complete=no
             printf 'status=failed\nprefix=%s\nexit=%s\nrestoration_complete=%s\nrestoration_error=%s\n' \
                 "$final_prefix" "$rc" "$restoration_complete" "$restore_error" \
                 > "$transaction_dir/prefix-failure" || true
             if [ "$restoration_complete" = yes ]; then
-                echo "!! prefix setup failed; the prior prefix was preserved" >&2
+                echo "!! Wine prefix setup failed. The previous prefix is back in place." >&2 || true
             else
-                echo "!! prefix setup failed and automatic restoration is incomplete: $restore_error" >&2
-                echo "!! inspect $transaction_dir/prefix-failure before retrying" >&2
+                echo "!! Wine prefix setup failed, and the previous prefix could not be fully restored: $restore_error" >&2 || true
+                echo "!! Keep the recovery files at $transaction_dir and report the problem." >&2 || true
             fi
         fi
     fi
@@ -464,7 +515,7 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 if [ -f "$final_prefix/system.reg" ]; then
-    echo "== staging a transactional copy of the existing prefix =="
+    prefix_note "== Preparing the existing Wine prefix =="
     cp -a --reflink=auto -- "$final_prefix/." "$stage_prefix/"
 fi
 export WINEPREFIX="$stage_prefix"
@@ -494,7 +545,8 @@ ableton_wineserver_quiesce()
 # detect-scale.sh): GNOME gets the upscaled-framebuffer matched set (LogPixels =
 # 96 x ceil(scale) + IFEO dpiAwareness=2), other compositors get plain
 # LogPixels = round(96 x scale) with no IFEO. auto applies the detected block on a
-# fresh prefix, preserves an existing one, refuses scales outside 100-250%.
+# fresh prefix, falls back to 100% when detection is unusable, and preserves an
+# existing prefix's settings.
 # The dpiAwareness IFEO is keyed on the exe name, so it is applied per installed Live (any edition);
 # on a fresh prefix Live isn't installed yet: the launcher applies it on every start.
 ifeo_root='HKLM\Software\Microsoft\Windows NT\CurrentVersion\Image File Execution Options'
@@ -554,19 +606,25 @@ check_mutter_knob() {  # warn when mutter's xwayland-native-scaling disagrees wi
     feats="$(gsettings get org.gnome.mutter experimental-features 2>/dev/null)" || return 0
     case "$1" in
         fractional*)   # upscaled-framebuffer sets need the knob
-            if ! printf '%s' "$feats" | grep -q xwayland-native-scaling; then
-                echo "!! mutter experimental-features lacks xwayland-native-scaling —"
-                echo "!! the '$1' DPI block expects it present; add it to"
-                echo "!!   org.gnome.mutter experimental-features (gsettings)"
+            if [[ "$feats" != *xwayland-native-scaling* ]]; then
+                prefix_warn "!! GNOME's xwayland-native-scaling setting is off, but the selected display scaling needs it."
+                prefix_warn "!! Add xwayland-native-scaling to org.gnome.mutter experimental-features."
             fi ;;
         *)
-            if printf '%s' "$feats" | grep -q xwayland-native-scaling; then
-                echo "!! mutter experimental-features lists xwayland-native-scaling —"
-                echo "!! the '$1' DPI block expects it absent; remove it from"
-                echo "!!   org.gnome.mutter experimental-features (gsettings)"
+            if [[ "$feats" = *xwayland-native-scaling* ]]; then
+                prefix_warn "!! GNOME's xwayland-native-scaling setting is on, but the selected display scaling does not use it."
+                prefix_warn "!! Remove xwayland-native-scaling from org.gnome.mutter experimental-features."
             fi ;;
     esac
     return 0
+}
+
+gnome_native_scaling_active()
+{
+    local feats
+    command -v gsettings >/dev/null 2>&1 || return 1
+    feats="$(gsettings get org.gnome.mutter experimental-features 2>/dev/null)" || return 1
+    [[ "$feats" = *xwayland-native-scaling* ]]
 }
 
 # 2026.07.18.1 seeded -DontCombineAPCs into Options.txt to cut a 30-40% idle CPU
@@ -580,19 +638,35 @@ strip_options_txt() {
     for prefs in "$WINEPREFIX"/drive_c/users/*/AppData/Roaming/Ableton/Live*/Preferences; do
         f="$prefs/Options.txt"
         [ -f "$f" ] || continue
-        # Match with CR stripped so a CRLF-edited copy is caught too.
-        tr -d '\r' < "$f" | grep -qxF -- "$line" || continue
-        tmp="$(mktemp)"
-        awk -v opt="$line" '{ l = $0; sub(/\r$/, "", l) } l != opt { print }' "$f" > "$tmp"
+        # Match with CR stripped so a CRLF-edited copy is caught too.  This is a
+        # repair, not a prefix-integrity condition: an unreadable preferences
+        # file is left alone and reported without discarding the prepared prefix.
+        awk -v opt="$line" \
+            '{ l = $0; sub(/\r$/, "", l); if (l == opt) found=1 } END { exit !found }' \
+            "$f" 2>/dev/null || continue
+        if ! tmp="$(mktemp)" \
+           || ! awk -v opt="$line" '{ l = $0; sub(/\r$/, "", l) } l != opt { print }' \
+                "$f" > "$tmp"; then
+            [ -z "${tmp:-}" ] || rm -f -- "$tmp" 2>/dev/null || true
+            prefix_warn "!! Could not update $f. Remove $line from that file before using Live."
+            continue
+        fi
         if [ -s "$tmp" ]; then
             # Write through the existing inode: keeps the file's permissions.
-            cat "$tmp" > "$f"
-            rm -f "$tmp"
-            echo "   removed $line from $f"
+            if cat "$tmp" > "$f"; then
+                prefix_note "   Removed $line from $f"
+            else
+                prefix_warn "!! Could not update $f. Remove $line from that file before using Live."
+            fi
+            rm -f -- "$tmp" 2>/dev/null || true
         else
             # The seed's touch created the file; nothing else in it: undo fully.
-            rm -f "$tmp" "$f"
-            echo "   removed $f (held only $line)"
+            rm -f -- "$tmp" 2>/dev/null || true
+            if rm -f -- "$f"; then
+                prefix_note "   Removed $f because it contained only $line"
+            else
+                prefix_warn "!! Could not remove $line from $f. Remove that file before using Live."
+            fi
         fi
     done
     shopt -u nullglob
@@ -601,11 +675,12 @@ strip_options_txt() {
 fresh_prefix=0
 [ -f "$WINEPREFIX/system.reg" ] || fresh_prefix=1
 if [ "$refresh" -eq 1 ] && [ "$fresh_prefix" -eq 1 ]; then
-    echo "!! --refresh needs an existing prefix at $WINEPREFIX: run without it to create one" >&2
+    prefix_warn "!! --refresh needs an existing Wine prefix at $WINEPREFIX. Run without --refresh to create one."
     exit 2
 fi
 
-# Resolve the mode now so a fresh prefix fails fast, before wineboot/winetricks run.
+# Resolve display scaling before Wine setup starts. Automatic detection is only
+# a convenience; a fresh prefix falls back to a safe 100% when it is unavailable.
 dpi_mode="${ABLETON_DPI_MODE:-auto}"
 dpi_block=preserve
 dpi_family=""
@@ -617,7 +692,7 @@ case "$dpi_mode" in
     if ableton_dpi_block_values "$dpi_mode" >/dev/null; then
         dpi_block="$dpi_mode"
     else
-        echo "!! ABLETON_DPI_MODE '$dpi_mode' is not a usable DPI block (want dpi<N> / fractional<N> with LogPixels N in 72..384)" >&2
+        prefix_warn "!! ABLETON_DPI_MODE '$dpi_mode' is invalid. Use dpi<N> or fractional<N>, with N from 72 to 384."
         exit 2
     fi
     ;;
@@ -629,39 +704,44 @@ case "$dpi_mode" in
         dpi_family="${detected#* }"
         if block="$(block_for_scale "$scale" "$dpi_family")"; then
             if [ "$fresh_prefix" -eq 1 ]; then
-                echo "   display scale $scale ($dpi_family) detected -> will apply the '$block' DPI block"
-                dpi_block="$block"
+                if [ "$dpi_family" = gnome ] && [[ "$block" = fractional* ]] \
+                   && ! gnome_native_scaling_active; then
+                    prefix_warn "!! GNOME native Xwayland scaling could not be confirmed; using 100% scaling for this fresh prefix."
+                    prefix_warn "!! Set ABLETON_DPI_MODE=$block explicitly only after enabling xwayland-native-scaling."
+                    dpi_block=100
+                else
+                    prefix_note "   Detected display scale $scale ($dpi_family); applying $block scaling settings."
+                    dpi_block="$block"
+                fi
             else
                 have="$(current_dpi_block)"
                 if [ "$have" = "$block" ]; then
-                    echo "   display scale $scale detected; existing prefix already holds the '$block' block"
+                    prefix_note "   Display scaling is already configured for scale $scale."
                 else
-                    echo "!! display scale $scale wants the '$block' DPI block, but this existing prefix holds '$have'"
-                    echo "!! preserving it: rerun with ABLETON_DPI_MODE=$block to recalibrate deliberately"
+                    prefix_warn "!! Display scale $scale differs from this Wine prefix's current settings ($have)."
+                    prefix_warn "!! Existing settings were kept. To change them, rerun with ABLETON_DPI_MODE=$block."
                 fi
             fi
         elif [ "$fresh_prefix" -eq 1 ]; then
-            echo "!! display scale $scale is outside the calibrated 100-250% range" >&2
-            echo "!! rerun with an explicit ABLETON_DPI_MODE=100 or =dpi<N> (LogPixels N in 72..384)" >&2
-            exit 2
+            dpi_block=100
+            prefix_warn "!! Display scale $scale is outside the supported automatic range. Using 100% scaling."
         else
-            echo "!! display scale $scale is outside the calibrated 100-250% range: preserving existing prefix values"
+            prefix_warn "!! Display scale $scale is outside the supported automatic range. Existing settings were kept."
         fi
     elif [ "$fresh_prefix" -eq 1 ]; then
-        echo "!! cannot detect the display scale (non-GNOME desktop or headless session?)" >&2
-        echo "!! a fresh prefix needs an explicit ABLETON_DPI_MODE=100 or =dpi<N>" >&2
-        exit 2
+        dpi_block=100
+        prefix_warn "!! Display scale could not be detected. Using 100% scaling."
     else
-        echo "   cannot detect display scale; preserving existing prefix values"
+        prefix_note "   Display scale could not be detected; existing settings were kept."
     fi
     ;;
   *)
-    echo "!! ABLETON_DPI_MODE must be auto, preserve, 100, fractional, or dpi<N>" >&2
+    prefix_warn "!! ABLETON_DPI_MODE must be auto, preserve, 100, fractional, or dpi<N>"
     exit 2
     ;;
 esac
 
-# Ableton Live auto-install candidate (run by step [6/6]) and the Live major
+# Ableton Live auto-install candidate and the Live major
 # the winetricks/redist recipes target: resolved together, up front, so an
 # opted-in auto-install can never put a Live 11 zip into a prefix prepared with
 # the Live 12 recipe. Major precedence: ABLETON_LIVE_VERSION pin > the major
@@ -686,7 +766,7 @@ newest_live_zip() {   # <dir> <case-insensitive glob>
 live_zip=""
 # The .run installs Ableton Live itself, from the payload given to it, and marks
 # the prefix run it owns with ABLETON_PREFIX_MANAGED=1. Neither the search below
-# nor step [6/6] runs there: two installers writing one prefix is not a
+# nor the standalone Live installer runs there: two installers writing one prefix is not a
 # supported combination, and the .run's own report is the one the user follows.
 if [ "${ABLETON_PREFIX_MANAGED:-0}" != 1 ] && [ -d "$installer_dir" ]; then
     if [ -n "${ABLETON_LIVE_VERSION:-}" ]; then
@@ -707,20 +787,21 @@ if [ "${ABLETON_PREFIX_MANAGED:-0}" != 1 ] && [ -z "${ABLETON_LIVE_VERSION:-}" ]
     case "$zip_major" in
         11|12)
             live_major="$zip_major"
-            [ "$live_major" = 12 ] || \
-                echo ":: $(basename "$live_zip") is Live $live_major: using the Live $live_major recipe (ABLETON_LIVE_VERSION overrides)"
+            if [ "$live_major" != 12 ]; then
+                prefix_note ":: $(basename "$live_zip") is Live $live_major; preparing its required Windows support files."
+            fi
             ;;
         "")
-            echo ":: cannot read a Live version from $(basename "$live_zip"): using the Live 12 recipe (set ABLETON_LIVE_VERSION if that is wrong)"
+            prefix_warn "!! Could not read the Live version from $(basename "$live_zip"); preparing for Live 12. Set ABLETON_LIVE_VERSION if that is wrong."
             ;;
         *)
-            echo "!! $(basename "$live_zip") looks like Live $zip_major: no recipe for that major (11|12); set ABLETON_LIVE_VERSION or remove the zip" >&2
+            prefix_warn "!! $(basename "$live_zip") looks like Live $zip_major, but setup supports Live 11 or 12. Set ABLETON_LIVE_VERSION or remove that zip."
             exit 2
             ;;
     esac
 fi
 
-echo "== [1/6] initialise prefix at $WINEPREFIX =="
+prefix_note "== Preparing Wine at $WINEPREFIX =="
 # While updating the prefix, wineboot offers Wine's Mono and Gecko installers. This runtime
 # vendors neither, so on a machine with no cached package it opens a modal "Wine Mono
 # Installer" prompt; nothing answers it in an unattended run and the wineserver -w below then
@@ -769,17 +850,21 @@ ableton_wineserver_quiesce || boot_wait_rc=$?
 [ "$boot_wait_rc" -eq 0 ] || [ "$boot_wait_rc" -eq 3 ] || exit "$boot_wait_rc"
 
 if [ "$refresh" -eq 1 ]; then
-    echo "== [2/6] winetricks: skipped (--refresh keeps the installed fonts/runtimes) =="
+    prefix_note "== Keeping the installed Windows fonts and support files =="
 else
+    command -v cabextract >/dev/null || {
+        prefix_warn "!! cabextract is needed to unpack the Windows support files. Install it and run setup again."
+        exit 1
+    }
     # Verb set per Live major: Live 12 needs vcrun2022 + mfc42; Live 11 needs
     # vcrun2019 + gdiplus (the Ableton forum Live-on-Linux guide). vcrun2019/gdiplus
     # payloads are not vendored yet: Live 11 setup downloads them on first run.
     case "$live_major" in
         11) verbs=(corefonts vcrun2019 gdiplus) ;;
         12) verbs=(corefonts vcrun2022 mfc42) ;;
-        *)  echo "!! internal: live_major '$live_major' has no winetricks recipe" >&2; exit 2 ;;
+        *)  prefix_warn "!! Live $live_major is not supported by this setup."; exit 2 ;;
     esac
-    echo "== [2/6] winetricks (Live $live_major): ${verbs[*]} =="
+    prefix_note "== Installing Windows fonts and support files for Live $live_major =="
     kit_root_or_die
     export W_CACHE_OVERRIDE=""            # unused
     export WINETRICKS_LATEST_VERSION_CHECK=disabled
@@ -794,18 +879,24 @@ else
         original_xdg_cache="$XDG_CACHE_HOME"
     fi
     if [ -d "$root/vendor/winetricks-cache" ]; then
-        tmpc="$(mktemp -d)"
         # Per-verb symlinks, not one dir link: the vendored cache may be
         # read-only (nix store), and verbs missing from it must still be able
-        # to download into the writable parent.
-        mkdir "$tmpc/winetricks"
-        # nullglob: an empty cache would otherwise link a file named "*".
-        ( shopt -s nullglob
-          for cached in "$root/vendor/winetricks-cache"/*; do
-              ln -s "$cached" "$tmpc/winetricks/"
-          done )
-        export XDG_CACHE_HOME="$tmpc"
-        echo "   using bundled winetricks cache ($root/vendor/winetricks-cache)"
+        # to download into the writable parent. Failure to build this temporary
+        # view falls back to normal winetricks downloads.
+        tmpc=""
+        if tmpc="$(mktemp -d)" \
+           && mkdir "$tmpc/winetricks" \
+           && ( shopt -s nullglob
+                for cached in "$root/vendor/winetricks-cache"/*; do
+                    ln -s "$cached" "$tmpc/winetricks/" || exit 1
+                done ); then
+            export XDG_CACHE_HOME="$tmpc"
+            prefix_note "   Using the bundled dependency cache."
+        else
+            [ -z "$tmpc" ] || rm -rf -- "$tmpc" 2>/dev/null || true
+            tmpc=""
+            prefix_warn "!! The bundled dependency cache could not be prepared. Setup will download the required files instead."
+        fi
     fi
     # WINE64 preset: this is a new-style WoW64 tree (single wine binary, no
     # wine64). winetricks' arch autodetection reads the ELF header of $WINE,
@@ -821,7 +912,7 @@ else
             bash "$root/vendor/winetricks" -q win10
     fi
     if [ -n "$tmpc" ]; then
-        rm -rf "$tmpc"
+        rm -rf -- "$tmpc" 2>/dev/null || true
         if [ "$original_xdg_cache_set" -eq 1 ]; then
             export XDG_CACHE_HOME="$original_xdg_cache"
         else
@@ -876,11 +967,8 @@ install_maxplug_fallback_fonts() {
     fi
 
     if [ -z "$src" ]; then
-        echo "!! Bitstream Vera fonts not found - Max for Live devices that request"
-        echo "   a missing typeface WILL hang Live (frozen window, audio still"
-        echo "   playing). Vendor them into vendor/fonts/bitstream-vera/ or install"
-        echo "   your distro's package (Debian/Ubuntu: ttf-bitstream-vera,"
-        echo "   Fedora: bitstream-vera-fonts, Arch: ttf-bitstream-vera)."
+        prefix_warn "!! Bitstream Vera fonts were not found. Some Max for Live devices may freeze Live when a typeface is missing."
+        prefix_warn "!! Install ttf-bitstream-vera (Debian/Ubuntu or Arch) or bitstream-vera-fonts (Fedora), then rerun setup."
         return 0                      # non-fatal: everything else still works
     fi
 
@@ -889,7 +977,7 @@ install_maxplug_fallback_fonts() {
     # worse than a working prefix plus a loud warning. check-m4l-fonts.sh
     # catches the not-installed state later.
     if ! mkdir -p "$winfonts"; then
-        echo "!! cannot create $winfonts; skipping the M4L font fallback repair"
+        prefix_warn "!! Max for Live fallback fonts could not be installed at $winfonts."
         return 0
     fi
 
@@ -901,17 +989,19 @@ install_maxplug_fallback_fonts() {
         if cp -u "$src/$n" "$winfonts/$n" 2>/dev/null || cp "$src/$n" "$winfonts/$n"; then
             copied=$((copied + 1))
         else
-            echo "!! failed to copy $n into $winfonts"
+            prefix_warn "!! Max for Live fallback font $n could not be copied to $winfonts."
         fi
     done
-    [ "$missing" -eq 1 ] && echo "   (some Vera faces absent from $src; registering what is present)"
+    if [ "$missing" -eq 1 ]; then
+        prefix_warn "!! Some Bitstream Vera font files are missing; the available fonts will still be installed."
+    fi
 
     # One import rather than ten `wine reg add` calls: each spawns a wine
     # process, and this runs on every setup and every --refresh. Backslashes are
     # doubled and lines are CRLF because that is what .reg format wants; the
     # values land byte-identical to what reg add wrote.
     local reg_file fonts_key='HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Fonts'
-    reg_file="$(mktemp)" || { echo "!! cannot write a temporary .reg; skipping registration"; return 0; }
+    reg_file="$(mktemp)" || { prefix_warn "!! Max for Live fallback fonts could not be registered."; return 0; }
     {
         printf 'REGEDIT4\r\n\r\n'
         printf '[%s]\r\n' "$fonts_key"
@@ -928,21 +1018,19 @@ install_maxplug_fallback_fonts() {
     if [ "$registered" -gt 0 ] && ! wine reg import "$reg_file" >/dev/null 2>&1; then
         registered=0                  # import failed: nothing landed
     fi
-    rm -f "$reg_file"
+    rm -f -- "$reg_file" 2>/dev/null || true
     ableton_wineserver_wait || true
 
     if [ "$registered" -eq 0 ]; then
-        echo "!! MaxPlug font fallback NOT registered ($copied file(s) copied)."
-        echo "   M4L devices requesting a missing typeface will hang Live."
-        echo "   Re-run this script with Live closed, then verify with:"
-        echo "     scripts/check-m4l-fonts.sh"
+        prefix_warn "!! Copied $copied Max for Live fallback font files, but they could not be registered."
+        prefix_warn "!! Close Live, rerun setup, then check with scripts/check-m4l-fonts.sh."
     elif [ "$registered" -lt "${#faces[@]}" ]; then
-        echo "   MaxPlug font fallback partially registered ($registered/${#faces[@]}); verify with scripts/check-m4l-fonts.sh"
+        prefix_warn "!! Only $registered of ${#faces[@]} Max for Live fallback fonts were registered. Check with scripts/check-m4l-fonts.sh."
     else
-        echo "   MaxPlug font fallback installed and registered (source: $src)"
+        prefix_note "   Max for Live fallback fonts are ready."
     fi
 }
-echo "== fonts: Max for Live fallback chain =="
+prefix_note "== Installing Max for Live fallback fonts =="
 install_maxplug_fallback_fonts
 
 # Live bundles the exact VC++ redistributable it was built against in its own
@@ -983,9 +1071,9 @@ install_live_redist() {
     ableton_wineserver_wait
     case "$status" in
         0|102|194) ;;
-        *) echo "!! Live's bundled VC++ redist failed (exit $status)" >&2; return 1 ;;
+        *) prefix_warn "!! Live's Microsoft Visual C++ installer failed (exit $status)."; return 1 ;;
     esac
-    vc_runtime_ready || { echo "!! bundled redist ran, but system32 still holds placeholder/missing runtime DLLs" >&2; return 1; }
+    vc_runtime_ready || { prefix_warn "!! Required Microsoft Visual C++ files are still missing after installation."; return 1; }
 }
 
 # wineboot -u replaces redist natives (msvcp140 etc.) with wine's higher-versioned stubs, which
@@ -995,14 +1083,14 @@ install_live_redist() {
 # or vcrun2019 (Live 11): both ship the vc_redist.x64/x86.exe pair with the same cab layout.
 redist_verb=vcrun2022
 [ "$live_major" = 11 ] && redist_verb=vcrun2019
-echo "== [2b/6] force native VC++ runtime over wine's builtin stubs ($redist_verb) =="
+prefix_note "== Checking Microsoft Visual C++ support =="
 kit_root || true   # vendored cache is only a candidate; absence is not fatal here
 if ! vc_runtime_ready; then
     live_redist="$(find_live_redist || true)"
     if [ -n "$live_redist" ]; then
-        echo "   installing VC++ redist from Live's own Redist: ${live_redist#"$WINEPREFIX"/}"
+        prefix_note "   Installing the Microsoft Visual C++ files included with Live."
         install_live_redist "$live_redist" || \
-            echo "!! falling back to the vendored vc_redist payload" >&2
+            prefix_warn "!! Trying the bundled Microsoft Visual C++ files instead."
     fi
 fi
 redist_dir=""
@@ -1012,11 +1100,16 @@ for d in "$root/vendor/winetricks-cache/$redist_verb" \
 done
 if [ -z "$redist_dir" ]; then
     if vc_runtime_ready; then
-        echo "   no vendored vc_redist.x64.exe: relying on the runtime verified above"
+        prefix_note "   Required Microsoft Visual C++ files are already installed."
     else
-        echo "!! vc_redist.x64.exe not found (vendor or winetricks cache): cannot assert a native VC runtime" >&2; exit 1
+        prefix_warn "!! Required Microsoft Visual C++ files are missing, and their installer could not be found."
+        exit 1
     fi
 else
+    command -v cabextract >/dev/null || {
+        prefix_warn "!! cabextract is needed to unpack the Microsoft Visual C++ files. Install it and run setup again."
+        exit 1
+    }
     vc_tmp="$(mktemp -d)"
     for arch in x64 x86; do
         cabextract -q -d "$vc_tmp/$arch/burst" "$redist_dir/vc_redist.$arch.exe"
@@ -1034,22 +1127,23 @@ else
         dest="$WINEPREFIX/drive_c/windows/$wdir/$name"
         builtin="$WINE_ROOT/lib/wine/$barch/$name"
         if [ ! -s "$dest" ] || { [ -s "$builtin" ] && cmp -s "$dest" "$builtin"; }; then
-            echo "   restoring native $wdir/$name (was wine builtin or missing)"
+            prefix_note "   Installing $name."
             install -m 644 "$f" "$dest"
         fi
         # gate: a file still identical to wine's builtin means the heal failed
         if [ -s "$builtin" ] && cmp -s "$dest" "$builtin"; then
-            echo "!! $wdir/$name is still wine's builtin stub" >&2; vc_bad=1
+            prefix_warn "!! Required Microsoft Visual C++ file $wdir/$name was not installed correctly."
+            vc_bad=1
         fi
     done
-    rm -rf "$vc_tmp"
-    [ "$vc_bad" -eq 0 ] || { echo "!! native VC++ runtime gate FAILED" >&2; exit 1; }
+    rm -rf -- "$vc_tmp" 2>/dev/null || true
+    [ "$vc_bad" -eq 0 ] || { prefix_warn "!! Ableton's required Microsoft Visual C++ files could not be installed correctly."; exit 1; }
 fi
 
-echo "== [3/6] DPI policy ($dpi_mode -> $dpi_block) =="
+prefix_note "== Configuring display scaling =="
 case "$dpi_block" in
   preserve)
-    echo "   preserving current LogPixels and dpiAwareness values"
+    prefix_note "   Existing display scaling settings were kept."
     # Still sanity-check the mutter knob against what the prefix holds.
     have="$(current_dpi_block)"
     if [ "$have" != custom ]; then
@@ -1072,14 +1166,14 @@ case "$dpi_block" in
         fi
     done < <(live_exe_names)
     if [ "$ifeo_set" -eq 0 ] && [ "$dpi_ifeo" = 2 ]; then
-        echo "   (Live not installed yet: the launcher sets its per-app DPI flag on first start)"
+        prefix_note "   Live-specific scaling will be applied automatically when Live first starts."
     fi
     check_mutter_knob "$dpi_block" "$dpi_family"
     ;;
 esac
 ableton_wineserver_wait
 
-echo "== [3b/6] theme policy (${ABLETON_THEME_MODE:-auto}) =="
+prefix_note "== Configuring the desktop theme =="
 # Live's "Follow system" theme reads AppsUseLightTheme; without the key it always renders
 # light. Seed it from the host scheme (the launcher re-syncs on every start), plus the
 # EnableTransparency=0 the known-good prefixes carry.
@@ -1093,15 +1187,15 @@ case "$theme_mode" in
     preserve|'') light_val="" ;;
 esac
 if [ -n "$light_val" ]; then
-    echo "   applying $theme_mode theme"
+    prefix_note "   Applying the $theme_mode theme."
     wine reg add 'HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize' /v AppsUseLightTheme /t REG_DWORD /d "$light_val" /f
     wine reg add 'HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize' /v EnableTransparency /t REG_DWORD /d 0 /f
     ableton_wineserver_wait
 else
-    echo "   preserving existing theme values"
+    prefix_note "   Existing theme settings were kept."
 fi
 
-echo "== [3c/6] text: subpixel antialiasing =="
+prefix_note "== Configuring text rendering =="
 # Wine takes the antialiasing mode from the host's Xft resources, so a desktop
 # set to grayscale renders every Win32 menu, dialog and control grayscale
 # whatever the prefix asks for. Patch 0084 lets an explicit FontSmoothingType
@@ -1116,34 +1210,43 @@ if command -v gsettings >/dev/null 2>&1; then
         bgr) smoothing_order=0 ;;
     esac
 fi
-case "$smoothing_order" in 0) echo "   subpixel order: BGR" ;; *) echo "   subpixel order: RGB" ;; esac
+case "$smoothing_order" in
+    0) prefix_note "   Using BGR subpixel order." ;;
+    *) prefix_note "   Using RGB subpixel order." ;;
+esac
 wine reg add 'HKCU\Control Panel\Desktop' /v FontSmoothing /t REG_SZ /d 2 /f
 wine reg add 'HKCU\Control Panel\Desktop' /v FontSmoothingType /t REG_DWORD /d 2 /f
 wine reg add 'HKCU\Control Panel\Desktop' /v FontSmoothingOrientation /t REG_DWORD /d "$smoothing_order" /f
 ableton_wineserver_wait
 
-echo "== [4/6] register packaged PipeASIO =="
+prefix_note "== Configuring PipeASIO audio =="
 # Recheck at the last safe point.  The prefix is still the sibling staging
 # copy, so a service/client change cannot leave the retained prefix half
 # registered.  Registration removes and verifies only PipeASIO's one CLSID.
 # The driver's unix half must resolve libpipewire-0.3.so.0 - the tarball build
 # from the host's libs (it carries no rpath on purpose), the nix build from its
 # nixpkgs RUNPATH. ldd follows both; ldconfig -p sees neither on NixOS.
-if ldd "$WINE_ROOT/lib/wine/x86_64-unix/pipeasio64.dll.so" 2>/dev/null \
-    | grep -F 'libpipewire-0.3.so.0' | grep -q 'not found'; then
-    echo "!! the PipeASIO driver cannot resolve libpipewire-0.3.so.0; install pipewire (0.3.56 or newer, 1.6+ recommended)"
+pipeasio_ldd="$(ldd "$WINE_ROOT/lib/wine/x86_64-unix/pipeasio64.dll.so" 2>/dev/null || true)"
+if grep -Eq 'libpipewire-0[.]3[.]so[.]0.*not found' <<< "$pipeasio_ldd"; then
+    prefix_warn "!! PipeASIO cannot start because the PipeWire client library is missing. Install PipeWire 1.4.2 or newer."
 fi
-[ -S "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/pipewire-0" ] || \
-    echo "!! no PipeWire socket at ${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/pipewire-0 - Live will list no PipeASIO device until the PipeWire daemon runs"
+if [ ! -S "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/pipewire-0" ]; then
+    prefix_warn "!! PipeWire is not running. Live will not list a PipeASIO device until PipeWire starts."
+fi
 ableton_pipewire_preflight "$WINE_ROOT/bin/pipewire-version-probe" "registering PipeASIO"
 ableton_pipeasio_register wine ableton_wineserver_wait
 
 # Seed the driver defaults once; the file is the config surface (PIPEASIO_*
 # environment variables override it per launch, see the README).
-pipeasio_cfg="${XDG_CONFIG_HOME:-$HOME/.config}/pipeasio/config.ini"
-if [ ! -e "$pipeasio_cfg" ] && [ ! -L "$pipeasio_cfg" ]; then
-    pipeasio_tmp="$(mktemp "$transaction_dir/pipeasio.XXXXXX")"
-    cat > "$pipeasio_tmp" <<'EOF'
+write_default_pipeasio_settings()
+{
+    local pipeasio_cfg="${XDG_CONFIG_HOME:-$HOME/.config}/pipeasio/config.ini"
+    local pipeasio_tmp="" pipeasio_parent pipeasio_seeded=0
+    if [ ! -e "$pipeasio_cfg" ] && [ ! -L "$pipeasio_cfg" ]; then
+        pipeasio_parent="$(dirname "$pipeasio_cfg")"
+        if mkdir -p -- "$pipeasio_parent" \
+           && pipeasio_tmp="$(mktemp "$pipeasio_parent/.config.ini.XXXXXX")"; then
+            if cat > "$pipeasio_tmp" <<'EOF'
 [pipeasio]
 inputs = 2
 outputs = 2
@@ -1151,15 +1254,35 @@ buffer_size = 256
 fixed_buffer_size = true
 auto_connect = true
 EOF
-    ableton_install_file 600 "$pipeasio_tmp" "$pipeasio_cfg" config
-    rm -f -- "$pipeasio_tmp"
-    ableton_write_ownership_manifest
-    echo "   seeded $pipeasio_cfg (2 in / 2 out, fixed 256-frame buffer)"
-elif [ -L "$pipeasio_cfg" ] && [ ! -e "$pipeasio_cfg" ]; then
-    echo "   kept your dangling PipeASIO configuration link: $pipeasio_cfg"
-fi
+            then
+                if chmod 600 "$pipeasio_tmp" \
+                   && mv -T -n -- "$pipeasio_tmp" "$pipeasio_cfg" \
+                   && [ ! -e "$pipeasio_tmp" ] && [ -f "$pipeasio_cfg" ] && [ ! -L "$pipeasio_cfg" ]; then
+                    pipeasio_seeded=1
+                fi
+            fi
+        fi
+        if [ "$pipeasio_seeded" -eq 1 ]; then
+            printf '   created default PipeASIO settings at %s (2 in / 2 out, fixed 256-frame buffer)\n' \
+                "$pipeasio_cfg" 2>/dev/null || true
+        else
+            [ -z "$pipeasio_tmp" ] || rm -f -- "$pipeasio_tmp" 2>/dev/null || true
+            if [ -e "$pipeasio_cfg" ] || [ -L "$pipeasio_cfg" ]; then
+                printf '   kept the existing PipeASIO settings at %s\n' \
+                    "$pipeasio_cfg" 2>/dev/null || true
+            else
+                printf '%s\n' "!! Default PipeASIO settings could not be written. Run prefix update to retry." >&2 2>/dev/null || true
+            fi
+        fi
+    elif [ -L "$pipeasio_cfg" ] && [ ! -e "$pipeasio_cfg" ]; then
+        printf '   kept your PipeASIO settings link even though its target is missing: %s\n' \
+            "$pipeasio_cfg" 2>/dev/null || true
+    fi
+    return 0
+}
+write_default_pipeasio_settings
 
-echo "== [5/6] set portal policy and scope the Push USB bridge to its helpers =="
+prefix_note "== Configuring file dialogs and Push USB access =="
 # Default only: a policy the user set with set-file-portal-policy survives re-runs.
 if ! wine reg query 'HKCU\Software\Wine\X11 Driver' /v FileDialogPortal >/dev/null 2>&1; then
   wine reg add 'HKCU\Software\Wine\X11 Driver' \
@@ -1189,6 +1312,28 @@ wine reg delete 'HKLM\Software\Microsoft\Windows\CurrentVersion\Installer\Upgrad
 wine reg delete 'HKLM\Software\Classes\Installer\UpgradeCodes\86C5CFEA462003E469588217A219FCE4' /v 16A75B0B0E11E2A4A911BAE107021162 /f >/dev/null 2>&1 || true
 wine reg delete 'HKLM\Software\Classes\Installer\Products\16A75B0B0E11E2A4A911BAE107021162' /f >/dev/null 2>&1 || true
 wine reg delete 'HKLM\Software\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products\16A75B0B0E11E2A4A911BAE107021162' /f >/dev/null 2>&1 || true
+wine reg query 'HKLM\Software' >/dev/null 2>&1 || {
+    prefix_warn "!! The Wine registry could not be checked after removing an old Live 11 installer workaround."
+    exit 1
+}
+for placeholder_query in \
+    'HKLM\Software\Microsoft\Windows\CurrentVersion\Installer\UpgradeCodes\86C5CFEA462003E469588217A219FCE4|/v|16A75B0B0E11E2A4A911BAE107021162' \
+    'HKLM\Software\Classes\Installer\UpgradeCodes\86C5CFEA462003E469588217A219FCE4|/v|16A75B0B0E11E2A4A911BAE107021162' \
+    'HKLM\Software\Classes\Installer\Products\16A75B0B0E11E2A4A911BAE107021162||' \
+    'HKLM\Software\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products\16A75B0B0E11E2A4A911BAE107021162||'; do
+    IFS='|' read -r placeholder_key placeholder_option placeholder_value <<< "$placeholder_query"
+    placeholder_status=0
+    if [ -n "$placeholder_option" ]; then
+        wine reg query "$placeholder_key" "$placeholder_option" "$placeholder_value" \
+            >/dev/null 2>&1 || placeholder_status=$?
+    else
+        wine reg query "$placeholder_key" >/dev/null 2>&1 || placeholder_status=$?
+    fi
+    [ "$placeholder_status" -eq 1 ] || {
+        prefix_warn "!! An old Live 11 installer workaround is still present in the Wine registry."
+        exit 1
+    }
+done
 
 # winemenubuilder's entries assume `wine` on PATH (never true here) and are dead buttons: disable
 # it and delete entries it already wrote for this prefix (matched by WINEPREFIX=; install.sh's entries can't match).
@@ -1202,64 +1347,89 @@ for entry_dir in "${XDG_DATA_HOME:-$HOME/.local/share}/applications" "$desktop_d
     [ -d "$entry_dir" ] || continue
     find "$entry_dir" -maxdepth 3 -name '*.desktop' -type f 2>/dev/null | while IFS= read -r f; do
         if grep -qF "WINEPREFIX=\"$final_prefix\"" "$f" 2>/dev/null; then
-            echo "   removing dead winemenubuilder entry: $f"
-            ableton_txn_snapshot "$f"
-            ableton_txn_expect "$f" absent
-            rm -f "$f"
+            prefix_note "   Removing an obsolete desktop shortcut: $f"
+            rm -f -- "$f" 2>/dev/null \
+                || prefix_warn "!! Could not remove the obsolete desktop shortcut at $f."
         fi
-    done
+    done || true
 done
 update-desktop-database "${XDG_DATA_HOME:-$HOME/.local/share}/applications" 2>/dev/null || true
 ableton_wineserver_wait
 
-echo "== [5b/6] remove the 2026.07.18.1 Options.txt seed (issue #29) =="
+prefix_note "== Removing an obsolete Live audio setting =="
 strip_options_txt "-DontCombineAPCs"
 
 # -_ForceGdiBackend disables Live's GPU renderer. Early prefixes carried it
 # (inherited from pre-repo setups); with the d2d1 base fork Live's GPU
 # renderer works, removes the WebView2 pane flicker, and drops idle CPU.
-echo "== [5c/6] remove -_ForceGdiBackend so Live uses its GPU renderer =="
+prefix_note "== Enabling Live's GPU renderer =="
 strip_options_txt "-_ForceGdiBackend"
 
-echo "== [6/6] Ableton Live =="
+prefix_note "== Checking Ableton Live =="
 # Runs the USER'S OWN Ableton download - this repo ships no Live payload and no
 # license. OPT-IN ONLY (ABLETON_LIVE_AUTOINSTALL=1): the automatic run is
 # silent, which defers Ableton's EULA to first launch, and a prefix refresh must
 # never execute an installer the user did not explicitly ask it to.
 # Search dir: ~/Proprietary (the official ableton_live*.zip from ableton.com);
 # ABLETON_INSTALLER_DIR overrides. The zip candidate - and the recipe major it
-# implies - was resolved before step [1/6]. Under the .run this step reports and
-# does nothing: installer.sh installs Live from its own payload, with the
-# handling this step repeats rather than shares, that copy not being present in
-# a packaged install.
+# implies - was resolved before Wine setup. Under the .run, installer.sh installs
+# Live from its own payload after this prefix is ready.
 live_ready=0
+remove_extracted_live_installer()
+{
+    local unpack_dir="$1"
+    if [ -e "$unpack_dir" ] || [ -L "$unpack_dir" ]; then
+        rm -rf -- "$unpack_dir" 2>/dev/null || true
+    fi
+    if [ -e "$unpack_dir" ] || [ -L "$unpack_dir" ]; then
+        printf '!! Temporary Ableton Live installer files remain at %s.\n' \
+            "$unpack_dir" >&2 2>/dev/null || true
+    fi
+    return 0
+}
 if [ "${ABLETON_PREFIX_MANAGED:-0}" = 1 ]; then
     live_installed && live_ready=1
-    echo "   installed by the ableton-wine-setup installer, not by this step"
+    if [ "$live_ready" -eq 1 ]; then
+        prefix_note "   Live is already installed."
+    else
+        prefix_note "   The installer will install Live after Wine setup finishes."
+    fi
 elif live_installed; then
     live_ready=1
-    echo "   Live is already installed in this prefix - not touching it"
+    prefix_note "   Live is already installed; it was left unchanged."
 elif [ "${ABLETON_LIVE_AUTOINSTALL:-}" = 0 ]; then
-    echo "   skipped (ABLETON_LIVE_AUTOINSTALL=0)"
+    prefix_note "   Automatic Live installation is disabled."
 elif [ "${ABLETON_LIVE_AUTOINSTALL:-0}" != 1 ]; then
     if [ -n "$live_zip" ]; then
-        echo "   found $(basename "$live_zip") - rerun with ABLETON_LIVE_AUTOINSTALL=1 to install it"
-        echo "   (silent install: Ableton's EULA is then shown on Live's first launch, not before)"
+        prefix_note "   Found $(basename "$live_zip"). Set ABLETON_LIVE_AUTOINSTALL=1 to install it."
+        prefix_note "   Ableton's license agreement will be shown when Live first starts."
     else
-        echo "   skipped - ABLETON_LIVE_AUTOINSTALL=1 (opt-in) installs your ableton_live*.zip from $installer_dir"
+        prefix_note "   To install your own Ableton download automatically, place it in $installer_dir and set ABLETON_LIVE_AUTOINSTALL=1."
     fi
 elif [ -z "$live_zip" ]; then
     if [ -n "${ABLETON_LIVE_VERSION:-}" ]; then
-        echo "   no Live $ABLETON_LIVE_VERSION installer (ableton_live*_${ABLETON_LIVE_VERSION}.*.zip) in $installer_dir - manual install steps are printed below"
+        prefix_warn "!! No Live $ABLETON_LIVE_VERSION installer was found in $installer_dir."
     else
-        echo "   no ableton_live*.zip in $installer_dir - manual install steps are printed below"
+        prefix_warn "!! No Ableton Live installer zip was found in $installer_dir."
     fi
-    echo "   (drop the official ableton.com zip there, or point ABLETON_INSTALLER_DIR at it)"
+    prefix_note "   Put the official ableton.com zip there, or set ABLETON_INSTALLER_DIR to its directory."
 else
-    echo "   unpacking $(basename "$live_zip")"
-    unpack_dir="${XDG_CACHE_HOME:-$HOME/.cache}/ableton-wine-setup/live-installer"
-    rm -rf "$unpack_dir"
-    mkdir -p "$unpack_dir"
+    prefix_note "   Unpacking $(basename "$live_zip")."
+    preferred_unpack_dir="${XDG_CACHE_HOME:-$HOME/.cache}/ableton-wine-setup/live-installer"
+    unpack_dir="$preferred_unpack_dir"
+    if [ -d "$unpack_dir" ] && [ ! -L "$unpack_dir" ]; then
+        rm -rf -- "$unpack_dir" 2>/dev/null || true
+    fi
+    if [ -e "$unpack_dir" ] || [ -L "$unpack_dir" ] \
+       || ! mkdir -p -- "$unpack_dir" 2>/dev/null; then
+        # This is disposable extraction cache. A stale, foreign-shaped, or
+        # unwritable cache path cannot veto prefix preparation; use private
+        # scratch space and leave the old object untouched for inspection.
+        unpack_dir="$(mktemp -d "${TMPDIR:-/tmp}/ableton-live-installer.XXXXXX")" \
+            || { prefix_warn "!! Temporary space for the Live installer could not be created."; exit 1; }
+        printf '!! Old extracted installer files could not be replaced at %s; using temporary space instead.\n' \
+            "$preferred_unpack_dir" >&2 2>/dev/null || true
+    fi
     unpack_ok=1
     extract_timeout="$(ableton_timeout_value "${ABLETON_PAYLOAD_EXTRACT_TIMEOUT:-900}" ABLETON_PAYLOAD_EXTRACT_TIMEOUT 60 7200)"
     # -o + </dev/null stop unzip hanging on a "replace? (y/n)" prompt.
@@ -1271,7 +1441,7 @@ else
         ableton_run_bounded "$extract_timeout" python3 -m zipfile -e "$live_zip" "$unpack_dir" </dev/null || unpack_ok=0
     else
         unpack_ok=0
-        echo "!! nothing available to unpack the zip (looked for unzip, bsdtar, python3)"
+        prefix_warn "!! The Live installer zip cannot be opened because unzip, bsdtar, and python3 are unavailable."
     fi
     live_exe=""
     if [ "$unpack_ok" -eq 1 ]; then
@@ -1281,13 +1451,13 @@ else
         if [ "${#payload_exes[@]}" -eq 1 ]; then
             live_exe="${payload_exes[0]}"
         else
-            echo "!! expected exactly one installer executable in the zip, found ${#payload_exes[@]}"
+            prefix_warn "!! Expected one installer program in the Live zip, but found ${#payload_exes[@]}."
         fi
     fi
     if [ "$unpack_ok" -eq 0 ]; then
-        echo "!! could not unpack $(basename "$live_zip") - manual install steps are printed below"
+        prefix_warn "!! Could not unpack $(basename "$live_zip"). You can still install Live manually."
     elif [ -z "$live_exe" ]; then
-        echo "!! no single installer (.exe) inside that zip - is it the official ableton.com download?"
+        prefix_warn "!! The zip does not contain one clear Live installer. Use the official ableton.com download."
     else
         # The silent flags depend on the installer engine, identified by the
         # test installer.sh makes: Live 11 ships a WiX Burn bundle, Live 12 an
@@ -1318,32 +1488,32 @@ else
             [ "$rc" -eq 0 ] || [ "$rc" -eq 3 ] || return "$rc"
         }
         if [ "${ABLETON_INSTALLER_UI:-0}" = 1 ]; then
-            echo "   starting the Ableton installer - from here just click through its window"
-            run_installer || echo "!! the Ableton installer exited with an error - manual install steps are printed below"
+            prefix_note "   Starting the Ableton installer. Follow the installer window."
+            run_installer || prefix_warn "!! The Ableton installer exited with an error. You can retry the installation manually."
             end_session
         else
-            echo "   installing Ableton Live silently - takes a few minutes (ABLETON_INSTALLER_UI=1 for the installer window)"
+            prefix_note "   Installing Ableton Live. This can take a few minutes."
             # Keep the display attached: the installer engines need a window
             # connection even under these switches - a headless run installs
             # nothing at all; with the display it installs silently.
             run_installer "${silent_flags[@]}" || true
             end_session
             if ! live_installed; then
-                echo "!! the silent install produced no installation - starting the installer window"
-                run_installer || echo "!! the Ableton installer exited with an error - manual install steps are printed below"
+                prefix_warn "!! Automatic installation did not install Live. Starting the installer window."
+                run_installer || prefix_warn "!! The Ableton installer exited with an error. You can retry the installation manually."
                 end_session
             fi
         fi
         if live_installed; then live_ready=1; fi
     fi
-    [ ! -e "$unpack_dir" ] || rm -rf "$unpack_dir"
+    remove_extracted_live_installer "$unpack_dir"
 fi
 
 # Promote the fully prepared prefix only after every Wine command and gate has
 # succeeded.  The original remains beside it until the outer transaction commits.
 prefix_marker="$WINEPREFIX/.ableton-linux-prefix"
 if [ -L "$prefix_marker" ] || { [ -e "$prefix_marker" ] && [ ! -f "$prefix_marker" ]; }; then
-    echo "!! staged Wine prefix has an unsafe ownership marker" >&2
+    prefix_warn "!! The prepared Wine prefix is missing a valid Ableton Linux setup record."
     exit 1
 fi
 prefix_marker_tmp="$(mktemp "$WINEPREFIX/.prefix-marker.XXXXXX")"
@@ -1353,29 +1523,69 @@ if ! printf 'format=1\nprefix=%s\n' "$final_prefix" > "$prefix_marker_tmp" \
    || [ -e "$prefix_marker_tmp" ] || [ ! -f "$prefix_marker" ] || [ -L "$prefix_marker" ] \
    || ! ableton_prefix_marker_valid "$WINEPREFIX" "$final_prefix"; then
     rm -f -- "$prefix_marker_tmp"
-    echo "!! could not mark the staged Wine prefix safely" >&2
+    prefix_warn "!! The prepared Wine prefix could not be marked safely."
     exit 1
 fi
 prefix_backup=absent
 if [ -e "$final_prefix" ]; then
     prefix_backup="$final_prefix.transaction-${transaction_dir##*/}"
     [ ! -e "$prefix_backup" ] && [ ! -L "$prefix_backup" ] \
-        || { echo "!! prefix transaction backup already exists: $prefix_backup" >&2; exit 1; }
+        || { prefix_warn "!! An old Wine prefix recovery directory already exists: $prefix_backup"; exit 1; }
 fi
-ableton_promote_directory "$WINEPREFIX" "$final_prefix" "$prefix_backup" \
-    "$transaction_dir/prefix.tsv"
+# Revalidate both names immediately before the rename. New project launchers
+# share the global installation lock, but a direct stock-Wine command or a
+# launcher using the pre-update runtime can still start against the selected
+# prefix while this first update is staging. Promotion is therefore scoped by
+# the exact WINEPREFIX value, not by the runtime generation. The staging check
+# separately proves that our own work left no process addressing the directory
+# about to be renamed.
+late_prefix_holders="$(ableton_prefix_wine_processes_any_runtime "$final_prefix")"
+if [ -n "$late_prefix_holders" ]; then
+    IFS=$'\t' read -r late_prefix_pid late_prefix_exe <<< "$late_prefix_holders" || {
+        prefix_warn "!! The Wine process using $final_prefix could not be identified."
+        exit 1
+    }
+    prefix_warn "!! A Wine program started while setup was running (pid $late_prefix_pid, $late_prefix_exe). Close it and run setup again."
+    exit 1
+fi
+late_prefix_holders="$(ableton_prefix_wine_processes_any_runtime "$WINEPREFIX")"
+if [ -n "$late_prefix_holders" ]; then
+    IFS=$'\t' read -r late_prefix_pid late_prefix_exe <<< "$late_prefix_holders" || {
+        prefix_warn "!! A Wine process using the prepared prefix could not be identified."
+        exit 1
+    }
+    prefix_warn "!! A Wine program is still using the prepared prefix (pid $late_prefix_pid, $late_prefix_exe). Close it and run setup again."
+    exit 1
+fi
+# A direct setup has not changed the live prefix before this point. Publish its
+# active marker only for the atomic promotion window where recovery may truly
+# be needed; the coordinator's outer transaction already has its own marker.
+if [ "$own_prefix_transaction" -eq 1 ]; then
+    : > "$transaction_dir/active"
+fi
+if ! ableton_promote_directory "$WINEPREFIX" "$final_prefix" "$prefix_backup" \
+        "$transaction_dir/prefix.tsv"; then
+    prefix_warn "!! The prepared Wine prefix could not be put into place."
+    exit 1
+fi
 prefix_promoted=1
+prefix_core_ready=1
 export WINEPREFIX="$final_prefix"
 if [ "$own_prefix_transaction" -eq 1 ]; then
-    prefix_transaction_commit "$transaction_dir"
-    if ! rm -rf -- "$transaction_dir"; then
-        echo "!! committed prefix transaction could not be retired" >&2
-        exit 1
+    ableton_mark_transaction_core_complete "$transaction_dir" 2>/dev/null || true
+    if prefix_transaction_commit "$transaction_dir"; then
+        if ! rm -rf -- "$transaction_dir"; then
+            prefix_warn "!! The Wine prefix is ready, but old recovery files remain at $transaction_dir."
+        fi
+    else
+        rm -f -- "$transaction_dir/active" 2>/dev/null || true
+        prefix_warn "!! The Wine prefix is ready, but old recovery files remain at $transaction_dir."
     fi
 fi
 
-echo
-echo "OK: prefix ready at $WINEPREFIX"
+if [ "$own_prefix_transaction" -eq 1 ]; then
+prefix_note ""
+prefix_note "OK: Wine is ready at $WINEPREFIX"
 if [ "${ABLETON_PREFIX_MANAGED:-0}" != 1 ]; then
 if [ "$live_ready" -eq 1 ]; then
     banner="Remaining steps (you supply your own license):"
@@ -1395,7 +1605,7 @@ else
 STEP1
 )"
 fi
-cat <<EOF
+cat <<EOF 2>/dev/null || true
 
 ────────────────────────────────────────────────────────────────────────
 $banner
@@ -1410,5 +1620,5 @@ $step1
 ────────────────────────────────────────────────────────────────────────
 EOF
 fi
+fi
 prefix_promoted=0
-trap - EXIT

--- a/scripts/setup-run-header.sh
+++ b/scripts/setup-run-header.sh
@@ -50,7 +50,10 @@ cleanup()
 {
     local rc=$?
     trap - EXIT
-    rm -rf -- "$workdir"
+    rm -rf -- "$workdir" 2>/dev/null || true
+    if [ -e "$workdir" ] || [ -L "$workdir" ]; then
+        echo "!! The installer finished, but temporary files remain at $workdir. You can remove that directory." >&2 || true
+    fi
     exit "$rc"
 }
 trap cleanup EXIT
@@ -58,21 +61,24 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 payload_line="$(awk '/^__PAYLOAD_BELOW__$/{print NR+1; exit}' "$self")"
-[ -n "$payload_line" ] || { echo "!! installer payload marker is missing" >&2; exit 1; }
+[ -n "$payload_line" ] || {
+    echo "!! This installer file is incomplete or damaged. Download it again." >&2
+    exit 1
+}
 header_bytes="$(head -n "$((payload_line-1))" "$self" | wc -c)"
 total_bytes="$(stat -c %s "$self" 2>/dev/null || wc -c < "$self")"
 payload_bytes=$((total_bytes - header_bytes))
-printf '== Ableton-on-Wine installer %s ==\n' "$VERSION"
-printf '%s\n' "-- copying embedded kit ($((payload_bytes / 1024 / 1024)) MiB; progress is bytes copied)"
+printf '== Ableton-on-Wine installer %s ==\n' "$VERSION" || true
+printf '%s\n' "-- copying embedded kit ($((payload_bytes / 1024 / 1024)) MiB; progress is bytes copied)" || true
 payload="$workdir/payload.tar"
-if dd --help 2>&1 | grep -q iflag; then
+if dd --help 2>&1 | grep iflag >/dev/null; then
     bounded dd if="$self" of="$payload" iflag=skip_bytes skip="$header_bytes" bs=4M status=progress
 else
     bounded tail -n +"$payload_line" "$self" > "$payload"
 fi
 
-echo "-- verifying embedded kit (progress is bytes hashed)"
-if dd --help 2>&1 | grep -q status; then
+printf '%s\n' "-- verifying embedded kit (progress is bytes hashed)" || true
+if dd --help 2>&1 | grep status >/dev/null; then
     actual="$(bounded dd if="$payload" bs=4M status=progress | sha256sum | awk '{print $1}')"
 else
     actual="$(bounded sha256sum "$payload" | awk '{print $1}')"
@@ -84,23 +90,24 @@ fi
 
 kit="$workdir/kit"
 mkdir -p -- "$kit"
-echo "-- extracting embedded kit"
-if tar --help 2>&1 | grep -q -- '--checkpoint'; then
+printf '%s\n' "-- extracting embedded kit" || true
+if tar --help 2>&1 | grep -- '--checkpoint' >/dev/null; then
     bounded tar --checkpoint=200 --checkpoint-action=dot -xf "$payload" -C "$kit"
-    printf '\n' >&2
+    printf '\n' >&2 || true
 else
     bounded tar -xf "$payload" -C "$kit"
 fi
-rm -f -- "$payload"
+rm -f -- "$payload" 2>/dev/null || true
 
 if [ -n "$extract_dir" ]; then
     mkdir -p -- "$extract_dir"
     cp -a -- "$kit/." "$extract_dir/"
-    printf 'OK: kit extracted to %s\n' "$extract_dir"
+    printf 'OK: kit extracted to %s\n' "$extract_dir" || true
     exit 0
 fi
 
 export ABLETON_INSTALLER_MEDIA_DIR="$media_dir"
+export ABLETON_INSTALLER_PATH="$self"
 export ABLETON_INSTALLER_VERSION="$VERSION"
 # Delegate without exec: the EXIT trap must still remove $workdir.  The exit
 # keeps bash from reading past the payload marker after a successful install.

--- a/scripts/shortcut-hold.sh
+++ b/scripts/shortcut-hold.sh
@@ -479,7 +479,21 @@ ableton_shortcuts_watch_loop()
             sleep "$delay"
             continue
         fi
-        ableton_shortcuts_restore_if_idle && break
+        # A detached watcher can outlive a failed launch.  Its state-file and
+        # gsettings restoration must not overlap uninstall or another lifecycle
+        # transaction.  Acquire in the same global -> shortcut-operation order
+        # used everywhere else, and retry if an installer currently owns it.
+        if declare -F ableton_install_lock_acquire >/dev/null 2>&1; then
+            if ableton_install_lock_acquire 2>/dev/null; then
+                if ableton_shortcuts_restore_if_idle; then
+                    ableton_install_lock_release || true
+                    break
+                fi
+                ableton_install_lock_release || true
+            fi
+        elif ableton_shortcuts_restore_if_idle; then
+            break
+        fi
         sleep "$delay"
     done
 }

--- a/scripts/test-config-boundary.sh
+++ b/scripts/test-config-boundary.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+work="$(mktemp -d "${TMPDIR:-/tmp}/ableton-config-boundary-test.XXXXXX")"
+cleanup()
+{
+    case "${work:-}" in
+        "${TMPDIR:-/tmp}"/ableton-config-boundary-test.*) rm -rf -- "$work" ;;
+    esac
+}
+trap cleanup EXIT
+
+pass=0
+ok()
+{
+    pass=$((pass + 1))
+    printf 'ok - %s\n' "$1"
+}
+fail()
+{
+    printf 'not ok - %s\n' "$1" >&2
+    exit 1
+}
+
+new_env()
+{
+    local base="$work/$1"
+    mkdir -p -- "$base/home" "$base/tmp"
+    printf '%s\n' "$base"
+}
+
+run_isolated()
+{
+    local base="$1"
+    shift
+    env -u ABLETON_WINE_ROOT -u ABLETON_WINEPREFIX \
+        -u ABLETON_DATA_HOME -u ABLETON_CONFIG_HOME \
+        -u ABLETON_CONFIG_FILE -u ABLETON_STATE_HOME \
+        -u ABLETON_CACHE_HOME -u ABLETON_BIN_HOME \
+        -u ABLETON_LINKD -u ABLETON_LINK_MODE \
+        -u ABLETON_CONFIG_LAYOUT_ROOTS -u ABLETON_CONFIG_REPAIR_MODE \
+        -u ABLETON_CONFIG_REPAIR_NEEDED \
+        -u ABLETON_CONFIG_SNAPSHOT_PATH -u ABLETON_CONFIG_SNAPSHOT_TOKEN \
+        -u ABLETON_CONFIG_SNAPSHOT_VALUES \
+        HOME="$base/home" XDG_CONFIG_HOME="$base/config" \
+        XDG_DATA_HOME="$base/data" XDG_STATE_HOME="$base/state" \
+        XDG_CACHE_HOME="$base/cache" XDG_RUNTIME_DIR="$base/run" \
+        TMPDIR="$base/tmp" PATH=/usr/bin:/bin "$@"
+}
+
+# The three exported snapshot fields are one record. A partial inherited record
+# must be replaced, and verification must remain safe under set -u when any
+# individual field is later missing.
+base="$(new_env partial-snapshot)"
+run_isolated "$base" env \
+    ABLETON_CONFIG_SNAPSHOT_PATH="$base/config/ableton-wine/config" \
+    bash -c '
+        set -euo pipefail
+        . "$1/lib/config.sh"
+        ABLETON_CONFIG_LAYOUT_ROOTS=none
+        export ABLETON_CONFIG_LAYOUT_ROOTS
+        ableton_config_init repair
+        [ -n "$ABLETON_CONFIG_SNAPSHOT_PATH" ]
+        [ -n "$ABLETON_CONFIG_SNAPSHOT_TOKEN" ]
+        [ -n "$ABLETON_CONFIG_SNAPSHOT_VALUES" ]
+        ableton_config_snapshot_verify
+
+        saved_path="$ABLETON_CONFIG_SNAPSHOT_PATH"
+        saved_token="$ABLETON_CONFIG_SNAPSHOT_TOKEN"
+        saved_values="$ABLETON_CONFIG_SNAPSHOT_VALUES"
+        unset ABLETON_CONFIG_SNAPSHOT_PATH
+        ! ableton_config_snapshot_verify
+        ABLETON_CONFIG_SNAPSHOT_PATH="$saved_path"
+        export ABLETON_CONFIG_SNAPSHOT_PATH
+        unset ABLETON_CONFIG_SNAPSHOT_TOKEN
+        ! ableton_config_snapshot_verify
+        ABLETON_CONFIG_SNAPSHOT_TOKEN="$saved_token"
+        export ABLETON_CONFIG_SNAPSHOT_TOKEN
+        unset ABLETON_CONFIG_SNAPSHOT_VALUES
+        ! ableton_config_snapshot_verify
+        ABLETON_CONFIG_SNAPSHOT_VALUES="$saved_values"
+        export ABLETON_CONFIG_SNAPSHOT_VALUES
+        ableton_config_snapshot_verify
+
+        ableton_config_object_token() { return 1; }
+        ! ableton_config_snapshot_capture
+        [ "$ABLETON_CONFIG_SNAPSHOT_PATH" = "$saved_path" ]
+        [ "$ABLETON_CONFIG_SNAPSHOT_TOKEN" = "$saved_token" ]
+        [ "$ABLETON_CONFIG_SNAPSHOT_VALUES" = "$saved_values" ]
+    ' _ "$here" || fail "partial installer-settings snapshot was accepted or caused an unbound-variable exit"
+ok "installer-settings snapshots are complete records under set -u"
+
+# Once a caller intentionally enters repair mode, the state marker and settings
+# writer must not re-enter strict mode and reject the same repairable generation.
+base="$(new_env repair-reentry)"
+config="$base/config/ableton-wine/config"
+mkdir -p -- "$(dirname "$config")"
+printf '# ableton-linux installer configuration; managed by the installer\nformat=1\nruntime_root=%s\nprefix=%s\nlive_major=12\nlink_mode=off\nlinkd=%s\nobsolete_field=remove-me\n' \
+    "$base/runtime" "$base/prefix" "$base/data/ableton-wine/ableton-linkd" \
+    > "$config"
+run_isolated "$base" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ABLETON_CONFIG_LAYOUT_ROOTS=none
+    export ABLETON_CONFIG_LAYOUT_ROOTS
+    ableton_config_init repair
+    [ "$ABLETON_CONFIG_REPAIR_NEEDED" -eq 1 ]
+    ableton_mark_state_home
+    ableton_write_config
+    [ "$ABLETON_CONFIG_REPAIR_NEEDED" -eq 0 ]
+    ableton_managed_config_valid "$ABLETON_CONFIG_FILE"
+    [ -f "$ABLETON_STATE_HOME/.ableton-linux-state" ]
+' _ "$here" || fail "repair mode was re-gated by a generated malformed settings file"
+if grep -q '^obsolete_field=' "$config"; then
+    fail "repair-mode settings rewrite retained an obsolete generated field"
+fi
+ok "state and settings writers preserve an established repair mode"
+
+# Initial command scopes may deliberately omit settings. The writer itself must
+# still reject both its temporary directory and a custom final file under Wine.
+for overlap_kind in config-home custom-file; do
+    base="$(new_env "settings-overlap-$overlap_kind")"
+    mkdir -p -- "$base/runtime" "$base/settings"
+    case "$overlap_kind" in
+        config-home)
+            config_home="$base/runtime"
+            config_file="$base/runtime/config" ;;
+        custom-file)
+            config_home="$base/settings"
+            config_file="$base/runtime/installer-config" ;;
+    esac
+    if run_isolated "$base" env \
+        ABLETON_WINE_ROOT="$base/runtime" \
+        ABLETON_CONFIG_HOME="$config_home" \
+        ABLETON_CONFIG_FILE="$config_file" \
+        bash -c '
+            set -euo pipefail
+            . "$1/lib/config.sh"
+            ABLETON_CONFIG_LAYOUT_ROOTS=none
+            export ABLETON_CONFIG_LAYOUT_ROOTS
+            ableton_config_init repair
+            ableton_write_config
+        ' _ "$here" > "$base/out" 2> "$base/err"; then
+        fail "$overlap_kind settings destination was written under the Wine runtime"
+    fi
+    [ ! -e "$config_file" ] && [ ! -L "$config_file" ] \
+        || fail "$overlap_kind settings refusal changed the Wine runtime"
+done
+ok "settings writes enforce their concrete layout at point of use"
+
+# A stale regular transactions child is project-owned after the exact state
+# marker is verified. Replace it, while refusing a child symlink or unmarked
+# state without touching either foreign object.
+base="$(new_env transaction-child)"
+state="$base/state/ableton-wine"
+mkdir -p -- "$state"
+printf 'format=1\nowner=ableton-linux\n' > "$state/.ableton-linux-state"
+printf 'stale project work file\n' > "$state/transactions"
+run_isolated "$base" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ABLETON_CONFIG_LAYOUT_ROOTS=none
+    export ABLETON_CONFIG_LAYOUT_ROOTS
+    ableton_config_init repair
+    ableton_prepare_transactions_dir
+    [ -d "$ABLETON_STATE_HOME/transactions" ]
+    [ ! -L "$ABLETON_STATE_HOME/transactions" ]
+' _ "$here" || fail "owned stale transaction file was not repaired"
+
+rmdir -- "$state/transactions"
+printf 'foreign transaction target\n' > "$base/foreign-transactions"
+ln -s -- "$base/foreign-transactions" "$state/transactions"
+if run_isolated "$base" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ABLETON_CONFIG_LAYOUT_ROOTS=none
+    export ABLETON_CONFIG_LAYOUT_ROOTS
+    ableton_config_init repair
+    ableton_prepare_transactions_dir
+' _ "$here" > "$base/symlink.out" 2> "$base/symlink.err"; then
+    fail "transaction-directory repair followed or replaced a symlink"
+fi
+[ -L "$state/transactions" ] \
+    && grep -qxF 'foreign transaction target' "$base/foreign-transactions" \
+    || fail "transaction-directory refusal changed a symlink or its target"
+
+base="$(new_env unowned-transaction-child)"
+state="$base/state/ableton-wine"
+mkdir -p -- "$state"
+printf 'foreign transaction file\n' > "$state/transactions"
+if run_isolated "$base" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ABLETON_CONFIG_LAYOUT_ROOTS=none
+    export ABLETON_CONFIG_LAYOUT_ROOTS
+    ableton_config_init repair
+    ableton_prepare_transactions_dir
+' _ "$here" > "$base/out" 2> "$base/err"; then
+    fail "transaction-directory repair claimed unmarked state"
+fi
+grep -qxF 'foreign transaction file' "$state/transactions" \
+    || fail "transaction-directory refusal changed unmarked state"
+ok "stale transaction files are repaired only beneath exactly owned state"
+
+# Link-only installation writes data and state. Foreign objects at the runtime,
+# prefix, installer-settings, and command roots are unrelated and must survive.
+base="$(new_env link-destination-scope)"
+for root_name in runtime prefix config bin; do
+    printf 'foreign %s root\n' "$root_name" > "$base/foreign-$root_name"
+done
+run_isolated "$base" env \
+    ABLETON_WINE_ROOT="$base/foreign-runtime" \
+    ABLETON_WINEPREFIX="$base/foreign-prefix" \
+    ABLETON_CONFIG_HOME="$base/foreign-config" \
+    ABLETON_BIN_HOME="$base/foreign-bin" \
+    bash "$here/install.sh" --link-assets-only \
+    > "$base/out" 2> "$base/err" \
+    || { sed -n '1,40p' "$base/err" >&2; fail "unrelated roots blocked Link-file installation"; }
+for root_name in runtime prefix config bin; do
+    grep -qxF "foreign $root_name root" "$base/foreign-$root_name" \
+        || fail "Link-file installation changed the unrelated $root_name root"
+done
+[ -x "$base/data/ableton-wine/ableton-linkctl" ] \
+    && [ -x "$base/data/ableton-wine/setup-link.sh" ] \
+    || fail "Link-file installation did not publish its selected destinations"
+ok "Link-only installation validates only its data and state destinations"
+
+printf '1..%d\n' "$pass"

--- a/scripts/test-desktop-integration.sh
+++ b/scripts/test-desktop-integration.sh
@@ -36,7 +36,7 @@ new_env()
 
 install_fake_desktop_tools()
 {
-    local base="$1"
+    local base="$1" probe
     cat > "$base/fakebin/xdg-mime" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -73,7 +73,13 @@ EOF
 exit 0
 EOF
     done
-    chmod +x "$base/fakebin/"*
+    probe="$base/home/.local/opt/wine-d2d1-nspa-11.13/bin/pipewire-version-probe"
+    mkdir -p -- "$(dirname "$probe")"
+    cat > "$probe" <<'EOF'
+#!/bin/sh
+printf 'client=1.4.2\ndaemon=1.4.2\n'
+EOF
+    chmod +x "$base/fakebin/"* "$probe"
 }
 
 run_isolated()

--- a/scripts/test-desktop-integration.sh
+++ b/scripts/test-desktop-integration.sh
@@ -55,6 +55,10 @@ case "${1:-}" in
         done ;;
     query)
         [ "${2:-}" = default ] && [ "$#" -eq 3 ]
+        if [ "${ABLETON_TEST_XDG_QUERY_FAIL:-0}" -eq 1 ]; then
+            printf 'fake MIME default query failure\n' >&2
+            exit 93
+        fi
         if [ "${ABLETON_TEST_XDG_STICKY:-0}" -eq 1 ]; then
             printf 'foreign.desktop\n'
         else
@@ -127,22 +131,41 @@ EOF
         >"$base/out" 2>"$base/err"; then
         fail "launcher accepts live-options.sh without $missing_live_options_function"
     fi
-    grep -q 'live-options.sh helper is missing or incomplete' "$base/err" \
-        || fail "launcher does not name its incomplete audio settings helper"
+    grep -q 'support files are incomplete. Run the latest installer again.' "$base/err" \
+        || fail "launcher does not explain how to repair incomplete support files"
 done
-ok "launcher requires every audio thread calculation helper"
+ok "launcher gives one repair instruction for incomplete support files"
 
 base="$(new_env unique-handlers)"
 install_fake_desktop_tools "$base"
-mkdir -p -- "$base/data/applications"
+state="$base/state/ableton-wine"
+legacy_handler="$base/data/applications/wine-protocol-ableton.desktop"
+private_support="$base/data/ableton-wine/setup-realtime.sh"
+mkdir -p -- "$base/data/applications" "$(dirname "$private_support")" \
+    "$state/install-prestate"
+printf 'older generated support bytes\n' > "$private_support"
 cat > "$base/data/applications/wine-protocol-ableton.desktop" <<EOF
 [Desktop Entry]
+Type=Application
+Name=Ableton URL Handler
 Exec=$base/home/.local/bin/ableton-live %u
+NoDisplay=true
+MimeType=x-scheme-handler/ableton;
 EOF
 cat > "$base/data/applications/wine-extension-auz.desktop" <<'EOF'
 [Desktop Entry]
 Exec=env WINEPREFIX=/tmp/foreign wine start %f
 EOF
+# Repair installs must identify the legacy handler from its exact generated
+# shape, not from old uninstall inventory. Deliberately leave both historical
+# state files unusable and make sure neither can veto or redirect the repair.
+printf 'format=1\nowner=ableton-linux\n' > "$state/.ableton-linux-state"
+printf 'malformed legacy ownership row\n' > "$state/install-manifest.tsv"
+printf 'present\t%s\t/tmp/untrusted-handler-backup\n' "$legacy_handler" \
+    > "$state/install-prestate.tsv"
+printf 'stale backup sentinel\n' > "$state/install-prestate/not-a-valid-slot"
+chmod 600 "$state/.ableton-linux-state" "$state/install-manifest.tsv" \
+    "$state/install-prestate.tsv"
 if ! run_isolated "$base" bash "$here/install.sh" --integration-only >"$base/out" 2>"$base/err"; then
     cat "$base/err" >&2
     fail "installer cannot install desktop integration in an isolated home"
@@ -151,10 +174,14 @@ fi
 [ -f "$base/data/applications/$auz_id" ] || fail "installer omits the project AUZ handler"
 [ -f "$base/data/ableton-wine/$protocol_id" ] || fail "installer omits the staged protocol handler"
 [ -f "$base/data/ableton-wine/$auz_id" ] || fail "installer omits the staged AUZ handler"
+cmp -s -- "$here/setup-realtime.sh" "$private_support" \
+    || fail "damaged optional bookkeeping blocked private support-file repair"
 [ ! -e "$base/data/applications/wine-protocol-ableton.desktop" ] \
     || fail "installer keeps its globally named legacy protocol handler"
 [ -f "$base/data/applications/wine-extension-auz.desktop" ] \
     || fail "installer removes a foreign globally named handler"
+grep -qxF 'stale backup sentinel' "$state/install-prestate/not-a-valid-slot" \
+    || fail "legacy handler repair consumed unrelated stale recovery data"
 [ "$(awk -F '\t' '$1 == "x-scheme-handler/ableton" { print $2 }' "$base/mime-defaults.tsv")" = "$protocol_id" ] \
     || fail "installer does not pin the project protocol handler"
 [ "$(awk -F '\t' '$1 == "application/x-wine-extension-auz" { print $2 }' "$base/mime-defaults.tsv")" = "$auz_id" ] \
@@ -221,17 +248,189 @@ if legacy_ntsync_owned; then
 fi
 ok "legacy ownership recognises both project NTSync diagnostic generations"
 
-base="$(new_env registration-failure)"
+base="$(new_env mime-query-ignored)"
 install_fake_desktop_tools "$base"
-if run_isolated "$base" env ABLETON_TEST_XDG_STICKY=1 \
-    bash "$here/install.sh" --integration-only >"$base/out" 2>"$base/err"; then
-    fail "installer accepts a handler default that did not stick"
+printf 'application/x-unrelated\tforeign.desktop\n' > "$base/mime-defaults.tsv"
+query_status=0
+run_isolated "$base" env ABLETON_TEST_XDG_QUERY_FAIL=1 \
+    ABLETON_INTERNAL_OPTIONAL_STATUS=1 \
+    bash "$here/install.sh" --integration-only >"$base/out" 2>"$base/err" \
+    || query_status=$?
+[ "$query_status" -eq 0 ] \
+    || fail "MIME default query failure produced an internal retry status"
+! grep -qF 'fake MIME default query failure' "$base/err" \
+    || fail "installer queried MIME defaults after publishing them"
+! grep -qF 'Some shortcuts or support files could not be updated.' "$base/err" \
+    || fail "MIME default query failure produced an alarming retry warning"
+[ -f "$base/data/applications/$protocol_id" ] \
+    || fail "MIME default query failure blocked the protocol handler"
+[ -x "$base/home/.local/bin/ableton-live" ] \
+    || fail "MIME default query failure blocked the generated launcher"
+grep -qxF $'application/x-unrelated\tforeign.desktop' "$base/mime-defaults.tsv" \
+    || fail "MIME default publication corrupted an unrelated default"
+grep -qxF $'x-scheme-handler/ableton\tio.github.shibco.ableton-linux.protocol.desktop' \
+    "$base/mime-defaults.tsv" || fail "MIME default was not published before verification was skipped"
+ok "MIME defaults are published without a redundant query failure gate"
+
+optional_real_mv="$(command -v mv)"
+
+base="$(new_env optional-version-warning)"
+install_fake_desktop_tools "$base"
+cat > "$base/fakebin/mv" <<EOF
+#!/bin/sh
+last=""
+for argument do last="\$argument"; done
+[ "\$last" != "\${ABLETON_TEST_FAIL_TARGET:-}" ] || exit 88
+exec "$optional_real_mv" "\$@"
+EOF
+chmod 755 "$base/fakebin/mv"
+txn="$base/parent-transaction"
+mkdir -p -- "$txn"
+run_isolated "$base" env \
+    ABLETON_TEST_FAIL_TARGET="$base/data/ableton-wine/VERSION" \
+    bash "$here/install.sh" --integration-only --transaction-dir "$txn" \
+    >"$base/out" 2>"$base/err" \
+    || fail "optional version failure aborted a parent-owned integration phase"
+[ -x "$base/home/.local/bin/ableton-live" ] \
+    || fail "optional version failure rolled back the generated launcher"
+grep -qF 'Ableton was installed, but its support files could not be fully updated.' \
+    "$base/err" || fail "optional version failure was not a plain warning"
+if grep -q '^OK:' "$base/out"; then
+    fail "parent-owned integration phase printed a child success line"
 fi
-grep -q "resolves to 'foreign.desktop'" "$base/err" \
-    || fail "installer does not report the handler that defeated registration"
-[ ! -e "$base/data/applications/$protocol_id" ] \
-    || fail "failed registration leaves the new protocol handler installed"
-ok "installer reports and rolls back a failed MIME default"
+run_isolated "$base" bash "$here/install.sh" --preflight-commit "$txn" \
+    >"$base/preflight.out" 2>"$base/preflight.err" \
+    || fail "optional version failure poisoned the parent commit check"
+ok "optional version failure warns without invalidating parent-owned generated files"
+
+base="$(new_env optional-file-list-warning)"
+install_fake_desktop_tools "$base"
+cat > "$base/fakebin/mv" <<EOF
+#!/bin/sh
+last=""
+for argument do last="\$argument"; done
+[ "\$last" != "\${ABLETON_TEST_FAIL_TARGET:-}" ] || exit 89
+exec "$optional_real_mv" "\$@"
+EOF
+chmod 755 "$base/fakebin/mv"
+run_isolated "$base" env \
+    ABLETON_TEST_FAIL_TARGET="$base/state/ableton-wine/install-manifest.tsv" \
+    bash "$here/install.sh" --integration-only >"$base/out" 2>"$base/err" \
+    || fail "installed-file list failure aborted generated integration"
+[ -x "$base/home/.local/bin/ableton-live" ] \
+    || fail "installed-file list failure rolled back the generated launcher"
+grep -qF 'Ableton was installed, but the installed-file list could not be updated.' \
+    "$base/err" || fail "installed-file list failure was not a plain warning"
+grep -qxF 'OK: Installation complete.' "$base/out" \
+    || fail "direct integration did not print its simple outcome"
+ok "installed-file list failure warns without invalidating generated files"
+
+base="$(new_env optional-cache-ignored)"
+install_fake_desktop_tools "$base"
+for tool in update-desktop-database update-mime-database; do
+    printf '#!/bin/sh\nprintf "fake cache refresh failure\\n" >&2\nexit 90\n' \
+        > "$base/fakebin/$tool"
+done
+cat > "$base/fakebin/gtk-update-icon-cache" <<'EOF'
+#!/bin/sh
+: > "${ABLETON_TEST_GTK_CALLED:?}"
+exit 90
+EOF
+chmod 755 "$base/fakebin/"*
+cache_status=0
+run_isolated "$base" env ABLETON_INTERNAL_OPTIONAL_STATUS=1 \
+    ABLETON_TEST_GTK_CALLED="$base/gtk-called" \
+    bash "$here/install.sh" --integration-only \
+    >"$base/out" 2>"$base/err" \
+    || cache_status=$?
+[ "$cache_status" -eq 0 ] \
+    || fail "desktop refresh failure produced an internal retry status"
+[ -x "$base/home/.local/bin/ableton-live" ] \
+    || fail "desktop refresh failure blocked the generated launcher"
+! grep -qF 'fake cache refresh failure' "$base/err" \
+    || fail "desktop refresh tool leaked alarming output"
+[ ! -e "$base/gtk-called" ] \
+    || fail "desktop integration invoked gtk-update-icon-cache"
+! grep -qF 'Some shortcuts or support files could not be updated.' "$base/err" \
+    || fail "desktop refresh failure produced an alarming retry warning"
+grep -qxF 'OK: Installation complete.' "$base/out" \
+    || fail "desktop refresh failure hid the successful install outcome"
+ok "desktop database refresh is silent best-effort work and GTK cache generation is skipped"
+
+base="$(new_env generated-file-publication-status)"
+install_fake_desktop_tools "$base"
+cat > "$base/fakebin/mv" <<EOF
+#!/bin/sh
+last=""
+for argument do last="\$argument"; done
+[ "\$last" != "\${ABLETON_TEST_FAIL_TARGET:-}" ] || exit 94
+exec "$optional_real_mv" "\$@"
+EOF
+chmod 755 "$base/fakebin/mv"
+publication_status=0
+run_isolated "$base" env \
+    ABLETON_TEST_FAIL_TARGET="$base/home/.local/bin/ableton-live" \
+    ABLETON_INTERNAL_OPTIONAL_STATUS=1 \
+    bash "$here/install.sh" --integration-only >"$base/out" 2>"$base/err" \
+    || publication_status=$?
+[ "$publication_status" -eq 3 ] \
+    || fail "generated launcher publication failure lost its internal retry status"
+[ ! -e "$base/home/.local/bin/ableton-live" ] \
+    || fail "failed generated launcher publication reported a usable launcher"
+grep -qF 'Some shortcuts or support files could not be updated. Run the installer again to retry them.' \
+    "$base/err" || fail "generated launcher publication failure omitted its retry warning"
+ok "generated-file publication failures still request a repair run"
+
+optional_real_rm="$(command -v rm)"
+for optional_mode in integration link; do
+    for cleanup_failure in active directory; do
+        base="$(new_env "optional-final-cleanup-$optional_mode-$cleanup_failure")"
+        install_fake_desktop_tools "$base"
+        cat > "$base/fakebin/rm" <<EOF
+#!/bin/sh
+for argument do
+    case "\${ABLETON_TEST_CLEANUP_FAILURE:-}:\$argument" in
+        active:*/tmp/ableton-install-plan.*/active) exit 91 ;;
+        directory:*/tmp/ableton-install-plan.*) exit 92 ;;
+    esac
+done
+exec "$optional_real_rm" "\$@"
+EOF
+        chmod 755 "$base/fakebin/rm"
+        case "$optional_mode" in
+            integration) selection=--integration-only ;;
+            link) selection=--link-assets-only ;;
+        esac
+        run_isolated "$base" env ABLETON_TEST_CLEANUP_FAILURE="$cleanup_failure" \
+            bash "$here/install.sh" "$selection" >"$base/out" 2>"$base/err" \
+            || fail "$optional_mode $cleanup_failure cleanup failure rejected usable generated files"
+        case "$optional_mode" in
+            integration)
+                [ -x "$base/home/.local/bin/ableton-live" ] \
+                    || fail "integration cleanup warning rolled back the generated launcher" ;;
+            link)
+                [ -x "$base/data/ableton-wine/ableton-linkctl" ] \
+                    && [ -x "$base/data/ableton-wine/setup-link.sh" ] \
+                    || fail "Link cleanup warning rolled back generated Link files" ;;
+        esac
+        case "$cleanup_failure" in
+            active)
+                grep -qF "Ableton's files are ready, but the installer could not finish its final housekeeping." \
+                    "$base/err" || fail "$optional_mode active cleanup failure was not a plain warning" ;;
+            directory)
+                grep -qF 'Installed files are ready, but temporary installer data remains at ' \
+                    "$base/err" || fail "$optional_mode directory cleanup failure was not a plain warning" ;;
+        esac
+        grep -qxF 'OK: Installation complete.' "$base/out" \
+            || fail "$optional_mode direct call did not print its simple outcome"
+        if [ -d "$base/state/ableton-wine/transactions" ] \
+           && find "$base/state/ableton-wine/transactions" -mindepth 1 -print -quit \
+                | grep -q .; then
+            fail "$optional_mode direct cleanup left a persistent core-recovery record"
+        fi
+    done
+done
+ok "integration and Link activity/directory cleanup failures warn after generated files are usable"
 
 base="$(new_env callback-discovery)"
 install_fake_desktop_tools "$base"
@@ -290,6 +489,7 @@ EOF
 mkdir -p -- "$base/nix/libexec/lib" "$base/runtime/share/ableton-wine/scripts"
 cp -- "$here/ableton-live" "$base/nix/libexec/ableton-live"
 cp -- "$here/lib/config.sh" "$here/lib/lifecycle.sh" "$here/lib/live-options.sh" \
+    "$here/lib/manifest.sh" \
     "$base/nix/libexec/lib/"
 cat > "$base/runtime/share/ableton-wine/scripts/audio-report.sh" <<'EOF'
 #!/bin/sh
@@ -307,7 +507,10 @@ run_isolated "$base" env USER=test ABLETON_MAX_AUDIO_THREADS=auto ABLETON_POWER=
     ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$base/nix/libexec/ableton-live" \
     'ableton://invalid-ableton-linux-probe' >"$base/nix.out" 2>"$base/nix.err" || true
 grep -qF "Run $base/runtime/share/ableton-wine/scripts/audio-report.sh to review the CPU details" \
-    "$base/nix.err" || fail "The Nix launcher fallback does not name its packaged audio report."
+    "$base/nix.err" || {
+        sed -n '1,80p' "$base/nix.err" >&2
+        fail "The Nix launcher fallback does not name its packaged audio report."
+    }
 cat > "$base/fakebin/nproc" <<'EOF'
 #!/bin/sh
 [ "$#" -eq 0 ] || exit 2

--- a/scripts/test-installer-lifecycle.sh
+++ b/scripts/test-installer-lifecycle.sh
@@ -282,6 +282,29 @@ grep -qF 'Max preferences moved aside' "$base/out" \
     || fail "public Live 11 repair created persistent state solely to lock"
 ok "public Live 11 repair honors the selected prefix without Wine or PipeWire"
 
+# Progress output is presentation, not part of the repair. GNU mv -v reports to
+# stdout after each successful move; a closed consumer used to turn that into a
+# false failure and stop before repairing the next user's preference file.
+base="$(new_env live11-repair-closed-output)"
+for repair_user in one two; do
+    max_settings="$base/prefix/drive_c/users/$repair_user/AppData/Roaming/Cycling '74/Max 8/Settings"
+    mkdir -p -- "$max_settings"
+    printf 'stale preferences for %s\n' "$repair_user" \
+        > "$max_settings/maxpreferences.maxpref"
+done
+printf 'WINE REGISTRY Version 2\n' > "$base/prefix/system.reg"
+printf 'format=1\nprefix=%s\n' "$base/prefix" > "$base/prefix/.ableton-linux-prefix"
+run_isolated "$base" bash "$here/installer.sh" prefix repair-live11 \
+    --prefix "$base/prefix" > /dev/full 2> "$base/err" \
+    || fail "closed progress output changed a completed Live 11 repair into failure"
+for repair_user in one two; do
+    max_settings="$base/prefix/drive_c/users/$repair_user/AppData/Roaming/Cycling '74/Max 8/Settings"
+    [ ! -e "$max_settings/maxpreferences.maxpref" ] \
+        && compgen -G "$max_settings/maxpreferences.maxpref.bak-*" >/dev/null \
+        || fail "closed output stopped Live 11 repair before every preference file was moved"
+done
+ok "Live 11 repair completes every safe move when progress output is closed"
+
 base="$(new_env maintenance-architecture)"
 mkdir -p "$base/fakebin"
 cat > "$base/fakebin/uname" <<'EOF'
@@ -351,20 +374,96 @@ ok "resolved XDG roots use real target directories without replacing parent syml
 base="$(new_env run-header)"
 kit="$base/kit"
 mkdir -p "$kit/scripts"
-printf '#!/bin/sh\nexit "${STUB_EXIT:-0}"\n' > "$kit/scripts/installer.sh"
+printf '#!/bin/sh\nprintf "%%s\\n" "${ABLETON_INSTALLER_PATH:-}" > "${STUB_PATH_FILE:?}"\nexit "${STUB_EXIT:-0}"\n' \
+    > "$kit/scripts/installer.sh"
 tar -cf "$base/payload.tar" -C "$kit" .
 sed -e 's/@VERSION@/suite-check/g' \
     -e "s/@PAYLOAD_SHA@/$(sha256sum "$base/payload.tar" | awk '{print $1}')/g" \
     "$here/setup-run-header.sh" > "$base/kit.run"
 cat "$base/payload.tar" >> "$base/kit.run"
-run_isolated "$base" env STUB_EXIT=0 sh "$base/kit.run" >"$base/out" 2>"$base/err" \
+run_isolated "$base" env STUB_EXIT=0 STUB_PATH_FILE="$base/installer-path" \
+    sh "$base/kit.run" >"$base/out" 2>"$base/err" \
     || fail "a successful delegated install exits zero through the .run header"
 status=0
-run_isolated "$base" env STUB_EXIT=42 sh "$base/kit.run" >>"$base/out" 2>>"$base/err" || status=$?
+run_isolated "$base" env STUB_EXIT=42 STUB_PATH_FILE="$base/installer-path" \
+    sh "$base/kit.run" >>"$base/out" 2>>"$base/err" || status=$?
 [ "$status" -eq 42 ] || fail "a delegated install failure code passes through the .run header"
+[ "$(cat "$base/installer-path")" = "$(readlink -f -- "$base/kit.run")" ] \
+    || fail "the .run header does not pass its reusable path to the installer"
 ! find "$base/tmp" -mindepth 1 -maxdepth 1 -name 'ableton-installer.*' 2>/dev/null | grep -q . \
     || fail "the .run header removes its work directory"
 ok "the .run header propagates the delegated installer exit code"
+
+# Extraction has completed once the files are copied. A closed output stream
+# must not reverse that result or prevent any of the transport work that precedes
+# the final success line.
+base="$(new_env run-header-extract-output)"
+run_isolated "$base" sh "$work/run-header/kit.run" extract "$base/extracted" \
+    > /dev/full 2> "$base/err" \
+    || fail "closed output changed a completed .run extraction into failure"
+[ -f "$base/extracted/scripts/installer.sh" ] \
+    || fail "closed output prevented the .run kit from being extracted"
+ok "the .run header preserves a successful extraction when output is closed"
+
+# GNU tar's progress dots go to stderr. Once tar has succeeded, even the
+# separating newline is presentation: a broken diagnostic consumer must not
+# stop extract before the verified kit is copied to its destination.
+base="$(new_env run-header-extract-stderr)"
+mkdir -p "$base/fakebin"
+cat > "$base/fakebin/dd" <<'EOF'
+#!/bin/sh
+[ "${1:-}" != --help ] || exit 0
+exec /usr/bin/dd "$@"
+EOF
+cat > "$base/fakebin/tar" <<'EOF'
+#!/bin/sh
+if [ "${1:-}" = --help ]; then
+    echo --checkpoint
+    exit 0
+fi
+[ "${1:-}" != --checkpoint=200 ] || shift
+[ "${1:-}" != --checkpoint-action=dot ] || shift
+exec /usr/bin/tar "$@"
+EOF
+chmod +x "$base/fakebin/dd" "$base/fakebin/tar"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    sh "$work/run-header/kit.run" extract "$base/extracted" \
+    > "$base/out" 2> /dev/full \
+    || fail "closed diagnostic output changed a completed .run extraction into failure"
+[ -f "$base/extracted/scripts/installer.sh" ] \
+    || fail "closed diagnostic output stopped the .run kit before its destination copy"
+ok "the .run header preserves extraction after checkpoint output closes"
+
+# A completed install stays successful even when temporary-file cleanup cannot
+# remove its work directory and the warning cannot be written.  Keep the
+# transport quiet until that cleanup path so /dev/full tests the final warning,
+# not extraction progress from dd or tar.
+base="$(new_env run-header-cleanup-output)"
+mkdir -p "$base/fakebin"
+cat > "$base/fakebin/dd" <<'EOF'
+#!/bin/sh
+[ "${1:-}" != --help ] || exit 0
+exec /usr/bin/dd "$@"
+EOF
+cat > "$base/fakebin/tar" <<'EOF'
+#!/bin/sh
+[ "${1:-}" != --help ] || exit 0
+exec /usr/bin/tar "$@"
+EOF
+cat > "$base/fakebin/rm" <<'EOF'
+#!/bin/sh
+[ "${1:-}" != -rf ] || exit 1
+exec /usr/bin/rm "$@"
+EOF
+chmod +x "$base/fakebin/dd" "$base/fakebin/tar" "$base/fakebin/rm"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" STUB_EXIT=0 \
+    STUB_PATH_FILE="$base/installer-path" sh "$work/run-header/kit.run" \
+    >"$base/out" 2>/dev/full \
+    || fail "cleanup output failure changed a successful .run result"
+find "$base/tmp" -mindepth 1 -maxdepth 1 -name 'ableton-installer.*' \
+    -type d -print -quit | grep -q . \
+    || fail "the cleanup-output fixture did not leave its temporary directory"
+ok "the .run header preserves success when cleanup output fails"
 
 base="$(new_env noninteractive)"
 if run_isolated "$base" bash "$here/installer.sh" >"$base/out" 2>"$base/err"; then
@@ -390,23 +489,24 @@ fi
 [ ! -e "$base/config" ] && [ ! -e "$base/state" ] || fail "duplicate-option failure mutates state"
 run_isolated "$base" bash "$here/installer.sh" --prefix --uninstall --dry-run \
     >"$base/legacy.out" 2>"$base/legacy.err"
-grep -q 'delete validated prefix' "$base/legacy.out" \
+grep -q 'delete the Wine prefix, including Live and its authorisation' "$base/legacy.out" \
     || fail "legacy uninstall prefix alias depends on argument order"
 ok "immutable options reject duplicates and legacy parsing is order-independent"
 
-base="$(new_env early-transaction-cleanup)"
+base="$(new_env unrelated-config-path)"
 mkdir -p "$base/config/pipeasio/config.ini"
-if run_isolated "$base" bash "$here/installer.sh" link disable \
-    >"$base/out" 2>"$base/err"; then
-    fail "unsafe pre-transaction configuration is accepted"
-fi
+run_isolated "$base" bash "$here/installer.sh" link disable \
+    >"$base/out" 2>"$base/err" \
+    || fail "an unrelated PipeASIO configuration path blocks Link disable"
 if find "$base/state/ableton-wine/transactions" -mindepth 1 -maxdepth 1 \
     -name 'installer.*' -print -quit 2>/dev/null | grep -q .; then
-    fail "a failure before transaction handlers are installed leaks its directory"
+    fail "successful Link disable leaks its temporary recovery directory"
 fi
-grep -qF 'current PipeASIO configuration is unsafe' "$base/err" \
-    || fail "early transaction refusal does not name the unsafe configuration"
-ok "failures during initial snapshots retire the unstarted transaction"
+[ -d "$base/config/pipeasio/config.ini" ] \
+    || fail "Link disable changed an unrelated PipeASIO configuration path"
+grep -qF 'OK: Ableton Link is off' "$base/out" \
+    || fail "successful Link disable does not report its outcome"
+ok "Link disable preserves unrelated configuration and retires temporary recovery data"
 
 base="$(new_env link-snapshot-cleanup)"
 mkdir -p "$base/data/ableton-wine" "$base/state/ableton-wine" \
@@ -448,10 +548,10 @@ ok "failed Link snapshots never publish or retain incomplete recovery state"
 
 base="$(new_env runtime-plan)"
 run_isolated "$base" bash "$here/installer.sh" --runtime-only --runtime-root "$base/runtime" --dry-run >"$base/out" 2>"$base/err"
-grep -q 'replace runtime tree atomically' "$base/out" || fail "runtime plan contains runtime"
-! grep -q 'write launcher:' "$base/out" || fail "runtime plan excludes integration"
-! grep -q 'write Link binary:' "$base/out" || fail "runtime plan excludes Link"
-grep -q 'apply the runtime PipeASIO panel record to existing launchers' "$base/out" \
+grep -q 'install or update Wine' "$base/out" || fail "runtime plan contains runtime"
+! grep -q 'install or update launchers' "$base/out" || fail "runtime plan excludes integration"
+! grep -q 'Ableton Link support' "$base/out" || fail "runtime plan excludes Link"
+grep -q 'update PipeASIO Settings shortcuts to match this Wine build' "$base/out" \
     || fail "runtime plan describes PipeASIO launcher reconciliation"
 [ ! -e "$base/runtime" ] && [ ! -e "$base/config" ] && [ ! -e "$base/state" ] || fail "runtime plan mutates no target"
 ok "runtime-only plan contains only the runtime component"
@@ -485,9 +585,9 @@ ok "runtime-only rejects unrelated Link options before mutation"
 
 base="$(new_env compat-plan)"
 run_isolated "$base" bash "$here/installer.sh" --no-launch --dry-run >"$base/out" 2>"$base/err"
-grep -q 'write launcher:' "$base/out" || fail "no-launch still means skip Live payload only"
-grep -q 'final Link policy: off' "$base/out" || fail "no-launch defaults Link off"
-! grep -Eq 'write Link binary:|write Link controller/setup/unit assets:' "$base/out" \
+grep -q 'install or update launchers' "$base/out" || fail "no-launch still means skip Live payload only"
+grep -q 'set Ableton Link mode: off' "$base/out" || fail "no-launch defaults Link off"
+! grep -Eq 'install or update Ableton Link support|use the configured Ableton Link helper' "$base/out" \
     || fail "no-launch unexpectedly stages Link assets"
 ! grep -Eq 'write ownership-marked user unit|launchers start session daemon|enable/start the owned user unit' "$base/out" \
     || fail "no-launch plans a Link service action"
@@ -507,8 +607,8 @@ link_mode=off
 linkd=$base/data/ableton-wine/ableton-linkd
 EOF
 run_isolated "$base" env ABLETON_DPI_MODE=preserve bash "$here/installer.sh" update --dry-run >"$base/out" 2>"$base/err"
-grep -q 'final Link policy: off' "$base/out" || fail "update preserves Link opt-out"
-! grep -q 'write Link binary:' "$base/out" || fail "opted-out update excludes Link assets"
+grep -q 'set Ableton Link mode: off' "$base/out" || fail "update preserves Link opt-out"
+! grep -q 'Ableton Link support' "$base/out" || fail "opted-out update excludes Link assets"
 ok "update preserves the persistent Link opt-out"
 
 base="$(new_env update-no-prefix)"
@@ -630,6 +730,9 @@ cat > "$kit/scripts/install.sh" <<'EOF'
 #!/bin/sh
 set -eu
 printf 'component %s\n' "$*" >> "${ABLETON_TEST_CALL_LOG:?}"
+case " $* " in
+    *' --commit '*) exit "${ABLETON_TEST_COMPONENT_COMMIT_EXIT:-0}" ;;
+esac
 exit 0
 EOF
 cat > "$kit/scripts/setup-prefix.sh" <<'EOF'
@@ -637,7 +740,9 @@ cat > "$kit/scripts/setup-prefix.sh" <<'EOF'
 set -eu
 printf 'prefix %s\n' "$*" >> "${ABLETON_TEST_CALL_LOG:?}"
 case " $* " in
-    *' --preflight-commit '*|*' --commit '*|*' --preflight-rollback '*|*' --rollback '*) exit 0 ;;
+    *' --preflight-commit '*|*' --preflight-rollback '*) exit 0 ;;
+    *' --commit '*) exit "${ABLETON_TEST_PREFIX_COMMIT_EXIT:-0}" ;;
+    *' --rollback '*) rm -rf -- "${ABLETON_WINEPREFIX:?}"; exit 0 ;;
 esac
 mkdir -p -- "${ABLETON_WINEPREFIX:?}"
 printf 'registry\n' > "${ABLETON_WINEPREFIX}/system.reg"
@@ -650,6 +755,15 @@ EOF
 cat > "$base/runtime/bin/wine" <<'EOF'
 #!/bin/sh
 printf 'wine %s\n' "$*" >> "${ABLETON_TEST_CALL_LOG:?}"
+case "$*" in
+    *'Ableton Live 12 Suite Installer.exe'*)
+        if [ "${ABLETON_TEST_SKIP_LIVE_EXE:-0}" -eq 0 ]; then
+            live_dir="${WINEPREFIX:?}/drive_c/ProgramData/Ableton/Live 12 Suite/Program"
+            mkdir -p -- "$live_dir"
+            printf 'exe\n' > "$live_dir/Ableton Live 12 Suite.exe"
+        fi ;;
+esac
+exit 0
 EOF
 cat > "$base/runtime/bin/wineserver" <<'EOF'
 #!/bin/sh
@@ -663,25 +777,43 @@ printf 'Ableton Live 12 Suite Installer\n' > "$base/Ableton Live 12 Suite Instal
 
 run_payload_install()
 {
+    local payload="$base/Ableton Live 12 Suite Installer.exe"
+    if [ "${1:-}" = --payload ]; then
+        payload="$2"
+        shift 2
+    fi
     : > "$base/calls.log"
     rm -rf -- "$base/prefix" "$base/config" "$base/state" "$base/data"
     run_isolated "$base" env ABLETON_TEST_CALL_LOG="$base/calls.log" "$@" \
         bash "$kit/scripts/installer.sh" install \
-            --live-installer "$base/Ableton Live 12 Suite Installer.exe" \
+            --live-installer "$payload" \
             --link=off --runtime-root "$base/runtime" --prefix "$base/prefix" --yes \
         >"$base/out" 2>"$base/err"
 }
 
 # 124 is timeout's TERM verdict: the wait ran out with a process still in the prefix.
 run_payload_install ABLETON_TEST_WAIT_EXIT=124 || fail "an expired payload wait fails the install"
-grep -q 'OK: install completed' "$base/out" || fail "an expired payload wait leaves the install incomplete"
+grep -q 'OK: Ableton Live 12 is installed' "$base/out" \
+    || fail "an expired payload wait leaves the install incomplete"
 ! grep -q 'wineserver -k' "$base/calls.log" || fail "the payload step stops the promoted prefix"
-grep -q 'the install is complete' "$base/out" || fail "an expired payload wait goes unreported"
+grep -q 'The Live installer finished; a background program is still using its Wine prefix' "$base/out" \
+    || fail "an expired payload wait goes unreported"
 grep -qF -- "$base/runtime/bin/wineserver -k" "$base/out" \
     || fail "the report withholds the command that ends the prefix"
 ! grep -q 'End every program' "$base/out" "$base/err" \
     || fail "a non-interactive install offers to end the prefix"
 ok "an expired payload wait reports the straggler, stops nothing, and still completes"
+
+run_payload_install ABLETON_TEST_WAIT_EXIT=127 \
+    || fail "an unavailable post-install Wine check fails a validated Live install"
+grep -q 'OK: Ableton Live 12 is installed' "$base/out" \
+    || fail "an unavailable post-install Wine check hides the completed install"
+grep -q 'Live is installed, but Wine could not be checked afterward (exit 127)' "$base/err" \
+    || fail "an unavailable post-install Wine check was not reported as advisory"
+if grep -Eq -- '--rollback |^component --rollback |^prefix --rollback ' "$base/calls.log"; then
+    fail "an unavailable post-install Wine check rolled back validated Live files"
+fi
+ok "every post-install Wine wait failure is advisory after Live validation"
 
 for image in AbletonPushCpl.exe tusbaudiocplapp.exe AbletonAudioCpl.exe MicrosoftEdgeUpdate.exe; do
     grep -qF "/im $image" "$base/calls.log" \
@@ -710,62 +842,160 @@ grep -q 'some-daw.exe (pid' "$base/out" || fail "the payload step does not name 
 ok "a program in the prefix is named at the end of an install, and --yes does not end it"
 
 run_payload_install || fail "a quiet payload wait fails the install"
-! grep -q 'the install is complete\.' "$base/out" || fail "a quiet prefix is reported as busy"
+! grep -q 'The Live installer finished' "$base/out" || fail "a quiet prefix is reported as busy"
 ok "a quiet prefix after the payload reports nothing"
 
-# Link setup runs after the Live payload. An expired sudo prompt stops the
-# firewall step. The installer must preserve Live. It must show the command that
-# resumes Link setup. Ctrl-C sends SIGINT while the installer waits. The Link
-# process then exits with status 130.
+# The coordinator does not extract Visual C++ cabinets itself. The prefix path
+# that actually needs cabextract owns that dependency check; another selected
+# prefix implementation must not be rejected by a redundant parent preflight.
+cat > "$base/no-cabextract.bash" <<'EOF'
+command()
+{
+    if [ "${1:-}" = -v ] && [ "${2:-}" = cabextract ]; then
+        return 1
+    fi
+    builtin command "$@"
+}
+EOF
+run_payload_install BASH_ENV="$base/no-cabextract.bash" \
+    || fail "the coordinator required cabextract before reaching the selected prefix path"
+grep -q 'OK: Ableton Live 12 is installed' "$base/out" \
+    || fail "the redundant cabextract preflight hid the completed install"
+ok "cabextract is checked only by the prefix extraction path that uses it"
+
+# Progress text and archive member listings are presentation, not install
+# postconditions. A failed progress write must not roll back the extracted and
+# validated Live payload.
+(
+    cd "$base"
+    python3 -m zipfile -c 'Ableton Live 12 Suite.zip' \
+        'Ableton Live 12 Suite Installer.exe'
+)
+cat > "$base/payload-progress-failure.bash" <<'EOF'
+echo()
+{
+    case "$*" in
+        --\ Extracting\ the\ Live\ installer\ \(*|--\ Running\ the\ Live\ installer\ \(*) return 74 ;;
+    esac
+    builtin echo "$@"
+}
+EOF
+run_payload_install --payload "$base/Ableton Live 12 Suite.zip" \
+    BASH_ENV="$base/payload-progress-failure.bash" \
+    || fail "failed Live progress output rolled back a valid ZIP installation"
+grep -q 'OK: Ableton Live 12 is installed' "$base/out" \
+    || fail "failed Live progress output hid the completed installation"
+if grep -Eq '(^|[[:space:]])(inflating:|extracting:|creating:)' "$base/out"; then
+    fail "Live ZIP extraction printed its archive member list"
+fi
+if grep -Eq -- '--rollback |^component --rollback |^prefix --rollback ' "$base/calls.log"; then
+    fail "failed Live progress output started core rollback"
+fi
+ok "Live ZIP extraction is quiet and progress output cannot gate valid work"
+
+# A successful Wine process is not proof that Live was installed. The selected
+# major must leave a regular executable in the promoted prefix before the core
+# work can commit.
+if run_payload_install ABLETON_TEST_SKIP_LIVE_EXE=1; then
+    fail "Wine exit 0 without a Live executable succeeds"
+fi
+grep -q 'exited without installing Ableton Live 12 in the selected prefix' "$base/err" \
+    || fail "missing Live executable failure does not name the unmet postcondition"
+if ! grep -q 'prefix --preflight-rollback ' "$base/calls.log" \
+   || ! grep -q 'component --preflight-rollback ' "$base/calls.log" \
+   || ! grep -q 'prefix --rollback ' "$base/calls.log" \
+   || ! grep -q 'component --rollback ' "$base/calls.log"; then
+    fail "missing Live executable does not roll back the core install"
+fi
+[ ! -e "$base/prefix" ] || fail "missing Live executable leaves the fresh prefix promoted"
+! grep -q '^OK:' "$base/out" || fail "missing Live executable reports success"
+ok "Wine exit 0 without the selected Live executable fails and rolls back"
+
+# Link setup runs after the core runtime, prefix, and Live installation commit.
+# Any Link failure keeps that usable core and reports a concrete retry command.
 cat > "$kit/scripts/setup-link.sh" <<'EOF'
 #!/bin/sh
 set -eu
 printf 'link %s\n' "$*" >> "${ABLETON_TEST_CALL_LOG:?}"
 [ "${1:-}" = enable ] || exit 0
-case "${ABLETON_TEST_LINK_ENABLE_EXIT:-0}" in
-    int) kill -INT "$PPID"; exit 130 ;;
-    *) exit "${ABLETON_TEST_LINK_ENABLE_EXIT:-0}" ;;
-esac
+exit "${ABLETON_TEST_LINK_ENABLE_EXIT:-0}"
 EOF
 run_failed_link_install()
 {
     : > "$base/calls.log"
     rm -rf -- "$base/prefix" "$base/config" "$base/state" "$base/data"
-    run_isolated "$base" env ABLETON_TEST_CALL_LOG="$base/calls.log" ABLETON_TEST_LINK_ENABLE_EXIT="$1" \
+    run_isolated "$base" env ABLETON_INSTALLER_PATH="$link_installer" \
+        ABLETON_TEST_CALL_LOG="$base/calls.log" ABLETON_TEST_LINK_ENABLE_EXIT="$1" \
         bash "$kit/scripts/installer.sh" install \
             --live-installer "$base/Ableton Live 12 Suite Installer.exe" \
             --link=always --runtime-root "$base/runtime" --prefix "$base/prefix" --yes \
         >"$base/out" 2>"$base/err"
 }
-run_failed_link_install 1 || fail "the install must finish after Link setup failure"
-grep -q 'OK: install completed' "$base/out" || fail "the output must confirm install completion"
-! grep -q 'prefix --rollback' "$base/calls.log" || fail "the installer must preserve the prefix"
-grep -qF 'Run this command to complete Link setup: installer link enable --mode=always' "$base/err" \
-    || fail "the output must include the Link recovery command and mode"
-grep -qF 'Link: setup stopped (run: installer link enable --mode=always)' "$base/out" \
-    || fail "the summary must report the stopped Link setup"
-ok "Link setup failure reports the resume command and preserves the install"
+link_installer="$base/Downloads/Ableton Installer.run"
+printf -v quoted_link_installer '%q' "$link_installer"
+link_resume_command="sh $quoted_link_installer link enable --mode=always"
+live_exe="$base/prefix/drive_c/ProgramData/Ableton/Live 12 Suite/Program/Ableton Live 12 Suite.exe"
+for link_failure in 1 70 75; do
+    run_failed_link_install "$link_failure" \
+        || fail "full install fails when Link exits $link_failure"
+    grep -q 'OK: Ableton Live 12 is installed' "$base/out" \
+        || fail "Link failure $link_failure hides the completed Live install"
+    [ -x "$base/runtime/bin/wine" ] && [ -f "$base/prefix/system.reg" ] \
+        && [ -f "$live_exe" ] \
+        || fail "Link failure $link_failure discards the runtime, prefix, or Live executable"
+    ! grep -q -- '--rollback' "$base/calls.log" \
+        || fail "Link failure $link_failure rolls back the completed core install"
+    grep -qF "Ableton Live 12 is installed, but Link could not be set up. Retry with: $link_resume_command" "$base/err" \
+        || fail "Link failure $link_failure omits the retry command and completed outcome"
+    grep -qF 'Link: unchanged; setup can be retried' "$base/out" \
+        || fail "Link failure $link_failure summary does not report retryable Link state"
+done
+ok "all Link failure statuses preserve a completed install with retry wording"
 
-run_failed_link_install int || fail "the install must finish after Ctrl-C stops Link setup"
-grep -q 'OK: install completed' "$base/out" || fail "the output must confirm install completion after Ctrl-C"
-! grep -q 'prefix --rollback' "$base/calls.log" || fail "the installer must preserve the prefix after Ctrl-C"
-grep -qF 'Run this command to complete Link setup: installer link enable --mode=always' "$base/err" \
-    || fail "the output must include the Link recovery command after Ctrl-C"
-ok "Ctrl-C stops Link setup and preserves the install"
+# Updates use the same boundary: Link remains retryable after the updated core
+# has committed, regardless of the helper's failure classification.
+for link_failure in 1 70 75; do
+    : > "$base/calls.log"
+    run_isolated "$base" env ABLETON_INSTALLER_PATH="$link_installer" \
+        ABLETON_TEST_CALL_LOG="$base/calls.log" ABLETON_TEST_LINK_ENABLE_EXIT="$link_failure" \
+        bash "$kit/scripts/installer.sh" update --link=always --yes \
+        >"$base/out" 2>"$base/err" \
+        || fail "full update fails when Link exits $link_failure"
+    grep -q 'OK: Ableton is updated' "$base/out" \
+        || fail "Link failure $link_failure hides the completed update"
+    [ -x "$base/runtime/bin/wine" ] && [ -f "$base/prefix/system.reg" ] \
+        && [ -f "$live_exe" ] \
+        || fail "Link failure $link_failure discards the updated runtime, prefix, or Live executable"
+    ! grep -q -- '--rollback' "$base/calls.log" \
+        || fail "Link failure $link_failure rolls back the completed update"
+    grep -qF "Ableton is updated, but Link could not be set up. Retry with: $link_resume_command" "$base/err" \
+        || fail "update Link failure $link_failure omits the retry command and outcome"
+    grep -qF 'Link: unchanged; setup can be retried' "$base/out" \
+        || fail "update Link failure $link_failure summary does not report retryable Link state"
+done
+ok "all Link failure statuses preserve a completed update with retry wording"
 
-# An update preserves the prefix and commits the new runtime after the same
-# Link setup failure.
-: > "$base/calls.log"
-run_isolated "$base" env ABLETON_TEST_CALL_LOG="$base/calls.log" ABLETON_TEST_LINK_ENABLE_EXIT=1 \
-    bash "$kit/scripts/installer.sh" update --yes >"$base/out" 2>"$base/err" \
-    || fail "the update must finish after Link setup failure"
-grep -q 'OK: update completed' "$base/out" || fail "the output must confirm update completion"
-! grep -q -- '--rollback' "$base/calls.log" || fail "the installer must preserve the update"
-grep -q 'Link setup stopped; the update continues' "$base/err" \
-    || fail "the output must report the stopped Link setup"
-grep -qF 'Link: setup stopped (run: installer link enable --mode=always)' "$base/out" \
-    || fail "the update summary must report the stopped Link setup"
-ok "Link setup failure reports the resume action and preserves the update"
+# Cleanup happens only after the usable core is committed. A cleanup failure
+# retains recovery files and warns, but must not turn that install into failure.
+for cleanup_failure in component prefix; do
+    cleanup_env=()
+    case "$cleanup_failure" in
+        component) cleanup_env+=(ABLETON_TEST_COMPONENT_COMMIT_EXIT=9) ;;
+        prefix) cleanup_env+=(ABLETON_TEST_PREFIX_COMMIT_EXIT=9) ;;
+    esac
+    run_payload_install "${cleanup_env[@]}" \
+        || fail "$cleanup_failure cleanup failure rejects a completed install"
+    grep -q 'OK: Ableton Live 12 is installed' "$base/out" \
+        || fail "$cleanup_failure cleanup failure hides the completed install"
+    grep -q 'old recovery files could not be removed' "$base/err" \
+        || fail "$cleanup_failure cleanup failure omits its warning"
+    [ -x "$base/runtime/bin/wine" ] && [ -f "$base/prefix/system.reg" ] \
+        && [ -f "$live_exe" ] \
+        || fail "$cleanup_failure cleanup failure discards the committed core"
+    ! grep -q -- '--rollback' "$base/calls.log" \
+        || fail "$cleanup_failure cleanup failure rolls back the committed core"
+done
+ok "cleanup failures warn and preserve a successful install"
 
 base="$(new_env launcher-preflight)"
 mkdir -p "$base/runtime/bin" "$base/prefix"
@@ -1080,8 +1310,8 @@ live_holder='C:\\ProgramData\\Ableton\\Live 12 Suite\\Program\\Ableton Live 12 S
 other_holder='C:\\some-daw.exe'
 refusal_leaves_busy_prefix_alone refusal-max-absent  max9         'no Max 9 installation'      "$live_holder"
 refusal_leaves_busy_prefix_alone refusal-live-absent ableton-live 'no Ableton Live installation' "$other_holder"
-refusal_leaves_busy_prefix_alone refusal-max-lock    max9         'bringing this prefix up'    "$live_holder" max  1
-refusal_leaves_busy_prefix_alone refusal-live-lock   ableton-live 'bringing this prefix up'    "$other_holder" live 1
+refusal_leaves_busy_prefix_alone refusal-max-lock    max9         'another Live or Max launch is starting' "$live_holder" max  1
+refusal_leaves_busy_prefix_alone refusal-live-lock   ableton-live 'another Live or Max launch is starting' "$other_holder" live 1
 ok "a launcher that refuses to start leaves a busy prefix alone, at every stage"
 
 base="$(new_env foreign-runtime)"
@@ -1128,7 +1358,10 @@ run_isolated "$base" env ABLETON_TRANSACTION_DIR="$base/txn" bash -c '
     && [ ! -e "$base/data/ableton-wine/detect-scale.sh" ] || fail "file transaction rolls back"
 ok "file transaction restores overwritten files and removes new files"
 
-base="$(new_env prefix-host-transaction)"
+# Retained transactions from older releases can still contain a host-file
+# journal. Recovery keeps understanding that format even though new prefix
+# setup runs no longer create an empty one.
+base="$(new_env legacy-prefix-host-transaction)"
 mkdir -p "$base/txn/prefix-host" "$base/config/pipeasio"
 printf 'before\n' > "$base/config/pipeasio/config.ini"
 run_isolated "$base" env ABLETON_TRANSACTION_DIR="$base/txn/prefix-host" bash -c '
@@ -1146,7 +1379,227 @@ run_isolated "$base" bash "$here/setup-prefix.sh" --rollback "$base/txn"
     || fail "prefix rollback leaves a pre-promotion host mutation behind"
 ok "prefix rollback restores host files even before prefix promotion"
 
-base="$(new_env uninstall-prestate)"
+# A current prefix transaction contains only the prefix layout record. It must
+# not need a fabricated empty host-file journal in order to recover.
+base="$(new_env prefix-layout-only-transaction)"
+prefix="$base/prefix"
+txn="$base/txn"
+backup="$prefix.transaction-${txn##*/}"
+mkdir -p -- "$prefix" "$backup" "$txn"
+printf 'format=1\nprefix=%s\n' "$prefix" > "$prefix/.ableton-linux-prefix"
+printf 'format=1\nprefix=%s\n' "$prefix" > "$backup/.ableton-linux-prefix"
+printf 'new prefix\n' > "$prefix/generation"
+printf 'old prefix\n' > "$backup/generation"
+printf '%s\t%s\n' "$prefix" "$backup" > "$txn/prefix.tsv"
+run_isolated "$base" env ABLETON_WINEPREFIX="$prefix" \
+    bash "$here/setup-prefix.sh" --preflight-rollback "$txn" \
+    || fail "prefix recovery required an empty host-file journal"
+run_isolated "$base" env ABLETON_WINEPREFIX="$prefix" \
+    bash "$here/setup-prefix.sh" --rollback "$txn" \
+    || fail "prefix-only recovery failed without a host-file journal"
+grep -qxF 'old prefix' "$prefix/generation" \
+    && [ ! -e "$backup" ] && [ ! -e "$txn/prefix.tsv" ] \
+    || fail "prefix-only recovery did not restore the saved prefix"
+ok "prefix recovery needs no empty host-file journal"
+
+# The EXIT handler has enough state to decide whether a late failure happened
+# before or after the prefix became usable. Diagnostic output is not part of
+# that decision, and a ready prefix must not also be reported as rolled back.
+base="$(new_env prefix-cleanup-output)"
+extract_setup_prefix_function()
+{
+    awk -v signature="$1()" \
+        '$0 == signature { copy=1 } copy { print } copy && /^}$/ { exit }' \
+        "$here/setup-prefix.sh" > "$2"
+}
+extract_setup_prefix_function prefix_cleanup "$base/prefix-cleanup.function"
+grep -q '^prefix_cleanup()$' "$base/prefix-cleanup.function" \
+    || fail "prefix cleanup test could not load the production handler"
+mkdir -p "$base/core-txn" "$base/commit-txn"
+run_isolated "$base" bash -c '
+    set -euo pipefail
+    . "$1"
+    prefix_core_ready=1
+    prefix_commit_started=0
+    prefix_promoted=1
+    transaction_dir="$2"
+    final_prefix="$3"
+    stage_prefix="$4"
+    prefix_transaction_rollback() { return 0; }
+    trap prefix_cleanup EXIT
+    false
+' cleanup "$base/prefix-cleanup.function" "$base/core-txn" \
+    "$base/prefix" "$base/stage" > "$base/core.out" 2> /dev/full \
+    || fail "closed diagnostics changed a ready prefix into failure"
+[ ! -e "$base/core-txn/prefix-failure" ] \
+    || fail "a ready prefix was also recorded as a rolled-back failure"
+run_isolated "$base" bash -c '
+    set -euo pipefail
+    . "$1"
+    prefix_core_ready=0
+    prefix_commit_started=1
+    prefix_promoted=1
+    transaction_dir="$2"
+    final_prefix="$3"
+    stage_prefix="$4"
+    prefix_transaction_rollback() { return 0; }
+    trap prefix_cleanup EXIT
+    false
+' cleanup "$base/prefix-cleanup.function" "$base/commit-txn" \
+    "$base/prefix" "$base/stage" > "$base/commit.out" 2> /dev/full \
+    || fail "closed diagnostics changed a committed prefix into failure"
+[ -f "$base/commit-txn/COMMITTED_CLEANUP_FAILURE" ] \
+    || fail "committed prefix cleanup did not retain its recovery record"
+ok "prefix cleanup follows the prefix state when diagnostic output is closed"
+
+# These helpers run after their durable outcome is known: writing defaults is
+# optional, an extracted Live payload is disposable, and the legacy prefix
+# marker has already been published before its informational report.
+extract_setup_prefix_function write_default_pipeasio_settings \
+    "$base/pipeasio-defaults.function"
+extract_setup_prefix_function remove_extracted_live_installer \
+    "$base/live-cleanup.function"
+extract_setup_prefix_function report_existing_prefix \
+    "$base/prefix-report.function"
+extract_setup_prefix_function prefix_note "$base/prefix-note.function"
+extract_setup_prefix_function prefix_warn "$base/prefix-warn.function"
+run_isolated "$base" bash -c '
+    set -euo pipefail
+    . "$1"
+    . "$2"
+    prefix_note "progress" > /dev/full
+    prefix_warn "warning" 2> /dev/full
+' output "$base/prefix-note.function" "$base/prefix-warn.function" \
+    || fail "closed output made Wine setup progress fail"
+run_isolated "$base" env XDG_CONFIG_HOME="$base/defaults" bash -c '
+    set -euo pipefail
+    . "$1"
+    write_default_pipeasio_settings > /dev/full
+' defaults "$base/pipeasio-defaults.function" \
+    || fail "closed output made default PipeASIO settings fail"
+[ -f "$base/defaults/pipeasio/config.ini" ] \
+    || fail "closed output stopped default PipeASIO settings from being written"
+mkdir -p "$base/blocked"
+printf 'not a directory\n' > "$base/blocked/pipeasio"
+run_isolated "$base" env XDG_CONFIG_HOME="$base/blocked" bash -c '
+    set -euo pipefail
+    . "$1"
+    write_default_pipeasio_settings
+' defaults "$base/pipeasio-defaults.function" \
+    > "$base/defaults.out" 2> /dev/full \
+    || fail "an unwritable optional PipeASIO settings path failed prefix setup"
+mkdir -p "$base/unpack" "$base/fakebin"
+printf 'payload\n' > "$base/unpack/file"
+cat > "$base/fakebin/rm" <<'EOF'
+#!/bin/sh
+exit "${TEST_RM_RC:-1}"
+EOF
+chmod +x "$base/fakebin/rm"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" bash -c '
+    set -euo pipefail
+    . "$1"
+    remove_extracted_live_installer "$2"
+' cleanup "$base/live-cleanup.function" "$base/unpack" \
+    > "$base/cleanup.out" 2> /dev/full \
+    || fail "an extracted Live payload cleanup warning failed prefix setup"
+[ -f "$base/unpack/file" ] \
+    || fail "the cleanup warning fixture did not preserve its failed target"
+ln -s -- "$base/missing-live-installer" "$base/unpack-link"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" TEST_RM_RC=0 bash -c '
+    set -euo pipefail
+    . "$1"
+    remove_extracted_live_installer "$2"
+' cleanup "$base/live-cleanup.function" "$base/unpack-link" \
+    > "$base/cleanup-link.out" 2> "$base/cleanup-link.err" \
+    || fail "a disposable Live installer cleanup report failed prefix setup"
+[ -L "$base/unpack-link" ] \
+    || fail "the successful-rm residue fixture did not retain its dangling link"
+grep -qF 'Temporary Ableton Live installer files remain at' "$base/cleanup-link.err" \
+    || fail "Live installer cleanup trusted rm status instead of its postcondition"
+if grep -qF 'Live is installed' "$base/cleanup-link.err"; then
+    fail "temporary Live installer cleanup claimed that Live was installed"
+fi
+run_isolated "$base" bash -c '
+    set -euo pipefail
+    . "$1"
+    report_existing_prefix "$2" > /dev/full
+' report "$base/prefix-report.function" "$base/prefix" \
+    || fail "closed output failed after a legacy prefix was adopted"
+ok "optional prefix reports cannot reverse completed or nonessential work"
+
+# Automatic display detection is advisory. A missing detector, a scale outside
+# the calibrated range, or an unverifiable GNOME native-scaling feature must
+# choose a safe fresh-prefix default instead of refusing Wine setup; explicitly
+# invalid input remains an input error.
+base="$(new_env automatic-dpi-fallback)"
+sed -n '/^case "$dpi_mode" in$/,/^esac$/p' "$here/setup-prefix.sh" \
+    > "$base/dpi-selection.bash"
+grep -q '^case "$dpi_mode" in$' "$base/dpi-selection.bash" \
+    || fail "DPI fallback test could not load the production selection logic"
+for detector in unavailable out-of-range; do
+    run_isolated "$base" bash -c '
+        set -euo pipefail
+        fresh_prefix=1
+        dpi_mode=auto
+        dpi_block=preserve
+        dpi_family=""
+        prefix_note() { :; }
+        prefix_warn() { :; }
+        current_dpi_block() { printf "custom\n"; }
+        if [ "$2" = unavailable ]; then
+            ableton_detect_scale_ex() { return 1; }
+        else
+            ableton_detect_scale_ex() { printf "3.00 gnome\n"; }
+        fi
+        block_for_scale() { return 1; }
+        ableton_dpi_block_values() { return 1; }
+        . "$1"
+        [ "$dpi_block" = 100 ]
+    ' dpi "$base/dpi-selection.bash" "$detector" \
+        || fail "$detector automatic display detection refused a fresh prefix"
+done
+for native_state in active unavailable; do
+    run_isolated "$base" bash -c '
+        set -euo pipefail
+        fresh_prefix=1
+        dpi_mode=auto
+        dpi_block=preserve
+        dpi_family=""
+        prefix_note() { :; }
+        prefix_warn() { :; }
+        current_dpi_block() { printf "custom\n"; }
+        ableton_detect_scale_ex() { printf "1.33333 gnome\n"; }
+        block_for_scale() { printf "fractional\n"; }
+        ableton_dpi_block_values() { return 1; }
+        if [ "$2" = active ]; then
+            gnome_native_scaling_active() { return 0; }
+        else
+            gnome_native_scaling_active() { return 1; }
+        fi
+        . "$1"
+        if [ "$2" = active ]; then
+            [ "$dpi_block" = fractional ]
+        else
+            [ "$dpi_block" = 100 ]
+        fi
+    ' dpi "$base/dpi-selection.bash" "$native_state" \
+        || fail "$native_state GNOME native-scaling state selected an unsafe fresh-prefix DPI block"
+done
+if run_isolated "$base" bash -c '
+    set -euo pipefail
+    fresh_prefix=1
+    dpi_mode=not-a-mode
+    dpi_block=preserve
+    dpi_family=""
+    prefix_note() { :; }
+    prefix_warn() { :; }
+    . "$1"
+' dpi "$base/dpi-selection.bash"; then
+    fail "an explicitly invalid display mode was accepted"
+fi
+ok "fresh Wine setup falls back to 100% only for automatic display detection"
+
+base="$(new_env uninstall-authoritative-icon)"
 foreign_icon="$base/data/icons/hicolor/scalable/apps/live-suite.svg"
 mkdir -p "$(dirname "$foreign_icon")" "$base/fakebin"
 printf 'foreign icon\n' > "$foreign_icon"
@@ -1158,8 +1611,11 @@ chmod +x "$base/fakebin/systemctl"
 run_isolated "$base" env PATH="$base/fakebin:$PATH" bash "$here/install.sh" --integration-only >"$base/install.out" 2>"$base/install.err"
 grep -q '<svg' "$foreign_icon" || fail "integration did not replace the collision fixture"
 run_isolated "$base" env PATH="$base/fakebin:$PATH" bash "$here/uninstall.sh" --keep-prefix --yes >"$base/out" 2>"$base/err"
-[ "$(cat "$foreign_icon")" = 'foreign icon' ] || fail "uninstall did not restore overwritten pre-install file"
-ok "uninstall restores a pre-existing file overwritten by integration"
+[ "$(cat "$foreign_icon")" = 'foreign icon' ] \
+    || fail "uninstall did not restore the icon that preceded installation"
+grep -qF "restored your earlier file at $foreign_icon" "$base/out" \
+    || fail "uninstall did not report restoration of the earlier icon"
+ok "canonical project icons are updated authoritatively and earlier files return on uninstall"
 
 base="$(new_env user-config)"
 user_config="$base/config/pipeasio/config.ini"
@@ -1175,35 +1631,30 @@ run_isolated "$base" env PATH="$base/fakebin:$PATH" bash "$here/uninstall.sh" \
     --keep-prefix --yes >"$base/out" 2>"$base/err"
 [ "$(cat "$user_config")" = 'user buffer setting' ] \
     || fail "uninstall removes user-modified seeded configuration"
-grep -q 'kept user-modified configuration' "$base/out" \
+grep -q 'kept user-modified configuration' "$base/err" \
     || fail "preserved user configuration is not reported"
 ok "uninstall preserves and de-owns user-modified seeded configuration"
 
-base="$(new_env modified-owned)"
+base="$(new_env authoritative-support-file)"
 run_isolated "$base" bash "$here/install.sh" --integration-only >"$base/first.out" 2>"$base/first.err"
 printf '\n# user change\n' >> "$base/data/ableton-wine/detect-scale.sh"
-if run_isolated "$base" bash "$here/install.sh" --integration-only >"$base/out" 2>"$base/err"; then
-    fail "integration overwrites a modified managed file"
-fi
-grep -qF '# user change' "$base/data/ableton-wine/detect-scale.sh" || fail "failed update lost managed-file modification"
-grep -q 'The installer kept the managed path because its saved checksum differs' "$base/err" \
-    || fail "changed managed file refusal gives the reason"
-ok "update refuses to overwrite a locally modified managed file"
+run_isolated "$base" bash "$here/install.sh" --integration-only >"$base/out" 2>"$base/err" \
+    || fail "integration could not repair a modified canonical support file"
+cmp -s -- "$here/detect-scale.sh" "$base/data/ableton-wine/detect-scale.sh" \
+    || fail "integration did not replace drift in a canonical support file"
+ok "update repairs a modified canonical support file authoritatively"
 
 # install.sh installs the version stamp inside an "if !" condition, which
 # suppresses set -e, so ableton_install_file must return non-zero for the
 # refusal to stop the run.
-base="$(new_env modified-version-stamp)"
+base="$(new_env authoritative-version-stamp)"
 run_isolated "$base" bash "$here/install.sh" --integration-only >"$base/first.out" 2>"$base/first.err"
 printf 'tampered\n' > "$base/data/ableton-wine/VERSION"
-if run_isolated "$base" bash "$here/install.sh" --integration-only >"$base/out" 2>"$base/err"; then
-    fail "integration overwrites a modified version stamp"
-fi
-grep -qxF tampered "$base/data/ableton-wine/VERSION" \
-    || fail "failed update lost the version stamp modification"
-grep -q 'The installer kept the managed path because its saved checksum differs' "$base/err" \
-    || fail "changed version stamp refusal gives the reason"
-ok "update refuses to overwrite a locally modified version stamp"
+run_isolated "$base" bash "$here/install.sh" --integration-only >"$base/out" 2>"$base/err" \
+    || fail "integration could not repair a modified canonical version stamp"
+cmp -s -- "$root/VERSION" "$base/data/ableton-wine/VERSION" \
+    || fail "integration did not replace drift in the canonical version stamp"
+ok "update repairs a modified canonical version stamp authoritatively"
 
 # Issues #211 and #251 showed that launcher checksum drift triggered rollback.
 # Cover every primary launcher, including Max and the handler copies used by
@@ -1256,8 +1707,6 @@ for launcher in "${launcher_paths[@]}"; do
     current="$(sha256sum "$launcher" | awk '{print $1}')"
     [ "$recorded" = "$current" ] \
         || fail "update saved an incorrect launcher checksum for $launcher"
-    grep -qF "The installer replaced a launcher because its saved checksum differed: $launcher" "$base/out" \
-        || fail "update omitted the launcher replacement message for $launcher"
 done
 [ -L "${launcher_paths[0]}.bak" ] \
     && [ "$(readlink -- "${launcher_paths[0]}.bak")" = "$launcher_copy" ] \
@@ -1285,7 +1734,7 @@ grep -qF 'Ableton Live launcher for the patched Wine stack' "$launcher_copy" \
 ok "update replaces every primary launcher after checksum drift"
 
 rollback_launcher="$base/data/applications/max9.desktop"
-printf '\n# launcher before genuine failure\n' >> "$rollback_launcher"
+printf '\n# launcher before refresh failure\n' >> "$rollback_launcher"
 printf 'previous adjacent backup\n' > "${rollback_launcher}.bak"
 mkdir -p "$base/fakebin"
 cat > "$base/fakebin/update-desktop-database" <<'EOF'
@@ -1293,17 +1742,16 @@ cat > "$base/fakebin/update-desktop-database" <<'EOF'
 exit 1
 EOF
 chmod +x "$base/fakebin/update-desktop-database"
-if run_isolated "$base" env PATH="$base/fakebin:$PATH" \
-    bash "$here/install.sh" --integration-only >"$base/failure.out" 2>"$base/failure.err"; then
-    fail "desktop database failure unexpectedly succeeded"
-fi
-grep -qF '# launcher before genuine failure' "$rollback_launcher" \
-    || fail "genuine failure did not restore the displaced launcher"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    bash "$here/install.sh" --integration-only >"$base/failure.out" 2>"$base/failure.err" \
+    || fail "desktop database refresh failure rejects installed shortcuts"
+! grep -qF '# launcher before refresh failure' "$rollback_launcher" \
+    || fail "desktop refresh failure left launcher drift in place"
 grep -qxF 'previous adjacent backup' "${rollback_launcher}.bak" \
-    || fail "genuine failure did not restore the previous launcher backup"
-grep -qF 'failed to update the desktop application database' "$base/failure.err" \
-    || fail "genuine failure did not report its actual cause"
-ok "genuine failure restores both the launcher and its previous adjacent backup"
+    || fail "desktop refresh failure replaced the existing saved launcher"
+! grep -qF 'Some shortcuts or support files could not be updated.' "$base/failure.err" \
+    || fail "desktop database refresh failure produced a retry warning"
+ok "desktop database refresh failure is silent and does not roll back installed shortcuts"
 
 # When the custom data root matches the XDG applications root, one invocation
 # reaches the handler twice. The second projection recognises the installed
@@ -1359,8 +1807,6 @@ recorded="$(awk -F '\t' -v p="$live_desktop" '$1=="file" && $2==p { print $3 }' 
 current="$(sha256sum "$live_desktop" | awk '{print $1}')"
 [ "$recorded" = "$current" ] \
     || fail "update did not refresh the Live desktop ownership digest"
-grep -qF "The installer replaced a launcher because its saved checksum differed: $live_desktop" "$base/out" \
-    || fail "update omitted the desktop entry refresh message"
 grep -qF 'StartupWMClass=ableton live 12 suite.exe' "${live_desktop}.bak" \
     || fail "Live desktop backup does not contain the displaced entry"
 ok "update refreshes a launcher-updated Live desktop entry"
@@ -1397,14 +1843,13 @@ live_desktop="$base/data/applications/ableton-live.desktop"
 orig_exec="$(grep '^Exec=' "$live_desktop")"
 sed -i 's|^Exec=.*|Exec=/usr/bin/other-app %f|' "$live_desktop"
 printf '# was: %s\n' "$orig_exec" >> "$live_desktop"
-if run_isolated "$base" env PATH="$base/fakebin:$PATH" bash "$here/uninstall.sh" \
-    --keep-prefix --yes >"$base/out" 2>"$base/err"; then
-    fail "uninstall removed a desktop entry re-pointed away from the launcher"
-fi
+run_isolated "$base" env PATH="$base/fakebin:$PATH" bash "$here/uninstall.sh" \
+    --keep-prefix --yes >"$base/out" 2>"$base/err" \
+    || fail "a preserved user-repointed desktop entry makes uninstall fail"
 [ -e "$live_desktop" ] || fail "uninstall removed the re-pointed desktop entry"
-grep -qF "kept modified file $live_desktop" "$base/err" \
+grep -qF "kept an unrecognised or user-modified file at $live_desktop" "$base/err" \
     || fail "kept re-pointed desktop entry is not reported"
-ok "uninstall keeps a desktop entry re-pointed away from the launcher"
+ok "uninstall warns and keeps a desktop entry re-pointed away from the launcher"
 
 # The transaction snapshots a launcher symlink before replacement and leaves
 # its referent unchanged.
@@ -1424,26 +1869,31 @@ run_isolated "$base" bash "$here/install.sh" --integration-only \
 [ -L "${live_desktop}.bak" ] \
     && [ "$(readlink -- "${live_desktop}.bak")" = "$base/home/live-entry-copy.desktop" ] \
     || fail "Live desktop backup is not the displaced symlink"
-grep -qF "The installer replaced a launcher because its saved checksum differed: $live_desktop" "$base/out" \
-    || fail "symlinked desktop entry replacement was not reported"
 ok "update replaces a symlinked managed Live desktop entry"
 
-base="$(new_env link-prestate)"
+base="$(new_env authoritative-link-binary)"
 foreign_linkd="$base/data/ableton-wine/ableton-linkd"
 mkdir -p "$(dirname "$foreign_linkd")" "$base/fakebin"
 printf '#!/bin/sh\necho foreign\n' > "$foreign_linkd"
 chmod +x "$foreign_linkd"
 cat > "$base/fakebin/systemctl" <<'EOF'
 #!/bin/sh
-exit 0
+case "$*" in
+    *'show -p Version --value'*) echo 255 ;;
+    *'show -p FragmentPath --value ableton-linkd.service'*) : ;;
+    *'is-enabled --quiet ableton-linkd.service'*) exit 1 ;;
+    *'is-active --quiet ableton-linkd.service'*) exit 1 ;;
+    *) exit 0 ;;
+esac
 EOF
 chmod +x "$base/fakebin/systemctl"
 run_isolated "$base" env PATH="$base/fakebin:$PATH" bash "$here/install.sh" --link-assets-only >"$base/install.out" 2>"$base/install.err"
 grep -qF 'native Ableton Link session anchor' < <(strings "$foreign_linkd") \
     || fail "Link asset install did not replace the collision fixture"
 run_isolated "$base" env PATH="$base/fakebin:$PATH" bash "$here/setup-link.sh" disable >"$base/out" 2>"$base/err"
-grep -qF 'echo foreign' "$foreign_linkd" || fail "Link disable did not restore overwritten pre-install binary"
-ok "Link disable restores a pre-existing binary overwritten by Link assets"
+[ ! -e "$foreign_linkd" ] && [ ! -L "$foreign_linkd" ] \
+    || fail "Link disable kept the managed canonical Link binary"
+ok "canonical Link assets are replaced authoritatively and removed on disable"
 
 base="$(new_env uninstall-safety)"
 if run_isolated "$base" env ABLETON_WINEPREFIX=/ ABLETON_WINE_ROOT="$base/runtime" \
@@ -1566,9 +2016,14 @@ exec "$@"
 EOF
 cat > "$base/fakebin/systemctl" <<'EOF'
 #!/bin/sh
+unit="${XDG_CONFIG_HOME:?}/systemd/user/ableton-linkd.service"
 case "$*" in
     *daemon-reload*) exit "${ABLETON_TEST_SYSTEMCTL_RELOAD_STATUS:-1}" ;;
-    *show*) exit 0 ;;
+    *'show -p Version --value'*) echo 255 ;;
+    *'show -p FragmentPath --value ableton-linkd.service'*)
+        [ ! -f "$unit" ] || printf '%s\n' "$unit" ;;
+    *'is-enabled --quiet ableton-linkd.service'*) exit 1 ;;
+    *'is-active --quiet ableton-linkd.service'*) exit 1 ;;
     *) exit 0 ;;
 esac
 EOF
@@ -1587,14 +2042,17 @@ if ! grep -qF 'could not inspect the active ufw rules' "$base/query.err"; then
 fi
 ok "Link enable refuses when it cannot inspect the active ufw rules"
 
-if run_isolated "$base" env PATH="$base/fakebin:$PATH" ABLETON_TEST_UFW="$base/ufw-rule" \
-    bash "$here/setup-link.sh" enable --mode=session >"$base/out" 2>"$base/err"; then
-    fail "Link enable succeeds after its systemd registration fails"
-fi
-[ ! -e "$base/ufw-rule" ] || fail "failed Link enable leaves its new firewall rule"
-[ "$(cat "$base/state/ableton-wine/link-firewall")" = none ] \
-    || fail "failed Link enable does not restore the prior firewall record"
-ok "Link enable failure restores firewall ownership and host state"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" ABLETON_TEST_UFW="$base/ufw-rule" \
+    bash "$here/setup-link.sh" enable --mode=session >"$base/out" 2>"$base/err" \
+    || fail "session Link depends on optional systemd registration"
+[ -e "$base/ufw-rule" ] || fail "successful session Link lost its firewall rule"
+[ "$(cat "$base/state/ableton-wine/link-firewall")" = ufw-added ] \
+    || fail "successful session Link lost its firewall tracking"
+grep -qF 'Link user service could not be refreshed yet' "$base/err" \
+    || fail "optional systemd refresh warning did not explain the actual effect"
+grep -qxF 'link_mode=session' "$base/config/ableton-wine/config" \
+    || fail "optional systemd refresh prevented Link mode from being saved"
+ok "session Link succeeds when only optional systemd registration fails"
 
 printf 'ufw-added\n' > "$base/state/ableton-wine/link-firewall"
 rm -f -- "$base/ufw-rule"
@@ -1607,9 +2065,136 @@ run_isolated "$base" env PATH="$base/fakebin:$PATH" \
     || fail "Link enable trusts stale ufw ownership without restoring the rule"
 [ "$(cat "$base/state/ableton-wine/link-firewall")" = ufw-added ] \
     || fail "Link enable loses ownership while repairing its ufw rule"
-grep -qF 'restoring the recorded ufw allowance' "$base/reconcile.out" \
+grep -qF 'Restoring the missing ufw rule for Link' "$base/reconcile.out" \
     || fail "Link enable does not report stale firewall reconciliation"
 ok "Link enable verifies and repairs its recorded firewall rule"
+
+# A failed enable/disable command may already have changed systemd state. Link
+# recovery must restore enabled and active separately and return a dedicated
+# status only after verifying them. This fake persists every systemctl change.
+base="$(new_env link-service-recovery-contract)"
+mkdir -p -- "$base/data/ableton-wine" "$base/state/ableton-wine" "$base/fakebin" \
+    "$base/service-state"
+printf 'format=1\nowner=ableton-linux\n' > "$base/state/ableton-wine/.ableton-linux-state"
+printf '#!/bin/sh\nexit 0\n' > "$base/data/ableton-wine/ableton-linkctl"
+printf '#!/bin/sh\nexit 0\n' > "$base/data/ableton-wine/ableton-linkd"
+chmod +x "$base/data/ableton-wine/ableton-linkctl" "$base/data/ableton-wine/ableton-linkd"
+cat > "$base/fakebin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+set -eu
+state="${ABLETON_TEST_SERVICE_STATE:?}"
+unit="${XDG_CONFIG_HOME:?}/systemd/user/ableton-linkd.service"
+case "$*" in
+    *'show -p Version --value'*) echo 255 ;;
+    *'show -p FragmentPath --value ableton-linkd.service'*)
+        [ ! -f "$unit" ] || printf '%s\n' "$unit" ;;
+    *'show -p ExecStart --value ableton-linkd.service'*)
+        printf '{ path=%s ; argv[]=%s ; }\n' \
+            "${ABLETON_LINKD:?}" "${ABLETON_LINKD:?}" ;;
+    *'is-enabled --quiet ableton-linkd.service'*) [ -e "$state/enabled" ] ;;
+    *'is-active --quiet ableton-linkd.service'*) [ -e "$state/active" ] ;;
+    *'daemon-reload'*) : ;;
+    *'enable --now ableton-linkd.service'*)
+        [ ! -e "$state/fail-enable-before" ] || exit 88
+        : > "$state/enabled"
+        if [ -e "$state/partial-enable" ]; then
+            : > "$state/refuse-disable"
+            exit 88
+        fi
+        : > "$state/active"
+        if [ -e "$state/signal-enable" ]; then
+            timeout_parent="$PPID"
+            setup_parent="$(ps -o ppid= -p "$timeout_parent" | tr -d ' ')"
+            kill -TERM "$setup_parent"
+        fi
+        [ ! -e "$state/fail-enable-after" ] || exit 88 ;;
+    *'disable --now ableton-linkd.service'*)
+        [ ! -e "$state/refuse-disable" ] || exit 89
+        rm -f -- "$state/enabled" "$state/active" ;;
+    *'enable ableton-linkd.service'*) : > "$state/enabled" ;;
+    *'disable ableton-linkd.service'*) rm -f -- "$state/enabled" ;;
+    *'start ableton-linkd.service'*) : > "$state/active" ;;
+    *'stop ableton-linkd.service'*) rm -f -- "$state/active" ;;
+    *) echo "unexpected systemctl invocation: $*" >&2; exit 97 ;;
+esac
+EOF
+cat > "$base/fakebin/grep" <<'EOF'
+#!/bin/sh
+for argument do
+    [ "$argument" != /etc/ufw/ufw.conf ] || exit 1
+done
+exec /usr/bin/grep "$@"
+EOF
+printf '#!/bin/sh\nexit 1\n' > "$base/fakebin/firewall-cmd"
+printf '#!/bin/sh\nexec "$@"\n' > "$base/fakebin/sudo"
+chmod +x "$base/fakebin/systemctl" "$base/fakebin/grep" \
+    "$base/fakebin/firewall-cmd" "$base/fakebin/sudo"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_TEST_SERVICE_STATE="$base/service-state" \
+    bash "$here/setup-link.sh" enable --mode=always >"$base/initial.out" 2>"$base/initial.err" \
+    || { sed -n '1,80p' "$base/initial.err" >&2; fail "stateful Link fixture could not enable its initial service"; }
+: > "$base/service-state/fail-enable-after"
+status=0
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_TEST_SERVICE_STATE="$base/service-state" \
+    bash "$here/setup-link.sh" enable --mode=always >"$base/command-error.out" 2>"$base/command-error.err" \
+    || status=$?
+[ "$status" -eq 0 ] || fail "a systemctl command error gated an already-achieved Link state (got $status)"
+[ -e "$base/service-state/enabled" ] && [ -e "$base/service-state/active" ] \
+    || fail "Link rejected an enable command whose requested state was achieved"
+grep -qF 'OK: Ableton Link is enabled in the background' "$base/command-error.out" \
+    || fail "Link did not report the achieved background state"
+ok "Link accepts an achieved service state despite a command error"
+
+rm -f -- "$base/service-state/fail-enable-after"
+: > "$base/service-state/fail-enable-before"
+status=0
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_TEST_SERVICE_STATE="$base/service-state" \
+    bash "$here/setup-link.sh" enable --mode=always >"$base/recovered.out" 2>"$base/recovered.err" \
+    || status=$?
+[ "$status" -eq 75 ] || fail "verified Link recovery did not return its dedicated status (got $status)"
+[ -e "$base/service-state/enabled" ] && [ -e "$base/service-state/active" ] \
+    || fail "Link recovery lost the prior enabled/active service state"
+grep -qxF 'link_mode=always' "$base/config/ableton-wine/config" \
+    || fail "Link recovery changed the last successfully saved setting"
+! find "$base/state/ableton-wine" -mindepth 1 -maxdepth 1 -name '.link-enable.*' \
+    -print -quit | grep -q . \
+    || fail "verified Link recovery retained a completed local snapshot"
+grep -qF 'previous firewall and service settings were restored' "$base/recovered.err" \
+    || fail "verified Link recovery did not identify its outcome"
+ok "Link enable failure restores the prior service state without gating on generated files"
+
+# Deliver TERM to setup-link after the fake enable command changes both flags.
+rm -f -- "$base/service-state/fail-enable-before"
+: > "$base/service-state/signal-enable"
+status=0
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_TEST_SERVICE_STATE="$base/service-state" \
+    bash "$here/setup-link.sh" enable --mode=always >"$base/signal.out" 2>"$base/signal.err" \
+    || status=$?
+[ "$status" -eq 75 ] || fail "signal recovery did not return verified-recovered status (got $status)"
+[ -e "$base/service-state/enabled" ] && [ -e "$base/service-state/active" ] \
+    || fail "signal recovery lost the prior service state"
+ok "TERM during service mutation completes verified Link recovery"
+
+# A failure while quiescing the partially changed service is incomplete and
+# must retain durable evidence rather than returning the recovered status.
+rm -f -- "$base/service-state/signal-enable"
+: > "$base/service-state/partial-enable"
+status=0
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_TEST_SERVICE_STATE="$base/service-state" \
+    bash "$here/setup-link.sh" enable --mode=always >"$base/incomplete.out" 2>"$base/incomplete.err" \
+    || status=$?
+[ "$status" -eq 70 ] || fail "incomplete Link recovery did not return its dedicated status (got $status)"
+recovery_snapshot="$(find "$base/state/ableton-wine" -mindepth 1 -maxdepth 1 \
+    -type d -name '.link-enable.*' -print -quit)"
+[ -n "$recovery_snapshot" ] && [ -f "$recovery_snapshot/FAILURE" ] \
+    || fail "incomplete Link recovery discarded its durable failure snapshot"
+grep -qxF 'restoration_complete=no' "$recovery_snapshot/FAILURE" \
+    || fail "incomplete Link recovery did not record its classification"
+ok "incomplete Link service recovery is distinct and keeps authoritative evidence"
 
 for legacy_args in '' ' --linger 0'; do
     case "$legacy_args" in
@@ -1635,9 +2220,28 @@ RestartSec=5
 [Install]
 WantedBy=default.target
 EOF
-    printf '#!/bin/sh\nexit 0\n' > "$base/fakebin/systemctl"
-    printf '#!/bin/sh\nexit 0\n' > "$base/fakebin/sudo"
-    chmod +x "$base/fakebin/systemctl" "$base/fakebin/sudo"
+    cat > "$base/fakebin/systemctl" <<'EOF'
+#!/bin/sh
+unit="${XDG_CONFIG_HOME:?}/systemd/user/ableton-linkd.service"
+case "$*" in
+    *'show -p Version --value'*) echo 255 ;;
+    *'show -p FragmentPath --value ableton-linkd.service'*) printf '%s\n' "$unit" ;;
+    *'is-enabled --quiet ableton-linkd.service'*) exit 1 ;;
+    *'is-active --quiet ableton-linkd.service'*) exit 1 ;;
+    *) exit 0 ;;
+esac
+EOF
+    cat > "$base/fakebin/grep" <<'EOF'
+#!/bin/sh
+for argument do
+    [ "$argument" != /etc/ufw/ufw.conf ] || exit 1
+done
+exec /usr/bin/grep "$@"
+EOF
+    printf '#!/bin/sh\nexit 1\n' > "$base/fakebin/firewall-cmd"
+    printf '#!/bin/sh\nexec "$@"\n' > "$base/fakebin/sudo"
+    chmod +x "$base/fakebin/systemctl" "$base/fakebin/grep" \
+        "$base/fakebin/firewall-cmd" "$base/fakebin/sudo"
     if ! run_isolated "$base" env PATH="$base/fakebin:$PATH" \
         bash "$here/setup-link.sh" enable --mode=session >"$base/out" 2>"$base/err"; then
         sed -n '1,80p' "$base/err" >&2
@@ -1670,18 +2274,36 @@ RestartSec=5
 [Install]
 WantedBy=default.target
 EOF
-cp "$unit" "$base/unit.before"
-printf '#!/bin/sh\nexit 0\n' > "$base/fakebin/systemctl"
-printf '#!/bin/sh\nexit 0\n' > "$base/fakebin/sudo"
-chmod +x "$base/fakebin/systemctl" "$base/fakebin/sudo"
-if run_isolated "$base" env PATH="$base/fakebin:$PATH" \
-    bash "$here/setup-link.sh" enable --mode=session >"$base/out" 2>"$base/err"; then
-    fail "Link setup replaces a modified legacy-shaped unit"
-fi
-cmp -s "$base/unit.before" "$unit" || fail "Link setup changes a refused unit"
-grep -q 'refusing to replace foreign systemd unit' "$base/err" \
-    || fail "Link setup does not explain the modified unit refusal"
-ok "Link setup keeps modified legacy-shaped units"
+cat > "$base/fakebin/systemctl" <<'EOF'
+#!/bin/sh
+unit="${XDG_CONFIG_HOME:?}/systemd/user/ableton-linkd.service"
+case "$*" in
+    *'show -p Version --value'*) echo 255 ;;
+    *'show -p FragmentPath --value ableton-linkd.service'*) printf '%s\n' "$unit" ;;
+    *'is-enabled --quiet ableton-linkd.service'*) exit 1 ;;
+    *'is-active --quiet ableton-linkd.service'*) exit 1 ;;
+    *) exit 0 ;;
+esac
+EOF
+cat > "$base/fakebin/grep" <<'EOF'
+#!/bin/sh
+for argument do
+    [ "$argument" != /etc/ufw/ufw.conf ] || exit 1
+done
+exec /usr/bin/grep "$@"
+EOF
+printf '#!/bin/sh\nexit 1\n' > "$base/fakebin/firewall-cmd"
+printf '#!/bin/sh\nexec "$@"\n' > "$base/fakebin/sudo"
+chmod +x "$base/fakebin/systemctl" "$base/fakebin/grep" \
+    "$base/fakebin/firewall-cmd" "$base/fakebin/sudo"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    bash "$here/setup-link.sh" enable --mode=session >"$base/out" 2>"$base/err" \
+    || fail "a modified generated Link unit blocks repair"
+grep -qxF 'X-AbletonLinuxOwned=true' "$unit" \
+    || fail "Link setup did not replace the modified generated unit"
+! grep -qF 'Environment=FOREIGN_SETTING=1' "$unit" \
+    || fail "Link setup retained foreign bytes at its canonical unit path"
+ok "Link setup overwrites its generated unit authoritatively"
 
 base="$(new_env link-unit-ownership)"
 unit="$base/config/systemd/user/ableton-linkd.service"
@@ -1715,24 +2337,77 @@ grep -q -- '--user start ableton-linkd.service' "$base/systemctl.log" \
     || fail "exact owned Link unit is not started"
 ok "Link controller starts only the exact ownership-marked unit"
 
+# Direct controller mutations participate in the same lifecycle lock as the
+# installer. A child already inside that transaction may reuse the descriptor,
+# but the detached daemon must close it before exec so the next command is not
+# locked out for the daemon's whole linger period.
+base="$(new_env link-controller-global-lock)"
+managed_linkd="$base/data/ableton-wine/ableton-linkd"
+mkdir -p -- "$(dirname "$managed_linkd")" "$base/run/ableton-wine"
+if [ -f "$root/dist/ableton-linkd" ]; then
+    cp -- "$root/dist/ableton-linkd" "$managed_linkd"
+else
+    cp -- "$root/bin/ableton-linkd" "$managed_linkd"
+fi
+chmod 755 "$managed_linkd"
+printf '999999\n' > "$base/run/ableton-wine/linkd.pid"
+exec {controller_lock}< "$base/home"
+flock -n "$controller_lock" || fail "could not create Link controller lock fixture"
+for controller_action in start stop; do
+    if run_isolated "$base" env -u ABLETON_INSTALL_LOCK_FD \
+        ABLETON_LINKD="$managed_linkd" ABLETON_LINK_MODE=session \
+        bash "$here/ableton-linkctl" "$controller_action" \
+        >"$base/$controller_action.out" 2>"$base/$controller_action.err"; then
+        fail "direct Link $controller_action bypassed an independent installer lock"
+    fi
+    grep -qF 'installation work is in progress' "$base/$controller_action.err" \
+        || fail "locked Link $controller_action refusal did not identify lifecycle work"
+    [ "$(cat "$base/run/ableton-wine/linkd.pid")" = 999999 ] \
+        || fail "locked Link $controller_action mutated the PID record"
+done
+[ ! -e "$base/state" ] && [ ! -e "$base/data/ableton-wine/logs" ] \
+    || fail "locked Link controller mutated persistent state before refusal"
+run_isolated "$base" env ABLETON_INSTALL_LOCK_FD="$controller_lock" \
+    ABLETON_LINKD="$managed_linkd" ABLETON_LINK_MODE=session ABLETON_LINKD_LINGER=5 \
+    bash "$here/ableton-linkctl" start >"$base/inherited.out" 2>"$base/inherited.err" \
+    || { sed -n '1,40p' "$base/inherited.err" >&2; fail "inherited installer Link start did not reuse its lock"; }
+link_controller_pid="$(cat "$base/run/ableton-wine/linkd.pid")"
+kill -0 "$link_controller_pid" 2>/dev/null \
+    || fail "inherited Link start did not leave its detached daemon running"
+exec {controller_lock}<&-
+run_isolated "$base" env -u ABLETON_INSTALL_LOCK_FD \
+    ABLETON_LINKD="$managed_linkd" ABLETON_LINK_MODE=session \
+    bash "$here/ableton-linkctl" stop >"$base/stop-after.out" 2>"$base/stop-after.err" \
+    || { sed -n '1,40p' "$base/stop-after.err" >&2; fail "detached Link daemon retained the global lock"; }
+kill -0 "$link_controller_pid" 2>/dev/null \
+    && fail "unlocked Link stop left the detached daemon running"
+[ ! -e "$base/run/ableton-wine/linkd.pid" ] \
+    || fail "unlocked Link stop retained its PID record"
+ok "Link controller serializes direct mutations without leaking the installer lock to its daemon"
+
 base="$(new_env legacy-ownership)"
 foreign_desktop="$base/data/applications/ableton-live.desktop"
 mkdir -p "$(dirname "$foreign_desktop")" "$base/fakebin"
 printf '[Desktop Entry]\nName=Foreign application\n' > "$foreign_desktop"
 printf '#!/bin/sh\nexit 0\n' > "$base/fakebin/systemctl"
 chmod +x "$base/fakebin/systemctl"
-if run_isolated "$base" env PATH="$base/fakebin:$PATH" bash "$here/uninstall.sh" \
-    --keep-prefix --yes >"$base/out" 2>"$base/err"; then
-    fail "manifest-free uninstall reports full success with a foreign canonical file"
-fi
+run_isolated "$base" env PATH="$base/fakebin:$PATH" bash "$here/uninstall.sh" \
+    --keep-prefix --yes >"$base/out" 2>"$base/err" \
+    || fail "preserving a foreign manifest-free desktop entry makes uninstall fail"
 [ -f "$foreign_desktop" ] || fail "legacy uninstall removes an unrecognised canonical desktop file"
-grep -q 'kept unrecognised or modified legacy file' "$base/err" \
+grep -qF "kept an unrecognised or modified file at $foreign_desktop" "$base/err" \
     || fail "legacy ownership refusal is not reported"
-[ -f "$base/config/ableton-wine/config" ] \
-    || fail "partial legacy uninstall discards the configuration needed to retry"
-grep -q 'run uninstall' "$base/err" \
+# This legacy fixture had no installer settings before uninstall. Defaults are
+# enough for a retry, so optional cleanup must not invent a configuration file.
+# If a future path does retain one, it still has to be a valid installer file.
+legacy_config="$base/config/ableton-wine/config"
+if [ -e "$legacy_config" ] || [ -L "$legacy_config" ]; then
+    ableton_managed_config_valid "$legacy_config" \
+        || fail "partial legacy uninstall retained invalid installer settings"
+fi
+grep -Eq 'Retry: .*uninstall\.sh --keep-prefix --yes' "$base/err" \
     || fail "legacy ownership rejection does not say how to finish the uninstall"
-ok "legacy uninstall retains unrecognised canonical files"
+ok "legacy uninstall warns and retains unrecognised canonical files"
 
 # Uninstall used to restore the MIME defaults after deleting its own desktop
 # entries.  xdg-mime reports no default once the entry file is gone, so the
@@ -1758,8 +2433,12 @@ run_isolated "$base" update-desktop-database "$base/data/applications" >/dev/nul
 mkdir -p "$base/config"
 run_isolated "$base" xdg-mime default third-party.desktop x-scheme-handler/ableton \
     || fail "test fixture could not set an explicit pre-install default"
+run_isolated "$base" xdg-mime default third-party.desktop text/plain \
+    || fail "test fixture could not set an unrelated MIME default"
 grep -qxF 'x-scheme-handler/ableton=third-party.desktop' "$base/config/mimeapps.list" \
     || fail "test fixture did not record an explicit pre-install default"
+grep -qxF 'text/plain=third-party.desktop' "$base/config/mimeapps.list" \
+    || fail "test fixture did not record its unrelated MIME default"
 run_isolated "$base" env PATH="$base/fakebin:$PATH" bash "$here/install.sh" --integration-only \
     >"$base/install.out" 2>"$base/install.err" \
     || { sed -n '1,40p' "$base/install.err" >&2; fail "integration install failed before MIME restoration"; }
@@ -1772,15 +2451,18 @@ if grep -Eq "=($ABLETON_PROTOCOL_DESKTOP_ID|$ABLETON_AUZ_DESKTOP_ID|ableton-live
     "$base/config/mimeapps.list"; then
     fail "uninstall leaves a MIME default naming an entry it removed"
 fi
-grep -qxF 'x-scheme-handler/ableton=third-party.desktop' "$base/config/mimeapps.list" \
-    || fail "uninstall does not restore an explicit pre-install default"
+! grep -q '^x-scheme-handler/ableton=' "$base/config/mimeapps.list" \
+    || fail "uninstall reconstructed an unknowable previous scheme default"
 ! grep -q '^application/x-wine-extension-auz=' "$base/config/mimeapps.list" \
     || fail "uninstall writes out a default the user never set explicitly"
-ok "uninstall clears its own MIME defaults and restores exactly what it found"
+grep -qxF 'text/plain=third-party.desktop' "$base/config/mimeapps.list" \
+    || fail "uninstall changed an unrelated MIME default"
+ok "uninstall clears project MIME defaults and preserves unrelated entries"
 
-# The installer saves a pre-existing launcher before writing the canonical
-# launcher. Uninstall restores the exact pre-install object.
-base="$(new_env foreign-live-entry)"
+# The canonical Live entry and its adjacent backup are installer-managed paths,
+# but either may contain an unrelated file before installation. Updates may
+# replace both while active; uninstall must return both originals exactly.
+base="$(new_env authoritative-live-entry)"
 mkdir -p "$base/data/applications" "$base/fakebin"
 printf '#!/bin/sh\nexit 0\n' > "$base/fakebin/systemctl"
 chmod +x "$base/fakebin/systemctl"
@@ -1789,7 +2471,7 @@ printf '[Desktop Entry]\nType=Application\nName=Foreign Live\nExec=/usr/bin/true
 cp "$base/data/applications/ableton-live.desktop" "$base/foreign-live.before"
 printf 'personal adjacent backup\n' > "$base/data/applications/ableton-live.desktop.bak"
 chmod 600 "$base/data/applications/ableton-live.desktop.bak"
-cp -a "$base/data/applications/ableton-live.desktop.bak" "$base/foreign-live-backup.before"
+cp "$base/data/applications/ableton-live.desktop.bak" "$base/foreign-live-backup.before"
 run_isolated "$base" env PATH="$base/fakebin:$PATH" bash "$here/install.sh" --integration-only \
     >"$base/out" 2>"$base/err" \
     || { sed -n '1,40p' "$base/err" >&2; fail "integration install failed with a foreign Live entry"; }
@@ -1798,25 +2480,26 @@ grep -qxF 'Name=Ableton Live' "$base/data/applications/ableton-live.desktop" \
 grep -Eq '^application/x-ableton-live-(set|clip|pack)=ableton-live\.desktop$' \
     "$base/config/mimeapps.list" \
     || fail "integration did not assign Live file types to its installed entry"
-prestate_id="$(printf '%s' "$base/data/applications/ableton-live.desktop" | sha256sum | awk '{print $1}')"
-backup_prestate_id="$(printf '%s' "$base/data/applications/ableton-live.desktop.bak" | sha256sum | awk '{print $1}')"
 cmp -s "$base/foreign-live.before" "$base/data/applications/ableton-live.desktop.bak" \
     || fail "integration did not create ableton-live.desktop.bak"
-cmp -s "$base/foreign-live.before" "$base/state/ableton-wine/install-prestate/$prestate_id" \
-    || fail "integration did not back up the foreign Live desktop entry"
-cmp -s "$base/foreign-live-backup.before" "$base/state/ableton-wine/install-prestate/$backup_prestate_id" \
-    || fail "integration did not preserve the pre-existing adjacent backup"
+# Force another launcher generation. The first install's saved originals must
+# remain authoritative instead of being replaced by this intermediate state.
+printf '\n# later generated-entry drift\n' >> "$base/data/applications/ableton-live.desktop"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" bash "$here/install.sh" --integration-only \
+    >"$base/update.out" 2>"$base/update.err" \
+    || { sed -n '1,40p' "$base/update.err" >&2; fail "launcher update failed after preserving both collisions"; }
+grep -qxF 'Name=Ableton Live' "$base/data/applications/ableton-live.desktop" \
+    || fail "launcher update did not repair the generated Live entry"
 run_isolated "$base" env PATH="$base/fakebin:$PATH" bash "$here/uninstall.sh" \
     --keep-prefix --yes >"$base/uninstall.out" 2>"$base/uninstall.err" \
     || { sed -n '1,40p' "$base/uninstall.err" >&2; fail "uninstall failed after replacing a foreign Live entry"; }
 cmp -s "$base/foreign-live.before" "$base/data/applications/ableton-live.desktop" \
     || fail "uninstall did not restore the foreign Live desktop entry"
 cmp -s "$base/foreign-live-backup.before" "$base/data/applications/ableton-live.desktop.bak" \
-    && [ "$(stat -c '%a' "$base/data/applications/ableton-live.desktop.bak")" = 600 ] \
     || fail "uninstall did not restore the pre-existing adjacent backup"
-ok "integration restores a foreign launcher and its pre-existing adjacent backup"
+ok "launcher updates preserve and uninstall restores both pre-existing desktop files"
 
-base="$(new_env dangling-launcher-backup)"
+base="$(new_env authoritative-dangling-launcher-backup)"
 dangling_launcher="$base/data/applications/ableton-live.desktop"
 dangling_backup="${dangling_launcher}.bak"
 dangling_target=personal-missing-backup-target
@@ -1825,24 +2508,21 @@ printf '#!/bin/sh\nexit 0\n' > "$base/fakebin/systemctl"
 chmod +x "$base/fakebin/systemctl"
 printf '[Desktop Entry]\nType=Application\nName=Foreign Live\nExec=/usr/bin/true %%f\n' \
     > "$dangling_launcher"
+cp "$dangling_launcher" "$base/foreign-live.before"
 ln -s "$dangling_target" "$dangling_backup"
 run_isolated "$base" env PATH="$base/fakebin:$PATH" bash "$here/install.sh" --integration-only \
     >"$base/install.out" 2>"$base/install.err" \
     || fail "integration install failed with a dangling adjacent backup"
-dangling_prestate_id="$(printf '%s' "$dangling_backup" | sha256sum | awk '{print $1}')"
-dangling_prestate="$base/state/ableton-wine/install-prestate/$dangling_prestate_id"
-[ -L "$dangling_prestate" ] && [ ! -e "$dangling_prestate" ] \
-    && [ "$(readlink -- "$dangling_prestate")" = "$dangling_target" ] \
-    || fail "integration did not preserve the dangling adjacent backup"
+grep -qxF 'Name=Foreign Live' "$dangling_backup" \
+    || fail "integration did not replace the dangling backup with the displaced launcher"
 run_isolated "$base" env PATH="$base/fakebin:$PATH" bash "$here/uninstall.sh" \
     --keep-prefix --yes >"$base/uninstall.out" 2>"$base/uninstall.err" \
-    || { sed -n '1,40p' "$base/uninstall.err" >&2; fail "uninstall failed with dangling launcher backup prestate"; }
-grep -qxF 'Name=Foreign Live' "$dangling_launcher" \
-    || fail "uninstall did not restore the launcher beside a dangling backup"
-[ -L "$dangling_backup" ] && [ ! -e "$dangling_backup" ] \
-    && [ "$(readlink -- "$dangling_backup")" = "$dangling_target" ] \
-    || fail "uninstall did not restore the dangling adjacent backup"
-ok "integration restores dangling adjacent launcher backup prestate"
+    || { sed -n '1,40p' "$base/uninstall.err" >&2; fail "uninstall failed after replacing a dangling launcher backup"; }
+cmp -s "$base/foreign-live.before" "$dangling_launcher" \
+    || fail "uninstall did not restore the launcher displaced before a dangling collision"
+[ -L "$dangling_backup" ] && [ "$(readlink -- "$dangling_backup")" = "$dangling_target" ] \
+    || fail "uninstall did not restore the pre-existing dangling adjacent backup"
+ok "launcher replacement preserves and restores a dangling adjacent backup"
 
 base="$(new_env identical-foreign-launcher)"
 identical_launcher="$base/home/.local/bin/ableton-live"
@@ -1870,35 +2550,37 @@ ok "byte-identical pre-existing launchers receive managed adjacent backups"
 base="$(new_env launcher-directory-collision)"
 directory_launcher="$base/data/applications/ableton-live.desktop"
 mkdir -p "$directory_launcher"
-if run_isolated "$base" bash "$here/install.sh" --integration-only \
-    >"$base/out" 2>"$base/err"; then
-    fail "integration replaced a directory at a launcher path"
-fi
+run_isolated "$base" bash "$here/install.sh" --integration-only \
+    >"$base/out" 2>"$base/err" \
+    || fail "one launcher directory collision blocked the rest of integration"
 [ -d "$directory_launcher" ] && [ ! -L "$directory_launcher" ] \
     || fail "launcher directory refusal changed the collision"
 [ ! -e "${directory_launcher}.bak" ] && [ ! -L "${directory_launcher}.bak" ] \
     || fail "launcher directory refusal created an adjacent backup"
 grep -qF "launcher path points to a directory: $directory_launcher" "$base/err" \
     || fail "launcher directory refusal did not report the actual cause"
-ok "launcher directory collisions fail with an explicit reason"
+grep -qF 'Some shortcuts or support files could not be updated. Run the installer again to retry them.' \
+    "$base/err" || fail "launcher directory refusal omitted the plain retry warning"
+ok "launcher directory collisions are preserved and warn without blocking other repairs"
 
 base="$(new_env launcher-fifo-collision)"
 fifo_launcher="$base/home/.local/bin/ableton-live"
 mkdir -p "$(dirname "$fifo_launcher")"
 mkfifo "$fifo_launcher"
-if run_isolated "$base" bash "$here/install.sh" --integration-only \
-    >"$base/out" 2>"$base/err"; then
-    fail "integration replaced a FIFO at a launcher path"
-fi
+run_isolated "$base" bash "$here/install.sh" --integration-only \
+    >"$base/out" 2>"$base/err" \
+    || fail "one launcher FIFO collision blocked the rest of integration"
 [ -p "$fifo_launcher" ] \
     || fail "launcher FIFO refusal changed the collision"
 [ ! -e "${fifo_launcher}.bak" ] && [ ! -L "${fifo_launcher}.bak" ] \
     || fail "launcher FIFO refusal created an adjacent backup"
 grep -qF "launcher path is not a regular file or symlink: $fifo_launcher" "$base/err" \
     || fail "launcher FIFO refusal did not report the actual path"
-ok "launcher special-file collisions fail with an explicit reason"
+grep -qF 'Some shortcuts or support files could not be updated. Run the installer again to retry them.' \
+    "$base/err" || fail "launcher FIFO refusal omitted the plain retry warning"
+ok "launcher special-file collisions are preserved and warn without blocking other repairs"
 
-# Session Link policy writes the unit for later but never runs it, so it must
+# Session Link mode writes the unit for later but never runs it, so it must
 # not need a user manager that answers.  Only always-on policy does.
 base="$(new_env link-no-user-manager)"
 mkdir -p "$base/data/ableton-wine" "$base/state/ableton-wine" "$base/fakebin"
@@ -1933,7 +2615,7 @@ if run_isolated "$base" env PATH="$base/fakebin:$PATH" \
     bash "$here/setup-link.sh" enable --mode=always >"$base/always.out" 2>"$base/always.err"; then
     fail "always-on Link enable succeeded with no systemd user manager"
 fi
-ok "session Link policy does not depend on a reachable systemd user manager"
+ok "session Link mode does not depend on a reachable systemd user manager"
 
 # setup-link.sh sources the ownership helper, so a Link-only install has to ship
 # it: TROUBLESHOOTING tells people to run the installed copy.
@@ -1944,7 +2626,7 @@ run_isolated "$base" bash "$here/install.sh" --link-assets-only \
 run_isolated "$base" bash "$base/data/ableton-wine/setup-link.sh" status \
     >"$base/status.out" 2>"$base/status.err" \
     || { sed -n '1,20p' "$base/status.err" >&2; fail "the installed setup-link.sh cannot run"; }
-grep -q '^policy:' "$base/status.out" || fail "installed Link status reported no policy"
+grep -q '^mode:' "$base/status.out" || fail "installed Link status reported no mode"
 ok "a link-only install ships every library its setup-link.sh needs"
 
 # Status only reads.  It has to answer while a lifecycle command holds the
@@ -1957,7 +2639,7 @@ run_isolated "$base" bash -c '
     flock -n "$held" || exit 9
     bash "$1" status' locked "$here/setup-link.sh" >"$base/out" 2>"$base/err" \
     || { sed -n '1,20p' "$base/err" >&2; fail "Link status fails while the installation lock is held"; }
-grep -q '^policy:' "$base/out" || fail "locked Link status reported no policy"
+grep -q '^mode:' "$base/out" || fail "locked Link status reported no mode"
 ok "Link status answers while the installation lock is held"
 
 # A missing prefix or runtime names itself.  Both used to arrive as an audio

--- a/scripts/test-installer-lifecycle.sh
+++ b/scripts/test-installer-lifecycle.sh
@@ -731,6 +731,10 @@ cat > "$kit/scripts/install.sh" <<'EOF'
 set -eu
 printf 'component %s\n' "$*" >> "${ABLETON_TEST_CALL_LOG:?}"
 case " $* " in
+    *' --integration-only '*)
+        [ "${ABLETON_TEST_CONFIG_DIRECTORY:-0}" -eq 0 ] \
+            || mkdir -p -- "${ABLETON_CONFIG_FILE:?}"
+        exit "${ABLETON_TEST_INTEGRATION_EXIT:-0}" ;;
     *' --commit '*) exit "${ABLETON_TEST_COMPONENT_COMMIT_EXIT:-0}" ;;
 esac
 exit 0
@@ -911,6 +915,41 @@ fi
 ! grep -q '^OK:' "$base/out" || fail "missing Live executable reports success"
 ok "Wine exit 0 without the selected Live executable fails and rolls back"
 
+# Desktop integration status 3 is a repair request after the core install has
+# committed. The final warning and summary must preserve that distinction.
+live_exe="$base/prefix/drive_c/ProgramData/Ableton/Live 12 Suite/Program/Ableton Live 12 Suite.exe"
+run_payload_install ABLETON_TEST_INTEGRATION_EXIT=3 \
+    || fail "desktop integration retry status rejects a completed install"
+grep -q 'OK: Ableton Live 12 is installed' "$base/out" \
+    || fail "desktop integration retry status hides the completed install"
+[ -x "$base/runtime/bin/wine" ] && [ -f "$base/prefix/system.reg" ] \
+    && [ -f "$live_exe" ] \
+    || fail "desktop integration retry status discards the committed core"
+! grep -q -- '--rollback' "$base/calls.log" \
+    || fail "desktop integration retry status rolls back the committed core"
+grep -qF 'Ableton Live 12 is installed, but some desktop files need another update. Run the installer again to retry them.' \
+    "$base/err" || fail "desktop integration retry status omits its repair warning"
+grep -qF 'desktop shortcuts: retry needed' "$base/out" \
+    || fail "desktop integration retry status is missing from the final summary"
+ok "desktop integration retry status preserves the core and names the remaining repair"
+
+# A settings-path collision can appear after the core commit. Saving those
+# settings remains retryable and the final summary must say so explicitly.
+run_payload_install ABLETON_TEST_CONFIG_DIRECTORY=1 \
+    || fail "saved-settings failure rejects a completed install"
+grep -q 'OK: Ableton Live 12 is installed' "$base/out" \
+    || fail "saved-settings failure hides the completed install"
+[ -x "$base/runtime/bin/wine" ] && [ -f "$base/prefix/system.reg" ] \
+    && [ -f "$live_exe" ] \
+    || fail "saved-settings failure discards the committed core"
+! grep -q -- '--rollback' "$base/calls.log" \
+    || fail "saved-settings failure rolls back the committed core"
+grep -qF 'Ableton Live 12 is installed, but the installer could not save these settings. Run the installer again to retry.' \
+    "$base/err" || fail "saved-settings failure omits its retry warning"
+grep -qF 'saved settings: retry needed' "$base/out" \
+    || fail "saved-settings failure is missing from the final summary"
+ok "saved-settings failure preserves the core and appears in the final summary"
+
 # Link setup runs after the core runtime, prefix, and Live installation commit.
 # Any Link failure keeps that usable core and reports a concrete retry command.
 cat > "$kit/scripts/setup-link.sh" <<'EOF'
@@ -934,7 +973,6 @@ run_failed_link_install()
 link_installer="$base/Downloads/Ableton Installer.run"
 printf -v quoted_link_installer '%q' "$link_installer"
 link_resume_command="sh $quoted_link_installer link enable --mode=always"
-live_exe="$base/prefix/drive_c/ProgramData/Ableton/Live 12 Suite/Program/Ableton Live 12 Suite.exe"
 for link_failure in 1 70 75; do
     run_failed_link_install "$link_failure" \
         || fail "full install fails when Link exits $link_failure"

--- a/scripts/test-launcher-transactions.sh
+++ b/scripts/test-launcher-transactions.sh
@@ -1,0 +1,1265 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+work="$(mktemp -d "${TMPDIR:-/tmp}/ableton-launcher-transaction-test.XXXXXX")"
+declare -a cleanup_pids=()
+
+cleanup()
+{
+    local pid
+    for pid in "${cleanup_pids[@]}"; do
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    done
+    rm -rf -- "$work"
+}
+trap cleanup EXIT
+
+pass=0
+ok()
+{
+    pass=$((pass + 1))
+    printf 'ok - %s\n' "$1"
+}
+fail()
+{
+    printf 'not ok - %s\n' "$1" >&2
+    exit 1
+}
+
+new_env()
+{
+    local base="$work/$1"
+    mkdir -p -- "$base/home" "$base/tmp" "$base/fakebin"
+    printf '%s\n' "$base"
+}
+
+run_isolated()
+{
+    local base="$1"; shift
+    env HOME="$base/home" XDG_CONFIG_HOME="$base/config" XDG_DATA_HOME="$base/data" \
+        XDG_STATE_HOME="$base/state" XDG_CACHE_HOME="$base/cache" \
+        XDG_RUNTIME_DIR="$base/run" TMPDIR="$base/tmp" \
+        ABLETON_SHORTCUTS=preserve ABLETON_MAX_AUDIO_THREADS=off \
+        PATH="$base/fakebin:/usr/bin:/bin" "$@"
+}
+
+protocol_id=io.github.shibco.ableton-linux.protocol.desktop
+auz_id=io.github.shibco.ableton-linux.auz.desktop
+
+prepare_fixture()
+{
+    local base="$1" live_exe
+    mkdir -p -- "$base/runtime/bin" \
+        "$base/prefix/drive_c/ProgramData/Ableton/Live 12 Suite/Program" \
+        "$base/prefix/drive_c/Program Files/Cycling '74/Max 9" \
+        "$base/data/ableton-wine" "$base/data/applications" \
+        "$base/config/ableton-wine" "$base/state/ableton-wine" "$base/run"
+    cp -- /bin/sleep "$base/runtime/bin/wine-client"
+    cat > "$base/runtime/bin/wine" <<'EOF'
+#!/usr/bin/env bash
+case " $* " in
+    *' taskkill '*)
+        [ -z "${ABLETON_TEST_TASKKILL_LOG:-}" ] \
+            || printf 'taskkill %s\n' "$*" >> "$ABLETON_TEST_TASKKILL_LOG"
+        exit 0 ;;
+esac
+printf 'wine %s\n' "$*" >> "${ABLETON_TEST_WINE_LOG:?}"
+if [ "${1:-}" = reg ]; then
+    # Real reg.exe brings up a wineserver which inherits the transaction token
+    # and remains observable until wineserver -k. Model that ownership contract
+    # so successful tests exercise the launcher's tagged-process allowlist.
+    if [ -n "${ABLETON_DPI_TRANSACTION:-}" ]; then
+        tagged_pid_file="${ABLETON_TEST_WINE_LOG}.tagged-pid"
+        tagged_pid="$(cat "$tagged_pid_file" 2>/dev/null || true)"
+        if [ -z "$tagged_pid" ] || ! kill -0 "$tagged_pid" 2>/dev/null; then
+            env WINEPREFIX="${WINEPREFIX:?}" \
+                ABLETON_DPI_TRANSACTION="$ABLETON_DPI_TRANSACTION" \
+                "${0%/*}/wine-client" 60 &
+            printf '%s\n' "$!" > "$tagged_pid_file"
+        fi
+    fi
+    case " $* " in
+        *' dpiAwareness '*)
+            if [ -n "${ABLETON_TEST_REG_FOREIGN_PID_FILE:-}" ]; then
+                env -u ABLETON_DPI_TRANSACTION WINEPREFIX="${WINEPREFIX:?}" \
+                    "${0%/*}/wine-client" 60 &
+                printf '%s\n' "$!" > "$ABLETON_TEST_REG_FOREIGN_PID_FILE"
+            fi ;;
+    esac
+    [ "${ABLETON_TEST_REG_FAIL:-0}" -ne 1 ] || exit 77
+    exit 0
+fi
+if [ -n "${ABLETON_TEST_APP_IMAGE:-}" ]; then
+    printf '%s\n' "$$" > "${ABLETON_TEST_APP_PID_FILE:?}"
+    exec -a "$ABLETON_TEST_APP_IMAGE" "${0%/*}/wine-client" 60
+fi
+if [ "${ABLETON_TEST_UNOBSERVABLE_WINE:-0}" -eq 1 ]; then
+    exec /bin/sleep 60
+fi
+exit 0
+EOF
+cat > "$base/runtime/bin/wineserver" <<'EOF'
+#!/usr/bin/env bash
+printf 'wineserver %s\n' "$*" >> "${ABLETON_TEST_WINE_LOG:?}"
+tagged_pid_file="${ABLETON_TEST_WINE_LOG}.tagged-pid"
+tagged_pid="$(cat "$tagged_pid_file" 2>/dev/null || true)"
+if [ "${1:-}" = -k ] && [ -n "$tagged_pid" ]; then
+    kill "$tagged_pid" 2>/dev/null || true
+    : > "$tagged_pid_file"
+fi
+[ "${1:-}" != -w ] || [ "${ABLETON_TEST_WINESERVER_WAIT_FAIL:-0}" -ne 1 ] || exit 78
+exit 0
+EOF
+    cat > "$base/runtime/bin/wineboot" <<'EOF'
+#!/bin/sh
+printf 'wineboot %s\n' "$*" >> "${ABLETON_TEST_WINE_LOG:?}"
+[ "${ABLETON_TEST_WINEBOOT_FAIL:-0}" -ne 1 ] || exit 79
+exit 0
+EOF
+    printf '#!/bin/sh\nexit 0\n' > "$base/runtime/bin/winepath"
+    cat > "$base/fakebin/xdg-mime" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state="${XDG_CONFIG_HOME:?}/mimeapps.list"
+case "${1:-}" in
+    query)
+        [ "${2:-}" = default ] && [ "$#" -eq 3 ]
+        awk -F '=' -v type="$3" '$1 == type { value=$2 } END { print value }' \
+            "$state" 2>/dev/null || true ;;
+    default)
+        [ "$#" -ge 3 ]
+        [ -z "${ABLETON_TEST_MIME_DEFAULT_LOG:-}" ] \
+            || printf '%s\n' "$XDG_CONFIG_HOME" >> "$ABLETON_TEST_MIME_DEFAULT_LOG"
+        [ "${ABLETON_TEST_MIME_DEFAULT_FAIL:-0}" -ne 1 ] || exit 77
+        application="$2"
+        shift 2
+        mkdir -p -- "$(dirname "$state")"
+        touch "$state"
+        for type in "$@"; do
+            awk -F '=' -v type="$type" '$1 != type' "$state" > "$state.tmp"
+            printf '%s=%s\n' "$type" "$application" >> "$state.tmp"
+            mv -f -- "$state.tmp" "$state"
+        done
+        ;;
+    *) exit 2 ;;
+esac
+EOF
+    cat > "$base/fakebin/update-desktop-database" <<'EOF'
+#!/bin/sh
+[ "${ABLETON_TEST_DESKTOP_DATABASE_FAIL:-0}" -ne 1 ]
+EOF
+    for tool in update-mime-database gtk-update-icon-cache; do
+        printf '#!/bin/sh\nexit 0\n' > "$base/fakebin/$tool"
+    done
+    chmod +x "$base/runtime/bin/"* "$base/fakebin/"*
+    printf 'registry\n' > "$base/prefix/system.reg"
+    printf 'registry\n' > "$base/prefix/user.reg"
+    live_exe="$base/prefix/drive_c/ProgramData/Ableton/Live 12 Suite/Program/Ableton Live 12 Suite.exe"
+    printf 'exe\n' > "$live_exe"
+    printf 'exe\n' > "$base/prefix/drive_c/Program Files/Cycling '74/Max 9/Max.exe"
+    cp -- "$here/detect-scale.sh" "$base/data/ableton-wine/detect-scale.sh"
+    sed "s#@BIN@#$base/home/.local/bin#g" "$here/../desktop/ableton-linux-protocol.desktop.in" \
+        > "$base/data/ableton-wine/$protocol_id"
+    sed "s#@BIN@#$base/home/.local/bin#g" "$here/../desktop/ableton-linux-auz.desktop.in" \
+        > "$base/data/ableton-wine/$auz_id"
+    cp -- "$base/data/ableton-wine/$protocol_id" "$base/data/applications/$protocol_id"
+    cp -- "$base/data/ableton-wine/$auz_id" "$base/data/applications/$auz_id"
+    cat > "$base/config/ableton-wine/config" <<EOF
+# ableton-linux installer configuration; managed by the installer
+format=1
+runtime_root=$base/runtime
+prefix=$base/prefix
+live_major=12
+link_mode=off
+linkd=$base/data/ableton-wine/ableton-linkd
+EOF
+    printf 'format=1\nowner=ableton-linux\n' > "$base/state/ableton-wine/.ableton-linux-state"
+    cat > "$base/config/mimeapps.list" <<EOF
+x-scheme-handler/ableton=$protocol_id
+application/x-wine-extension-auz=$auz_id
+EOF
+}
+
+run_live()
+{
+    local base="$1"; shift
+    run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+        ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=preserve \
+        ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+        ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+        ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$here/ableton-live" "$@"
+}
+
+# Mutter exposes mixed logical monitors to Xwayland through one framebuffer at
+# the highest active integer scale. The GNOME detector must therefore not
+# follow a 100% primary while a fractional secondary has doubled X11 space.
+base="$(new_env mixed-gnome-dpi)"
+cat > "$base/fakebin/gdbus" <<'EOF'
+#!/bin/sh
+printf '%s\n' "${ABLETON_TEST_GNOME_STATE:?}"
+EOF
+chmod +x "$base/fakebin/gdbus"
+gnome_state='([(0, 0, 1.0, uint32 0, true, "DP-1"), (-1920, 480, 1.3333333333333333, 0, false, "eDP-1")],)'
+detected="$(run_isolated "$base" env ABLETON_TEST_GNOME_STATE="$gnome_state" \
+    bash -c '. "$1"; ableton_detect_scale_ex' _ "$here/detect-scale.sh" \
+    2>"$base/detect.err")"
+[ "$detected" = '1.33333 gnome' ] \
+    || fail "GNOME mixed-scale detection followed the primary instead of Xwayland's shared framebuffer"
+block="$(run_isolated "$base" bash -c \
+    '. "$1"; ableton_dpi_block_for_scale 1.33333 gnome' _ "$here/detect-scale.sh")"
+[ "$block" = fractional ] \
+    || fail "GNOME mixed-scale detection did not select the doubled-framebuffer DPI block"
+grep -qF "using GNOME/Xwayland's shared framebuffer scale from 1.3333333333333333" \
+    "$base/detect.err" || fail "GNOME mixed-scale detection did not explain its global choice"
+ok "GNOME mixed scales follow Xwayland's shared framebuffer"
+
+# Changing LogPixels through reg.exe starts Wine under the old value. A cold
+# launcher must stop that owned session, wait, and only then wineboot and Live.
+base="$(new_env coherent-dpi-transaction)"
+prepare_fixture "$base"
+: > "$base/wine.log"
+cat > "$base/fakebin/gdbus" <<'EOF'
+#!/bin/sh
+printf '%s\n' "${ABLETON_TEST_GNOME_STATE:?}"
+EOF
+cat > "$base/fakebin/gsettings" <<'EOF'
+#!/bin/sh
+printf '%s\n' "['scale-monitor-framebuffer', 'xwayland-native-scaling']"
+EOF
+chmod +x "$base/fakebin/gdbus" "$base/fakebin/gsettings"
+run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=auto \
+    ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+    ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_GNOME_STATE="$gnome_state" \
+    ABLETON_TEST_APP_IMAGE='Ableton Live 12 Suite.exe' \
+    ABLETON_TEST_APP_PID_FILE="$base/app.pid" \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$here/ableton-live" \
+    >"$base/out" 2>"$base/err" &
+launcher_pid=$!
+cleanup_pids+=("$launcher_pid")
+for _ in {1..100}; do [ -s "$base/app.pid" ] && break; sleep 0.1; done
+[ -s "$base/app.pid" ] || fail "coherent DPI transaction did not reach Live"
+app_pid="$(cat "$base/app.pid")"
+cleanup_pids+=("$app_pid")
+reg_lp_line="$(grep -nF 'wine reg add HKCU\Control Panel\Desktop /v LogPixels /t REG_DWORD /d 192 /f' "$base/wine.log" | cut -d: -f1 || true)"
+reg_ifeo_line="$(grep -nF 'wine reg add HKLM\Software\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\Ableton Live 12 Suite.exe /v dpiAwareness /t REG_DWORD /d 2 /f' "$base/wine.log" | cut -d: -f1 || true)"
+stop_line="$(grep -nF 'wineserver -k' "$base/wine.log" | cut -d: -f1 || true)"
+wait_line="$(grep -nF 'wineserver -w' "$base/wine.log" | cut -d: -f1 || true)"
+boot_line="$(grep -nF 'wineboot -u' "$base/wine.log" | cut -d: -f1 || true)"
+live_line="$(grep -nF 'wine C:\ProgramData\Ableton\Live 12 Suite\Program\Ableton Live 12 Suite.exe' "$base/wine.log" | cut -d: -f1 || true)"
+if [ -z "$reg_lp_line" ] || [ -z "$reg_ifeo_line" ] || [ -z "$stop_line" ] \
+   || [ -z "$wait_line" ] || [ -z "$boot_line" ] || [ -z "$live_line" ] \
+   || [ "$reg_lp_line" -ge "$reg_ifeo_line" ] || [ "$reg_ifeo_line" -ge "$stop_line" ] \
+   || [ "$stop_line" -ge "$wait_line" ] || [ "$wait_line" -ge "$boot_line" ] \
+   || [ "$boot_line" -ge "$live_line" ]; then
+    fail "DPI registry writes, Wine restart, boot, and Live launch were not coherently ordered"
+fi
+kill "$app_pid" 2>/dev/null || true
+wait "$launcher_pid" 2>/dev/null || true
+ok "a changed DPI block restarts the owned Wine session before Live"
+
+# Every failure after the first registry write must leave the reseed marker in
+# place. A later launch may then finish a coherent boot; it must never mistake
+# partial registry, failed wait, or failed boot state for a completed transition.
+for dpi_failure in registry wait boot; do
+    base="$(new_env "dpi-$dpi_failure-failure")"
+    prepare_fixture "$base"
+    : > "$base/wine.log"
+    case "$dpi_failure" in
+        registry) failure_env=ABLETON_TEST_REG_FAIL=1 ;;
+        wait)     failure_env=ABLETON_TEST_WINESERVER_WAIT_FAIL=1 ;;
+        boot)     failure_env=ABLETON_TEST_WINEBOOT_FAIL=1 ;;
+    esac
+    if run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+        ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=fractional \
+        ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+        ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+        "$failure_env" ABLETON_TEST_WINE_LOG="$base/wine.log" \
+        bash "$here/ableton-live" >"$base/out" 2>"$base/err"; then
+        fail "$dpi_failure failure allowed Live to launch"
+    fi
+    reseed_marker="$base/prefix/.ableton-linux-dpi-reseed-required"
+    [ -n "$reseed_marker" ] && [ -f "$reseed_marker" ] \
+        || fail "$dpi_failure failure discarded the pending DPI reseed marker"
+    grep -qF 'wine reg add HKCU\Control Panel\Desktop' "$base/wine.log" \
+        || fail "$dpi_failure failure fixture never entered the DPI transaction"
+    if grep -qF 'wine C:\ProgramData\Ableton\Live 12 Suite\Program\Ableton Live 12 Suite.exe' \
+        "$base/wine.log"; then
+        fail "$dpi_failure failure continued into Live"
+    fi
+    case "$dpi_failure" in
+        registry|wait)
+            if grep -qF 'wineboot -u' "$base/wine.log"; then
+                fail "$dpi_failure failure continued into wineboot"
+            fi ;;
+        boot)
+            grep -qF 'wineboot -u' "$base/wine.log" \
+                || fail "wineboot failure fixture did not reach wineboot" ;;
+    esac
+done
+ok "DPI write, wait, and boot failures retain the coherent-reseed fence"
+
+# Auto-detection is not permission to keep the GNOME fractional block when
+# Mutter says native Xwayland scaling is off. Select the coherent 100% block
+# and apply it through the same atomic restart transaction.
+base="$(new_env gnome-auto-native-scaling-off)"
+prepare_fixture "$base"
+cat > "$base/prefix/user.reg" <<'EOF'
+[Control Panel\\Desktop]
+"LogPixels"=dword:000000c0
+EOF
+cat > "$base/prefix/system.reg" <<'EOF'
+[Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\Ableton Live 12 Suite.exe]
+"dpiAwareness"=dword:00000002
+EOF
+cat > "$base/fakebin/gdbus" <<'EOF'
+#!/bin/sh
+printf '%s\n' "${ABLETON_TEST_GNOME_STATE:?}"
+EOF
+cat > "$base/fakebin/gsettings" <<'EOF'
+#!/bin/sh
+printf '%s\n' "['scale-monitor-framebuffer']"
+EOF
+chmod +x "$base/fakebin/gdbus" "$base/fakebin/gsettings"
+: > "$base/wine.log"
+run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=auto \
+    ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+    ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_GNOME_STATE="$gnome_state" \
+    ABLETON_TEST_APP_IMAGE='Ableton Live 12 Suite.exe' \
+    ABLETON_TEST_APP_PID_FILE="$base/app.pid" \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$here/ableton-live" \
+    >"$base/out" 2>"$base/err" &
+launcher_pid=$!
+cleanup_pids+=("$launcher_pid")
+for _ in {1..100}; do [ -s "$base/app.pid" ] && break; sleep 0.1; done
+[ -s "$base/app.pid" ] || fail "GNOME feature-off auto mode did not reach Live"
+app_pid="$(cat "$base/app.pid")"
+cleanup_pids+=("$app_pid")
+grep -qF 'wine reg add HKCU\Control Panel\Desktop /v LogPixels /t REG_DWORD /d 96 /f' \
+    "$base/wine.log" || fail "GNOME feature-off auto mode did not select 96 DPI"
+grep -qF 'wine reg delete HKLM\Software\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\Ableton Live 12 Suite.exe /v dpiAwareness /f' \
+    "$base/wine.log" || fail "GNOME feature-off auto mode retained the fractional IFEO"
+grep -qF 'wineserver -k' "$base/wine.log" \
+    || fail "GNOME feature-off transition did not restart Wine"
+grep -qF 'wineboot -u' "$base/wine.log" \
+    || fail "GNOME feature-off transition did not coherently boot Wine"
+grep -qF 'GNOME xwayland-native-scaling is OFF; selecting the coherent 100% DPI block.' "$base/err" \
+    || fail "GNOME feature-off auto mode did not explain its coherent fallback"
+kill "$app_pid" 2>/dev/null || true
+wait "$launcher_pid" 2>/dev/null || true
+ok "GNOME auto mode selects a coherent DPI block when native scaling is off"
+
+# A missing settings client is not evidence that Mutter's required feature is
+# enabled. With no provably coherent automatic block, refuse before Wine and
+# require an explicit user policy.
+base="$(new_env gnome-auto-no-gsettings)"
+prepare_fixture "$base"
+cat > "$base/fakebin/gdbus" <<'EOF'
+#!/bin/sh
+printf '%s\n' "${ABLETON_TEST_GNOME_STATE:?}"
+EOF
+cat > "$base/no-gsettings.bash" <<'EOF'
+command()
+{
+    if [ "${1:-}" = -v ] && [ "${2:-}" = gsettings ]; then return 1; fi
+    builtin command "$@"
+}
+EOF
+chmod +x "$base/fakebin/gdbus"
+: > "$base/wine.log"
+: > "$base/taskkill.log"
+if run_isolated "$base" env USER=test BASH_ENV="$base/no-gsettings.bash" \
+    ABLETON_POWER=off ABLETON_RT=off ABLETON_THEME_MODE=preserve \
+    ABLETON_DPI_MODE=auto ABLETON_UI_FONT=preserve \
+    ABLETON_TEXT_SMOOTHING=preserve ABLETON_TOPBAR_MODE=preserve \
+    ABLETON_LAUNCH_TIMEOUT=5 ABLETON_TEST_GNOME_STATE="$gnome_state" \
+    ABLETON_TEST_TASKKILL_LOG="$base/taskkill.log" \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$here/ableton-live" \
+    >"$base/out" 2>"$base/err"; then
+    fail "GNOME auto mode launched without verifying native Xwayland scaling"
+fi
+[ ! -s "$base/wine.log" ] \
+    || fail "GNOME unverifiable-feature refusal started Wine"
+[ ! -s "$base/taskkill.log" ] \
+    || fail "GNOME unverifiable-feature refusal ran prefix teardown"
+[ ! -e "$base/prefix/.ableton-linux-dpi-reseed-required" ] \
+    || fail "GNOME unverifiable-feature refusal created a DPI transaction marker"
+grep -qF 'GNOME xwayland-native-scaling could not be verified, so Live was not started.' "$base/err" \
+    || fail "GNOME auto mode did not report its unverifiable-feature refusal"
+ok "GNOME auto mode refuses when native scaling cannot be verified"
+
+# Exercise the production regression direction too: a persisted fractional
+# block returning to 100% must delete the IFEO value before the same restart.
+base="$(new_env coherent-dpi-reverse-transaction)"
+prepare_fixture "$base"
+cat > "$base/prefix/user.reg" <<'EOF'
+[Control Panel\\Desktop]
+"LogPixels"=dword:000000c0
+EOF
+cat > "$base/prefix/system.reg" <<'EOF'
+[Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\Ableton Live 12 Suite.exe]
+"dpiAwareness"=dword:00000002
+EOF
+: > "$base/wine.log"
+run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=100 \
+    ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+    ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_APP_IMAGE='Ableton Live 12 Suite.exe' \
+    ABLETON_TEST_APP_PID_FILE="$base/app.pid" \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$here/ableton-live" \
+    >"$base/out" 2>"$base/err" &
+launcher_pid=$!
+cleanup_pids+=("$launcher_pid")
+for _ in {1..100}; do [ -s "$base/app.pid" ] && break; sleep 0.1; done
+[ -s "$base/app.pid" ] || fail "reverse DPI transaction did not reach Live"
+app_pid="$(cat "$base/app.pid")"
+cleanup_pids+=("$app_pid")
+reg_lp_line="$(grep -nF 'wine reg add HKCU\Control Panel\Desktop /v LogPixels /t REG_DWORD /d 96 /f' "$base/wine.log" | cut -d: -f1 || true)"
+reg_ifeo_line="$(grep -nF 'wine reg delete HKLM\Software\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\Ableton Live 12 Suite.exe /v dpiAwareness /f' "$base/wine.log" | cut -d: -f1 || true)"
+stop_line="$(grep -nF 'wineserver -k' "$base/wine.log" | cut -d: -f1 || true)"
+wait_line="$(grep -nF 'wineserver -w' "$base/wine.log" | cut -d: -f1 || true)"
+boot_line="$(grep -nF 'wineboot -u' "$base/wine.log" | cut -d: -f1 || true)"
+live_line="$(grep -nF 'wine C:\ProgramData\Ableton\Live 12 Suite\Program\Ableton Live 12 Suite.exe' "$base/wine.log" | cut -d: -f1 || true)"
+if [ -z "$reg_lp_line" ] || [ -z "$reg_ifeo_line" ] || [ -z "$stop_line" ] \
+   || [ -z "$wait_line" ] || [ -z "$boot_line" ] || [ -z "$live_line" ] \
+   || [ "$reg_lp_line" -ge "$reg_ifeo_line" ] || [ "$reg_ifeo_line" -ge "$stop_line" ] \
+   || [ "$stop_line" -ge "$wait_line" ] || [ "$wait_line" -ge "$boot_line" ] \
+   || [ "$boot_line" -ge "$live_line" ]; then
+    fail "reverse DPI registry writes, restart, boot, and Live launch were not coherently ordered"
+fi
+kill "$app_pid" 2>/dev/null || true
+wait "$launcher_pid" 2>/dev/null || true
+ok "the 192-to-96 DPI transition restarts before Live"
+
+# A cold callback has no selected edition, but its prefix association can start
+# any installed Live. An IFEO-only drift must therefore transact every target.
+base="$(new_env cold-callback-adds-ifeo)"
+prepare_fixture "$base"
+mkdir -p -- "$base/prefix/drive_c/ProgramData/Ableton/Live 11 Standard/Program"
+printf 'exe\n' > "$base/prefix/drive_c/ProgramData/Ableton/Live 11 Standard/Program/Ableton Live 11 Standard.exe"
+cat > "$base/prefix/user.reg" <<'EOF'
+[Control Panel\\Desktop]
+"LogPixels"=dword:000000c0
+EOF
+cat > "$base/prefix/system.reg" <<'EOF'
+[Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\Ableton Live 12 Suite.exe]
+"dpiAwareness"=dword:00000002
+EOF
+: > "$base/wine.log"
+run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_LIVE_VERSION=12 \
+    ABLETON_LIVE_EXE="$base/prefix/drive_c/ProgramData/Ableton/Live 12 Suite/Program/Ableton Live 12 Suite.exe" \
+    ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=fractional \
+    ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+    ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_APP_IMAGE='Ableton Live 12 Suite.exe' \
+    ABLETON_TEST_APP_PID_FILE="$base/app.pid" \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$here/ableton-live" \
+    'ableton://dpi-transition' >"$base/out" 2>"$base/err" &
+launcher_pid=$!
+cleanup_pids+=("$launcher_pid")
+for _ in {1..100}; do [ -s "$base/app.pid" ] && break; sleep 0.1; done
+[ -s "$base/app.pid" ] || fail "cold callback did not repair its missing Live IFEO"
+app_pid="$(cat "$base/app.pid")"
+cleanup_pids+=("$app_pid")
+grep -qF 'wine reg add HKLM\Software\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\Ableton Live 12 Suite.exe /v dpiAwareness /t REG_DWORD /d 2 /f' \
+    "$base/wine.log" || fail "cold callback left the Live IFEO half-configured"
+grep -qF 'wine reg add HKLM\Software\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\Ableton Live 11 Standard.exe /v dpiAwareness /t REG_DWORD /d 2 /f' \
+    "$base/wine.log" || fail "cold callback obeyed edition selectors instead of repairing every possible callback target"
+grep -qF 'wineserver -k' "$base/wine.log" \
+    || fail "cold callback IFEO repair did not restart Wine"
+grep -qF 'wineboot -u' "$base/wine.log" \
+    || fail "cold callback IFEO repair did not boot the coherent block"
+grep -qF 'wine start /w ableton://dpi-transition' "$base/wine.log" \
+    || fail "cold callback did not continue after coherent DPI repair"
+kill "$app_pid" 2>/dev/null || true
+wait "$launcher_pid" 2>/dev/null || true
+ok "cold callbacks repair missing Live IFEO state before dispatch"
+
+# The inverse callback half-state is equally dangerous: a 96-DPI prefix with a
+# stale PMv2 IFEO override must delete it before dispatching the callback.
+base="$(new_env cold-callback-removes-ifeo)"
+prepare_fixture "$base"
+cat > "$base/prefix/user.reg" <<'EOF'
+[Control Panel\\Desktop]
+"LogPixels"=dword:00000060
+EOF
+cat > "$base/prefix/system.reg" <<'EOF'
+[Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\Ableton Live 12 Suite.exe]
+"dpiAwareness"=dword:00000002
+EOF
+: > "$base/wine.log"
+run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=100 \
+    ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+    ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_APP_IMAGE='Ableton Live 12 Suite.exe' \
+    ABLETON_TEST_APP_PID_FILE="$base/app.pid" \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$here/ableton-live" \
+    'ableton://dpi-transition-back' >"$base/out" 2>"$base/err" &
+launcher_pid=$!
+cleanup_pids+=("$launcher_pid")
+for _ in {1..100}; do [ -s "$base/app.pid" ] && break; sleep 0.1; done
+[ -s "$base/app.pid" ] || fail "cold callback did not remove its stale Live IFEO"
+app_pid="$(cat "$base/app.pid")"
+cleanup_pids+=("$app_pid")
+grep -qF 'wine reg delete HKLM\Software\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\Ableton Live 12 Suite.exe /v dpiAwareness /f' \
+    "$base/wine.log" || fail "cold callback retained its stale Live IFEO"
+grep -qF 'wineserver -k' "$base/wine.log" \
+    || fail "cold callback stale-IFEO repair did not restart Wine"
+grep -qF 'wineboot -u' "$base/wine.log" \
+    || fail "cold callback stale-IFEO repair did not boot the coherent block"
+grep -qF 'wine start /w ableton://dpi-transition-back' "$base/wine.log" \
+    || fail "cold callback did not continue after stale-IFEO repair"
+kill "$app_pid" 2>/dev/null || true
+wait "$launcher_pid" 2>/dev/null || true
+ok "cold callbacks remove stale Live IFEO state before dispatch"
+
+# A shared prefix cannot be restarted merely to apply a new DPI block. Refuse
+# without writing registry state or ending the existing client.
+base="$(new_env busy-dpi-refusal)"
+prepare_fixture "$base"
+: > "$base/wine.log"
+: > "$base/taskkill.log"
+mkdir -p -- "$base/foreign-runtime/bin"
+cp -- /bin/sleep "$base/foreign-runtime/bin/wine"
+env WINEPREFIX="$base/prefix" "$base/foreign-runtime/bin/wine" 60 &
+holder_pid=$!
+cleanup_pids+=("$holder_pid")
+sleep 0.2
+if run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=fractional \
+    ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+    ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" \
+    ABLETON_TEST_TASKKILL_LOG="$base/taskkill.log" bash "$here/ableton-live" \
+    >"$base/out" 2>"$base/err"; then
+    fail "launcher changed DPI while another prefix client was running"
+fi
+kill -0 "$holder_pid" 2>/dev/null \
+    || fail "DPI refusal ended the pre-existing prefix client"
+[ ! -s "$base/wine.log" ] \
+    || fail "DPI refusal started Wine or wrote registry state in the busy prefix"
+[ ! -s "$base/taskkill.log" ] \
+    || fail "DPI refusal ran session teardown against the busy prefix"
+grep -qF 'close Max or the other prefix program' "$base/err" \
+    || fail "busy DPI refusal did not explain how to retry safely"
+kill "$holder_pid" 2>/dev/null || true
+wait "$holder_pid" 2>/dev/null || true
+ok "a changed DPI block never restarts a shared Wine prefix"
+
+# If an uncoordinated Wine client appears after the registry writes, do not
+# kill it. Persist the pending reseed, refuse Live, and complete only after the
+# prefix becomes idle—even though the persistent values then look matched.
+base="$(new_env interrupted-dpi-reseed)"
+prepare_fixture "$base"
+: > "$base/wine.log"
+: > "$base/taskkill.log"
+if run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=fractional \
+    ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+    ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_REG_FOREIGN_PID_FILE="$base/foreign.pid" \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" \
+    ABLETON_TEST_TASKKILL_LOG="$base/taskkill.log" bash "$here/ableton-live" \
+    >"$base/out" 2>"$base/err"; then
+    fail "DPI transaction launched after an uncoordinated prefix client entered"
+fi
+[ -s "$base/foreign.pid" ] || fail "DPI race fixture did not create its foreign holder"
+holder_pid="$(cat "$base/foreign.pid")"
+cleanup_pids+=("$holder_pid")
+kill -0 "$holder_pid" 2>/dev/null \
+    || fail "DPI transaction killed the uncoordinated prefix client"
+if grep -Eq 'wineserver |wineboot |wine C:\\ProgramData' "$base/wine.log"; then
+    fail "interrupted DPI transaction stopped, booted, or launched into the contested prefix"
+fi
+[ ! -s "$base/taskkill.log" ] \
+    || fail "interrupted DPI transaction ran EXIT teardown against the contested prefix"
+reseed_marker="$base/prefix/.ableton-linux-dpi-reseed-required"
+[ -n "$reseed_marker" ] && [ -f "$reseed_marker" ] \
+    || fail "interrupted DPI transaction did not preserve its required-reseed marker"
+cat > "$base/prefix/user.reg" <<'EOF'
+[Control Panel\\Desktop]
+"LogPixels"=dword:000000c0
+EOF
+cat > "$base/prefix/system.reg" <<'EOF'
+[Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\Ableton Live 12 Suite.exe]
+"dpiAwareness"=dword:00000002
+EOF
+: > "$base/wine.log"
+: > "$base/taskkill.log"
+if run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=fractional \
+    ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+    ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" \
+    ABLETON_TEST_TASKKILL_LOG="$base/taskkill.log" bash "$here/ableton-live" \
+    >"$base/busy-retry.out" 2>"$base/busy-retry.err"; then
+    fail "pending matched DPI state launched while its stale Wine session was still busy"
+fi
+kill -0 "$holder_pid" 2>/dev/null \
+    || fail "pending DPI retry ended the client keeping its stale session alive"
+[ ! -s "$base/wine.log" ] \
+    || fail "pending matched DPI retry touched Wine before the prefix became idle"
+[ ! -s "$base/taskkill.log" ] \
+    || fail "pending matched DPI retry ran EXIT teardown against the busy prefix"
+[ -f "$reseed_marker" ] \
+    || fail "busy retry discarded the pending DPI reseed marker"
+grep -qF 'waiting for a safe prefix restart' "$base/busy-retry.err" \
+    || fail "busy pending-DPI retry did not explain the required restart"
+kill "$holder_pid" 2>/dev/null || true
+wait "$holder_pid" 2>/dev/null || true
+tagged_pid="$(cat "$base/wine.log.tagged-pid" 2>/dev/null || true)"
+if [ -n "$tagged_pid" ]; then
+    kill "$tagged_pid" 2>/dev/null || true
+fi
+: > "$base/wine.log"
+run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=fractional \
+    ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+    ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_APP_IMAGE='Ableton Live 12 Suite.exe' \
+    ABLETON_TEST_APP_PID_FILE="$base/app.pid" \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$here/ableton-live" \
+    >"$base/retry.out" 2>"$base/retry.err" &
+launcher_pid=$!
+cleanup_pids+=("$launcher_pid")
+for _ in {1..100}; do [ -s "$base/app.pid" ] && break; sleep 0.1; done
+[ -s "$base/app.pid" ] || fail "idle retry did not finish the pending DPI reseed"
+app_pid="$(cat "$base/app.pid")"
+cleanup_pids+=("$app_pid")
+grep -qF 'wineboot -u' "$base/wine.log" \
+    || fail "pending matched DPI state did not reseed Wine before Live"
+if grep -Eq 'wine reg |wineserver -k' "$base/wine.log"; then
+    fail "pending matched DPI retry rewrote registry state or killed an idle prefix"
+fi
+[ ! -e "$reseed_marker" ] \
+    || fail "successful coherent boot retained the pending DPI marker"
+kill "$app_pid" 2>/dev/null || true
+wait "$launcher_pid" 2>/dev/null || true
+ok "interrupted DPI changes stay pending until an idle coherent boot"
+
+# A pending reseed belongs to the prefix across Wine upgrades. A holder from an
+# older runtime must not become invisible merely because the current launcher's
+# bring-up lock uses a new runtime generation.
+base="$(new_env cross-runtime-pending-dpi-reseed)"
+prepare_fixture "$base"
+cat > "$base/prefix/user.reg" <<'EOF'
+[Control Panel\\Desktop]
+"LogPixels"=dword:000000c0
+EOF
+cat > "$base/prefix/system.reg" <<'EOF'
+[Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\Ableton Live 12 Suite.exe]
+"dpiAwareness"=dword:00000002
+EOF
+reseed_marker="$base/prefix/.ableton-linux-dpi-reseed-required"
+: > "$reseed_marker"
+: > "$base/wine.log"
+: > "$base/taskkill.log"
+mkdir -p -- "$base/old-runtime/bin"
+cp -- /bin/sleep "$base/old-runtime/bin/wine"
+env WINEPREFIX="$base/prefix" "$base/old-runtime/bin/wine" 60 &
+holder_pid=$!
+cleanup_pids+=("$holder_pid")
+sleep 0.2
+if run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=fractional \
+    ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+    ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" \
+    ABLETON_TEST_TASKKILL_LOG="$base/taskkill.log" bash "$here/ableton-live" \
+    >"$base/out" 2>"$base/err"; then
+    fail "runtime upgrade hid the prefix's pending DPI reseed"
+fi
+kill -0 "$holder_pid" 2>/dev/null \
+    || fail "cross-runtime pending-DPI refusal ended the old runtime holder"
+[ ! -s "$base/wine.log" ] \
+    || fail "cross-runtime pending-DPI refusal started the new Wine runtime"
+[ ! -s "$base/taskkill.log" ] \
+    || fail "cross-runtime pending-DPI refusal ran teardown against the old runtime"
+[ -f "$reseed_marker" ] \
+    || fail "cross-runtime pending-DPI refusal discarded the prefix fence"
+grep -qF 'waiting for a safe prefix restart' "$base/err" \
+    || fail "cross-runtime pending-DPI refusal did not explain the required restart"
+kill "$holder_pid" 2>/dev/null || true
+wait "$holder_pid" 2>/dev/null || true
+ok "pending DPI reseeds survive Wine runtime changes"
+
+# The prefix fence is never allowed to follow a symlink. Refuse both a dangling
+# link and a link to an existing file before Wine, and leave the target intact.
+for marker_shape in dangling existing-target; do
+    base="$(new_env "unsafe-dpi-marker-$marker_shape")"
+    prepare_fixture "$base"
+    : > "$base/wine.log"
+    : > "$base/taskkill.log"
+    marker="$base/prefix/.ableton-linux-dpi-reseed-required"
+    if [ "$marker_shape" = dangling ]; then
+        ln -s -- "$base/missing-marker-target" "$marker"
+    else
+        printf 'do not overwrite\n' > "$base/marker-target"
+        ln -s -- "$base/marker-target" "$marker"
+    fi
+    if run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+        ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=fractional \
+        ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+        ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+        ABLETON_TEST_WINE_LOG="$base/wine.log" \
+        ABLETON_TEST_TASKKILL_LOG="$base/taskkill.log" bash "$here/ableton-live" \
+        >"$base/out" 2>"$base/err"; then
+        fail "$marker_shape DPI marker symlink was accepted"
+    fi
+    [ ! -s "$base/wine.log" ] \
+        || fail "$marker_shape DPI marker refusal started Wine"
+    [ ! -s "$base/taskkill.log" ] \
+        || fail "$marker_shape DPI marker refusal ran prefix teardown"
+    grep -qF 'DPI reseed marker is not a regular file' "$base/err" \
+        || fail "$marker_shape DPI marker refusal did not identify the unsafe path"
+    if [ "$marker_shape" = existing-target ]; then
+        grep -qxF 'do not overwrite' "$base/marker-target" \
+            || fail "DPI marker symlink target was overwritten"
+    fi
+done
+ok "DPI reseed fences never follow symlinks"
+
+# Exercise the creation-failure branch after its initial path validation. The
+# launcher still owns no Wine session, so failure must not invoke EXIT teardown.
+base="$(new_env dpi-marker-publication-failure)"
+prepare_fixture "$base"
+cat > "$base/fakebin/gdbus" <<'EOF'
+#!/bin/sh
+mkdir -p -- "${WINEPREFIX:?}/.ableton-linux-dpi-reseed-required"
+printf '%s\n' "${ABLETON_TEST_GNOME_STATE:?}"
+EOF
+cat > "$base/fakebin/gsettings" <<'EOF'
+#!/bin/sh
+printf '%s\n' "['scale-monitor-framebuffer', 'xwayland-native-scaling']"
+EOF
+chmod +x "$base/fakebin/gdbus" "$base/fakebin/gsettings"
+: > "$base/wine.log"
+: > "$base/taskkill.log"
+if run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=auto \
+    ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+    ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_GNOME_STATE="$gnome_state" \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" \
+    ABLETON_TEST_TASKKILL_LOG="$base/taskkill.log" bash "$here/ableton-live" \
+    >"$base/out" 2>"$base/err"; then
+    fail "DPI marker publication failure was accepted"
+fi
+[ ! -s "$base/wine.log" ] \
+    || fail "DPI marker publication failure started Wine"
+[ ! -s "$base/taskkill.log" ] \
+    || fail "DPI marker publication failure ran prefix teardown"
+grep -qF 'safe restart marker could not be written' "$base/err" \
+    || fail "DPI marker publication failure was not explained"
+ok "DPI marker publication failure disarms pre-Wine teardown"
+
+# Sharing remains supported when registry state already matches: do not turn
+# the destructive-restart guard into a blanket ban on Live beside Max.
+base="$(new_env busy-matching-dpi)"
+prepare_fixture "$base"
+: > "$base/wine.log"
+env WINEPREFIX="$base/prefix" "$base/runtime/bin/wine-client" 60 &
+holder_pid=$!
+cleanup_pids+=("$holder_pid")
+sleep 0.2
+run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=100 \
+    ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+    ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_APP_IMAGE='Ableton Live 12 Suite.exe' \
+    ABLETON_TEST_APP_PID_FILE="$base/app.pid" \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$here/ableton-live" \
+    >"$base/out" 2>"$base/err" &
+launcher_pid=$!
+cleanup_pids+=("$launcher_pid")
+for _ in {1..100}; do [ -s "$base/app.pid" ] && break; sleep 0.1; done
+[ -s "$base/app.pid" ] || fail "matching DPI state blocked Live in a shared prefix"
+app_pid="$(cat "$base/app.pid")"
+cleanup_pids+=("$app_pid")
+kill -0 "$holder_pid" 2>/dev/null \
+    || fail "matching DPI launch disturbed the pre-existing prefix client"
+if grep -Eq 'wine reg |wineserver |wineboot ' "$base/wine.log"; then
+    fail "matching DPI launch rewrote or restarted the shared prefix"
+fi
+grep -qF 'wine C:\ProgramData\Ableton\Live 12 Suite\Program\Ableton Live 12 Suite.exe' \
+    "$base/wine.log" || fail "matching DPI launch did not reach Live"
+kill "$app_pid" "$holder_pid" 2>/dev/null || true
+wait "$launcher_pid" 2>/dev/null || true
+wait "$holder_pid" 2>/dev/null || true
+ok "matching DPI state leaves a shared Wine prefix running"
+
+# The same sharing contract applies to a coherent fractional block. Its PMv2
+# IFEO must not be mistaken for drift merely because Wine is already active.
+base="$(new_env busy-matching-fractional-dpi)"
+prepare_fixture "$base"
+cat > "$base/prefix/user.reg" <<'EOF'
+[Control Panel\\Desktop]
+"LogPixels"=dword:000000c0
+EOF
+cat > "$base/prefix/system.reg" <<'EOF'
+[Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\Ableton Live 12 Suite.exe]
+"dpiAwareness"=dword:00000002
+EOF
+: > "$base/wine.log"
+env WINEPREFIX="$base/prefix" "$base/runtime/bin/wine-client" 60 &
+holder_pid=$!
+cleanup_pids+=("$holder_pid")
+sleep 0.2
+run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=fractional \
+    ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+    ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_APP_IMAGE='Ableton Live 12 Suite.exe' \
+    ABLETON_TEST_APP_PID_FILE="$base/app.pid" \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$here/ableton-live" \
+    >"$base/out" 2>"$base/err" &
+launcher_pid=$!
+cleanup_pids+=("$launcher_pid")
+for _ in {1..100}; do [ -s "$base/app.pid" ] && break; sleep 0.1; done
+[ -s "$base/app.pid" ] || fail "matching fractional DPI state blocked Live in a shared prefix"
+app_pid="$(cat "$base/app.pid")"
+cleanup_pids+=("$app_pid")
+kill -0 "$holder_pid" 2>/dev/null \
+    || fail "matching fractional launch disturbed the pre-existing prefix client"
+if grep -Eq 'wine reg |wineserver |wineboot ' "$base/wine.log"; then
+    fail "matching fractional launch rewrote or restarted the shared prefix"
+fi
+grep -qF 'wine C:\ProgramData\Ableton\Live 12 Suite\Program\Ableton Live 12 Suite.exe' \
+    "$base/wine.log" || fail "matching fractional launch did not reach Live"
+kill "$app_pid" "$holder_pid" 2>/dev/null || true
+wait "$launcher_pid" 2>/dev/null || true
+wait "$holder_pid" 2>/dev/null || true
+ok "matching fractional DPI leaves a shared Wine prefix running"
+
+# Correct MIME defaults remain query-only. Drift in any project-generated
+# handler, desktop entry, or callback default is overwritten authoritatively
+# under the global launcher lock.
+base="$(new_env authoritative-integration-repair)"
+prepare_fixture "$base"
+live_desktop="$base/data/applications/ableton-live.desktop"
+printf '[Desktop Entry]\nName=My Local Live\nExec=/usr/bin/foreign %%f\nX-Foreign=true\n' \
+    > "$live_desktop"
+printf '[Desktop Entry]\nExec=/usr/bin/foreign %%u\n' \
+    > "$base/data/applications/$protocol_id"
+: > "$base/wine.log"
+: > "$base/mime-default.log"
+mime_before="$(sha256sum -- "$base/config/mimeapps.list" | awk '{print $1}')"
+run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=preserve ABLETON_UI_FONT=preserve \
+    ABLETON_TEXT_SMOOTHING=preserve ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_MIME_DEFAULT_LOG="$base/mime-default.log" ABLETON_TEST_WINE_LOG="$base/wine.log" \
+    bash "$here/ableton-live" >"$base/out" 2>"$base/err" || true
+[ ! -s "$base/mime-default.log" ] \
+    || fail "launcher rewrites MIME defaults that already resolve correctly"
+[ "$(sha256sum -- "$base/config/mimeapps.list" | awk '{print $1}')" = "$mime_before" ] \
+    || fail "query-only MIME verification changed mimeapps.list"
+cmp -s -- "$base/data/ableton-wine/$protocol_id" "$base/data/applications/$protocol_id" \
+    || fail "launcher retained drift in its generated protocol handler"
+if ! grep -qxF 'Name=Ableton Live 12 Suite' "$live_desktop" \
+   || ! grep -qxF "Exec=$base/home/.local/bin/ableton-live %f" "$live_desktop" \
+   || ! grep -qxF "Path=$base/prefix" "$live_desktop" \
+   || ! grep -qxF 'StartupWMClass=ableton live 12 suite.exe' "$live_desktop" \
+   || grep -q '^X-Foreign=' "$live_desktop"; then
+    fail "launcher did not completely rebuild its drifted generated desktop entry"
+fi
+sed -i "s#^x-scheme-handler/ableton=.*#x-scheme-handler/ableton=foreign.desktop#" \
+    "$base/config/mimeapps.list"
+: > "$base/mime-default.log"
+run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=preserve ABLETON_UI_FONT=preserve \
+    ABLETON_TEXT_SMOOTHING=preserve ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_MIME_DEFAULT_LOG="$base/mime-default.log" ABLETON_TEST_WINE_LOG="$base/wine.log" \
+    bash "$here/ableton-live" 'ableton://authoritative-repair' >"$base/out" 2>"$base/err" || true
+grep -qxF "x-scheme-handler/ableton=$protocol_id" "$base/config/mimeapps.list" \
+    || fail "launcher retained drift in its generated protocol default"
+grep -qxF "application/x-wine-extension-auz=$auz_id" "$base/config/mimeapps.list" \
+    || fail "launcher MIME repair lost the AUZ default"
+grep -qxF "$base/config" "$base/mime-default.log" \
+    || fail "launcher did not repair MIME drift against the live configuration"
+ok "launcher authoritatively overwrites generated desktop, handler, and MIME drift"
+
+# Damaged installer settings must stop both launchers before they use any
+# partially initialised path, with one actionable explanation rather than a
+# secondary set -u/unbound-variable error.
+base="$(new_env unreadable-installer-settings)"
+prepare_fixture "$base"
+printf 'not recognised\n' > "$base/config/ableton-wine/config"
+: > "$base/wine.log"
+if run_live "$base" >"$base/live.out" 2>"$base/live.err"; then
+    fail "Live accepted unreadable installer settings"
+fi
+if run_isolated "$base" env ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$here/max9" \
+    >"$base/max.out" 2>"$base/max.err"; then
+    fail "Max accepted unreadable installer settings"
+fi
+grep -qxF 'ableton-live: installer settings could not be read. Run the latest installer to repair them, then try again.' \
+    "$base/live.err" || fail "Live did not give one actionable settings error"
+grep -qxF 'max9: installer settings could not be read. Run the latest installer to repair them, then try again.' \
+    "$base/max.err" || fail "Max did not give one actionable settings error"
+[ ! -s "$base/wine.log" ] || fail "a launcher started Wine with unreadable installer settings"
+ok "Live and Max stop cleanly when installer settings cannot be read"
+
+# Desktop integration remains ancillary. Exercise independent handler publish,
+# MIME backend, desktop publish, and cache-refresh failures together; a healthy
+# runtime and prefix must still reach an observable Wine child.
+base="$(new_env ancillary-repair-failures)"
+prepare_fixture "$base"
+rm -f -- "$base/data/applications/$protocol_id" "$base/data/applications/$auz_id"
+mkdir -p -- "$base/data/applications/$protocol_id" "$base/data/applications/ableton-live.desktop"
+printf '[Desktop Entry]\nExec=/usr/bin/foreign %%f\n' > "$base/data/applications/$auz_id"
+sed -i "s#^x-scheme-handler/ableton=.*#x-scheme-handler/ableton=foreign.desktop#" \
+    "$base/config/mimeapps.list"
+: > "$base/wine.log"
+if ! run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=preserve ABLETON_UI_FONT=preserve \
+    ABLETON_TEXT_SMOOTHING=preserve ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_MIME_DEFAULT_FAIL=1 ABLETON_TEST_DESKTOP_DATABASE_FAIL=1 \
+    ABLETON_TEST_APP_IMAGE='Ableton Live 12 Suite.exe' ABLETON_TEST_APP_PID_FILE="$base/app.pid" \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$here/ableton-live" \
+    >"$base/out" 2>"$base/err"; then
+    fail "ancillary integration repair failure blocked an otherwise healthy Live launch"
+fi
+[ -s "$base/app.pid" ] && [ -s "$base/wine.log" ] \
+    || fail "ancillary integration repair failure prevented Wine from starting"
+app_pid="$(cat "$base/app.pid")"
+cleanup_pids+=("$app_pid")
+grep -qF 'Live will start, but browser activation, file opening, or the application menu may need repair.' \
+    "$base/err" || fail "ancillary integration failures were not reported in user-level language"
+[ "$(grep -cF 'Live will start, but browser activation, file opening, or the application menu may need repair.' "$base/err")" -eq 1 ] \
+    || fail "ancillary integration failures produced repeated warnings"
+kill "$app_pid" 2>/dev/null || true
+wait "$app_pid" 2>/dev/null || true
+ok "ancillary integration repair failures warn and continue to Wine"
+
+# Refusal is nonblocking and happens before the first diagnostic/state/handler
+# write. Max observes the same user-wide lock.
+base="$(new_env global-refusal)"
+prepare_fixture "$base"
+printf '[Desktop Entry]\nExec=/usr/bin/foreign %%u\n' > "$base/data/applications/$protocol_id"
+rm -rf -- "$base/state"
+: > "$base/wine.log"
+exec {install_lock_fd}< "$base/home"
+flock -n "$install_lock_fd" || fail "could not hold global launcher lock fixture"
+if run_live "$base" 'ableton://locked' >"$base/live.out" 2>"$base/live.err"; then
+    fail "Live waited for or bypassed an active installer"
+fi
+if run_isolated "$base" env ABLETON_POWER=off ABLETON_RT=off ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$here/max9" >"$base/max.out" 2>"$base/max.err"; then
+    fail "Max waited for or bypassed an active installer"
+fi
+flock -u "$install_lock_fd"
+exec {install_lock_fd}<&-
+if ! grep -q 'installation work is in progress' "$base/live.err" \
+   || ! grep -q 'installation work is in progress' "$base/max.err"; then
+    fail "global-lock refusals did not explain the retry"
+fi
+[ ! -e "$base/state" ] || fail "refused Live launch created its diagnostic state before locking"
+grep -qF 'Exec=/usr/bin/foreign %u' "$base/data/applications/$protocol_id" \
+    || fail "refused Live launch repaired a handler"
+[ ! -s "$base/wine.log" ] || fail "refused launcher started Wine"
+ok "Live and Max refuse an installer before every managed launcher-side write"
+
+# A crashed installer no longer owns the flock, but its active journal still
+# binds exact host and prefix generations. Both launchers must refuse before
+# self-heal or diagnostics can mutate that retained recovery state.
+base="$(new_env active-recovery-refusal)"
+prepare_fixture "$base"
+retained_transaction="$base/state/ableton-wine/transactions/installer.retained"
+mkdir -p -- "$retained_transaction"
+: > "$retained_transaction/active"
+printf '[Desktop Entry]\nExec=/usr/bin/foreign %%u\n' \
+    > "$base/data/applications/$protocol_id"
+sed -i 's#^x-scheme-handler/ableton=.*#x-scheme-handler/ableton=foreign.desktop#' \
+    "$base/config/mimeapps.list"
+: > "$base/wine.log"
+if run_live "$base" 'ableton://retained-recovery' >"$base/live.out" 2>"$base/live.err"; then
+    fail "Live launched while an unfinished installation transaction was retained"
+fi
+if run_isolated "$base" env ABLETON_POWER=off ABLETON_RT=off ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$here/max9" \
+    >"$base/max.out" 2>"$base/max.err"; then
+    fail "Max launched while an unfinished installation transaction was retained"
+fi
+if ! grep -qF "$retained_transaction" "$base/live.err" \
+   || ! grep -qF "$retained_transaction" "$base/max.err"; then
+    fail "retained-transaction refusals did not name the recovery directory"
+fi
+[ ! -e "$base/state/ableton-wine/logs/live.log" ] \
+    || fail "retained-transaction refusal wrote a Live diagnostic log"
+grep -qF 'Exec=/usr/bin/foreign %u' "$base/data/applications/$protocol_id" \
+    || fail "retained-transaction refusal repaired a handler"
+grep -qxF 'x-scheme-handler/ableton=foreign.desktop' "$base/config/mimeapps.list" \
+    || fail "retained-transaction refusal rewrote MIME defaults"
+[ ! -s "$base/wine.log" ] || fail "retained-transaction refusal started Wine"
+ok "Live and Max refuse retained recovery before diagnostics, self-heal, or Wine"
+
+# A completed core can leave its own cleanup directory behind. Its completion
+# marker makes that stale active file informational, so cleanup failure cannot
+# become a later launch failure.
+base="$(new_env committed-cleanup-launch)"
+prepare_fixture "$base"
+retained_transaction="$base/state/ableton-wine/transactions/installer.committed"
+mkdir -p -- "$retained_transaction/prefix-host"
+: > "$retained_transaction/active"
+: > "$retained_transaction/prefix-host/active"
+printf 'format=1\ncore=complete\n' > "$retained_transaction/core-complete"
+retained_prefix_transaction="$base/state/ableton-wine/transactions/installer.prefix-cleanup/prefix-host"
+mkdir -p -- "$retained_prefix_transaction"
+: > "$retained_prefix_transaction/active"
+printf 'format=1\ncore=complete\n' > "$retained_prefix_transaction/core-complete"
+: > "$base/wine.log"
+if ! run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+    ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=preserve ABLETON_UI_FONT=preserve \
+    ABLETON_TEXT_SMOOTHING=preserve ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_APP_IMAGE='Ableton Live 12 Suite.exe' ABLETON_TEST_APP_PID_FILE="$base/app.pid" \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$here/ableton-live" \
+    >"$base/out" 2>"$base/err"; then
+    fail "committed cleanup files blocked Live"
+fi
+[ -s "$base/app.pid" ] && [ -s "$base/wine.log" ] \
+    || fail "committed cleanup files prevented Wine from starting"
+app_pid="$(cat "$base/app.pid")"
+cleanup_pids+=("$app_pid")
+kill "$app_pid" 2>/dev/null || true
+wait "$app_pid" 2>/dev/null || true
+ok "committed cleanup files never become a later launch gate"
+
+# A pre-existing Max is not readiness evidence for this invocation. The new
+# launch must expose the exact handoff token, and failure remains bounded.
+base="$(new_env max-warm-spoof)"
+prepare_fixture "$base"
+: > "$base/wine.log"
+max_holder="C:\\Program Files\\Cycling '74\\Max 9\\Max.exe"
+# shellcheck disable=SC2016
+env WINEPREFIX="$base/prefix" bash -c 'exec -a "$2" "$1" 60' \
+    _ "$base/runtime/bin/wine-client" "$max_holder" &
+max_holder_pid=$!
+cleanup_pids+=("$max_holder_pid")
+sleep 0.2
+if run_isolated "$base" env ABLETON_POWER=off ABLETON_RT=off ABLETON_LAUNCH_TIMEOUT=5 \
+    ABLETON_TEST_UNOBSERVABLE_WINE=1 ABLETON_TEST_WINE_LOG="$base/wine.log" \
+    bash "$here/max9" >"$base/out" 2>"$base/err"; then
+    fail "pre-existing Max spoofed readiness for an unobservable new launch"
+fi
+kill -0 "$max_holder_pid" 2>/dev/null \
+    || fail "failed Max handoff ended the pre-existing Max session"
+grep -q 'Max did not start within 5s' "$base/err" \
+    || fail "Max handoff failure was not bounded and explicit"
+kill "$max_holder_pid" 2>/dev/null || true
+wait "$max_holder_pid" 2>/dev/null || true
+ok "Max readiness requires this launch's exact handoff and fails boundedly"
+
+# Configuration validation must happen before a supervised child exists. An
+# invalid bound is a user error, not permission to leave an untracked Wine
+# process behind while the launcher exits.
+base="$(new_env max-timeout-preflight)"
+prepare_fixture "$base"
+: > "$base/wine.log"
+if run_isolated "$base" env ABLETON_POWER=off ABLETON_RT=off ABLETON_LAUNCH_TIMEOUT=invalid \
+    ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$here/max9" \
+    >"$base/out" 2>"$base/err"; then
+    fail "Max accepted an invalid launch handoff timeout"
+fi
+[ ! -s "$base/wine.log" ] || fail "Max spawned Wine before validating its launch timeout"
+grep -qF 'ABLETON_LAUNCH_TIMEOUT must be a whole number of seconds' "$base/err" \
+    || fail "Max timeout preflight failure was not explicit"
+ok "Max validates the handoff bound before spawning Wine"
+
+launcher_releases_fds()
+{
+    local launcher="$1" image="$2" base app_pid launcher_pid coordinator probe_ok=0
+    base="$(new_env "${launcher}-fd-handoff")"
+    prepare_fixture "$base"
+    : > "$base/wine.log"
+    run_isolated "$base" env USER=test ABLETON_POWER=off ABLETON_RT=off \
+        ABLETON_THEME_MODE=preserve ABLETON_DPI_MODE=preserve \
+        ABLETON_UI_FONT=preserve ABLETON_TEXT_SMOOTHING=preserve \
+        ABLETON_TOPBAR_MODE=preserve ABLETON_LAUNCH_TIMEOUT=5 \
+        ABLETON_TEST_APP_IMAGE="$image" ABLETON_TEST_APP_PID_FILE="$base/app.pid" \
+        ABLETON_TEST_WINE_LOG="$base/wine.log" bash "$here/$launcher" \
+        >"$base/out" 2>"$base/err" &
+    launcher_pid=$!
+    cleanup_pids+=("$launcher_pid")
+    for _ in {1..100}; do [ -s "$base/app.pid" ] && break; sleep 0.1; done
+    [ -s "$base/app.pid" ] || fail "$launcher did not start its observable handoff fixture"
+    app_pid="$(cat "$base/app.pid")"
+    cleanup_pids+=("$app_pid")
+    for _ in {1..100}; do
+        # shellcheck disable=SC2016
+        if run_isolated "$base" env -u ABLETON_INSTALL_LOCK_FD -u ABLETON_INSTALL_LOCK_OWNER_BASHPID \
+            bash -c '. "$1/lib/config.sh"; ableton_config_init; ableton_install_lock_acquire || exit 1; ableton_install_lock_release' \
+            _ "$here" >/dev/null 2>&1; then
+            probe_ok=1
+            break
+        fi
+        sleep 0.1
+    done
+    [ "$probe_ok" -eq 1 ] || fail "$launcher Wine child retained the installation lock"
+    # shellcheck disable=SC2016
+    coordinator="$(run_isolated "$base" bash -c \
+        '. "$1/lib/config.sh"; ableton_config_init; . "$1/lib/lifecycle.sh"; ableton_lifecycle_runtime_dir' \
+        _ "$here")"
+    exec {bringup_probe_fd}> "$coordinator/bring-up.lock"
+    flock -n "$bringup_probe_fd" || fail "$launcher Wine child retained the bring-up lock"
+    flock -u "$bringup_probe_fd"
+    exec {bringup_probe_fd}>&-
+    kill "$app_pid" 2>/dev/null || true
+    wait "$launcher_pid" 2>/dev/null || true
+}
+
+launcher_releases_fds ableton-live \
+    'C:\ProgramData\Ableton\Live 12 Suite\Program\Ableton Live 12 Suite.exe'
+launcher_releases_fds max9 "C:\\Program Files\\Cycling '74\\Max 9\\Max.exe"
+ok "Wine children retain neither global nor per-prefix launcher locks"
+
+# The detached shortcut watcher is an independent launcher process by the time
+# it restores GNOME state. It must leave both dconf and its recovery snapshot
+# untouched while an installer owns the global lock, then retry and complete
+# after that exact owner releases it.
+base="$(new_env shortcut-watcher-global-lock)"
+prepare_fixture "$base"
+shortcut_state="$base/state/ableton-wine/hold-v2"
+mkdir -p -- "$base/run/ableton-wine-shortcuts"
+cat > "$shortcut_state" <<'EOF'
+ABLETON_SHORTCUT_HOLD_V2
+org.gnome.desktop.wm.keybindings|switch-to-workspace-up|['<Control><Alt>Up']|[]
+EOF
+chmod 600 "$shortcut_state"
+printf '[]\n' > "$base/shortcut.value"
+: > "$base/shortcut-set.log"
+: > "$base/install-lock-attempt.log"
+cat > "$base/fakebin/gsettings" <<'EOF'
+#!/bin/sh
+set -eu
+case "${1:-}" in
+    get) cat "${ABLETON_TEST_SHORTCUT_VALUE:?}" ;;
+    set)
+        printf '%s\n' "$4" > "${ABLETON_TEST_SHORTCUT_VALUE:?}.tmp"
+        mv -f -- "${ABLETON_TEST_SHORTCUT_VALUE}.tmp" "$ABLETON_TEST_SHORTCUT_VALUE"
+        printf '%s\t%s\t%s\n' "$2" "$3" "$4" >> "${ABLETON_TEST_SHORTCUT_SET_LOG:?}"
+        ;;
+    writable) printf '%s\n' true ;;
+    *) exit 2 ;;
+esac
+EOF
+chmod 755 "$base/fakebin/gsettings"
+mkfifo "$base/release-install-lock"
+(
+    exec 7< "$base/home"
+    flock -n 7 || exit 1
+    : > "$base/install-lock-ready"
+    IFS= read -r _ < "$base/release-install-lock"
+) &
+install_holder_pid=$!
+cleanup_pids+=("$install_holder_pid")
+for _ in {1..100}; do
+    [ -e "$base/install-lock-ready" ] && break
+    kill -0 "$install_holder_pid" 2>/dev/null || break
+    sleep 0.02
+done
+[ -e "$base/install-lock-ready" ] || fail "independent installation-lock holder did not start"
+# shellcheck disable=SC2016
+run_isolated "$base" env -u ABLETON_INSTALL_LOCK_FD -u ABLETON_INSTALL_LOCK_OWNER_BASHPID \
+    ABLETON_SHORTCUTS_POLL_SECONDS=0.02 \
+    ABLETON_TEST_SHORTCUT_VALUE="$base/shortcut.value" \
+    ABLETON_TEST_SHORTCUT_SET_LOG="$base/shortcut-set.log" \
+    ABLETON_TEST_INSTALL_LOCK_ATTEMPT_LOG="$base/install-lock-attempt.log" \
+    bash -c '
+        . "$1/lib/config.sh"
+        ableton_config_init
+        . "$1/shortcut-hold.sh"
+        ableton_shortcuts_init_state
+        ableton_shortcuts_live_running() { return 1; }
+        eval "$(declare -f ableton_install_lock_acquire \
+            | sed "1s/^ableton_install_lock_acquire/ableton_install_lock_acquire_real/")"
+        ableton_install_lock_acquire()
+        {
+            printf "attempt\n" >> "$ABLETON_TEST_INSTALL_LOCK_ATTEMPT_LOG"
+            ableton_install_lock_acquire_real
+        }
+        ableton_shortcuts_watch_loop
+    ' _ "$here" >"$base/watcher.out" 2>"$base/watcher.err" &
+watcher_pid=$!
+cleanup_pids+=("$watcher_pid")
+for _ in {1..100}; do
+    [ -s "$base/install-lock-attempt.log" ] && break
+    kill -0 "$watcher_pid" 2>/dev/null || break
+    sleep 0.02
+done
+[ -s "$base/install-lock-attempt.log" ] \
+    || fail "shortcut watcher did not attempt the held installation lock"
+[ -f "$shortcut_state" ] \
+    || fail "held installation lock allowed shortcut recovery state deletion"
+[ ! -s "$base/shortcut-set.log" ] \
+    || fail "held installation lock allowed a GNOME shortcut restoration"
+printf 'release\n' > "$base/release-install-lock"
+wait "$install_holder_pid" || fail "independent installation-lock holder failed"
+wait "$watcher_pid" || fail "shortcut watcher did not finish after the installer released"
+[ ! -e "$shortcut_state" ] \
+    || fail "shortcut watcher retained recovery state after the installer released"
+grep -qxF "['<Control><Alt>Up']" "$base/shortcut.value" \
+    && [ -s "$base/shortcut-set.log" ] \
+    || fail "shortcut watcher did not restore GNOME state after the installer released"
+ok "shortcut watcher defers restoration under an independent installer lock and retries afterward"
+
+# Prefix promotion must see stock/legacy Wine even though ordinary lifecycle
+# operations intentionally remain scoped to the selected runtime. Model the old
+# runtime with a separately rooted, Wine-named executable and the exact final
+# WINEPREFIX environment value.
+base="$(new_env any-runtime-prefix-holder)"
+prepare_fixture "$base"
+mkdir -p -- "$base/legacy-runtime/bin"
+cp -- /bin/sleep "$base/legacy-runtime/bin/wine64"
+env WINEPREFIX="$base/prefix" "$base/legacy-runtime/bin/wine64" 60 &
+legacy_wine_pid=$!
+cleanup_pids+=("$legacy_wine_pid")
+env WINEPREFIX="$base/prefix" /bin/sleep 60 &
+non_wine_pid=$!
+cleanup_pids+=("$non_wine_pid")
+env WINEPREFIX="$base/prefix-sibling" "$base/legacy-runtime/bin/wine64" 60 &
+sibling_prefix_wine_pid=$!
+cleanup_pids+=("$sibling_prefix_wine_pid")
+sleep 0.1
+# shellcheck disable=SC2016
+legacy_holder="$(run_isolated "$base" bash -c '
+    . "$1/lib/config.sh"
+    ableton_config_init
+    . "$1/lib/lifecycle.sh"
+    if ableton_prefix_busy "$ABLETON_WINE_ROOT" "$ABLETON_WINEPREFIX"; then
+        echo "selected-runtime scan unexpectedly matched the legacy fixture" >&2
+        exit 1
+    fi
+    ableton_prefix_wine_processes_any_runtime "$ABLETON_WINEPREFIX"
+' _ "$here")" || fail "any-runtime prefix scan could not inspect the legacy Wine fixture"
+[ "$legacy_holder" = "$legacy_wine_pid"$'\t'"$base/legacy-runtime/bin/wine64" ] \
+    || fail "any-runtime prefix scan did not narrowly report the exact-prefix legacy PID and executable"
+kill "$legacy_wine_pid" 2>/dev/null || true
+wait "$legacy_wine_pid" 2>/dev/null || true
+kill "$non_wine_pid" "$sibling_prefix_wine_pid" 2>/dev/null || true
+wait "$non_wine_pid" 2>/dev/null || true
+wait "$sibling_prefix_wine_pid" 2>/dev/null || true
+ok "prefix promotion recognizes an exact-prefix Wine process from another runtime"
+
+# Keep the two easy-to-regress close sites and promotion barrier explicit. The
+# behavioural handoff checks above cover fd 9 and the global fd; these source
+# gates cover the watcher's private fd 8 and both rename inputs.
+# shellcheck disable=SC2016
+grep -qF '"$apply" "$@" 8>&-' "$here/ableton-live" \
+    || fail "theme watcher Wine invocation no longer closes its private lock"
+# shellcheck disable=SC2016
+if ! grep -qF 'ableton_prefix_wine_processes_any_runtime "$final_prefix"' "$here/setup-prefix.sh" \
+   || ! grep -qF 'ableton_prefix_wine_processes_any_runtime "$WINEPREFIX"' "$here/setup-prefix.sh"; then
+    fail "prefix promotion no longer rechecks both final and staging paths"
+fi
+ok "theme children close fd 8 and promotion rechecks both prefix names"
+
+printf 'PASS: %s launcher transaction checks\n' "$pass"

--- a/scripts/test-link-boundary.sh
+++ b/scripts/test-link-boundary.sh
@@ -1,0 +1,562 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+scratch="$(mktemp -d "${TMPDIR:-/tmp}/ableton-link-boundary.XXXXXX")"
+trap 'rm -rf -- "$scratch"' EXIT
+tests=0
+
+fail()
+{
+    echo "not ok - $*" >&2
+    exit 1
+}
+
+ok()
+{
+    tests=$((tests + 1))
+    echo "ok - $*"
+}
+
+new_env()
+{
+    local name="$1"
+    base="$scratch/$name"
+    mkdir -p -- "$base/home" "$base/data/ableton-wine" \
+        "$base/state/ableton-wine" "$base/config" "$base/cache" \
+        "$base/run" "$base/fakebin"
+    printf 'format=1\nowner=ableton-linux\n' \
+        > "$base/state/ableton-wine/.ableton-linux-state"
+    printf '#!/bin/sh\nexit 0\n' > "$base/data/ableton-wine/ableton-linkd"
+    chmod 755 "$base/data/ableton-wine/ableton-linkd"
+    cat > "$base/fakebin/systemctl" <<'EOF'
+#!/bin/sh
+# These cases model a login without a reachable systemd user manager.
+exit 1
+EOF
+    cat > "$base/fakebin/grep" <<'EOF'
+#!/bin/sh
+for argument do
+    [ "$argument" != /etc/ufw/ufw.conf ] || exit 1
+done
+exec /usr/bin/grep "$@"
+EOF
+    printf '#!/bin/sh\nexit 1\n' > "$base/fakebin/firewall-cmd"
+    chmod 755 "$base/fakebin/systemctl" "$base/fakebin/grep" \
+        "$base/fakebin/firewall-cmd"
+}
+
+run_link()
+{
+    env HOME="$base/home" XDG_DATA_HOME="$base/data" \
+        XDG_CONFIG_HOME="$base/config" XDG_STATE_HOME="$base/state" \
+        XDG_CACHE_HOME="$base/cache" XDG_RUNTIME_DIR="$base/run" \
+        PATH="$base/fakebin:/usr/bin:/bin" "$@"
+}
+
+# A completed installer may leave the old transaction path exported after it
+# has removed that directory. Link's own generated state must not try to append
+# to that dead journal.
+new_env deleted-transaction
+run_link env ABLETON_TRANSACTION_DIR="$base/deleted-transaction" \
+    bash "$here/setup-link.sh" enable --mode=session \
+    > "$base/out" 2> "$base/err" \
+    || { sed -n '1,100p' "$base/err" >&2; fail "a deleted installer work directory blocks session Link"; }
+[ ! -e "$base/deleted-transaction" ] \
+    || fail "Link recreated a completed installer's work directory"
+grep -qxF 'link_mode=session' "$base/config/ableton-wine/config" \
+    || fail "session Link was not saved after the deleted-directory case"
+ok "a deleted installer work directory cannot gate Link setup"
+
+# The public installer owns the final success line because it still has
+# coordinator checks to finish after the Link child returns.
+new_env coordinated-output
+run_link env ABLETON_LINK_COORDINATED=1 \
+    bash "$here/setup-link.sh" enable --mode=session \
+    > "$base/out" 2> "$base/err" \
+    || { sed -n '1,100p' "$base/err" >&2; fail "coordinated Link setup failed"; }
+! grep -q '^OK:' "$base/out" \
+    || fail "Link child reported final success before its coordinator finished"
+grep -qxF 'link_mode=session' "$base/config/ableton-wine/config" \
+    || fail "coordinated Link child did not complete its requested mode"
+ok "coordinated Link leaves final success reporting to the installer"
+
+# The canonical service file belongs to this project. Re-running setup repairs
+# arbitrary bytes at that path instead of demanding an old checksum.
+new_env authoritative-unit
+mkdir -p -- "$base/config/systemd/user"
+printf 'foreign bytes at a generated path\n' \
+    > "$base/config/systemd/user/ableton-linkd.service"
+run_link bash "$here/setup-link.sh" enable --mode=session \
+    > "$base/out" 2> "$base/err" \
+    || { sed -n '1,100p' "$base/err" >&2; fail "a modified generated unit blocks Link repair"; }
+grep -qxF 'X-AbletonLinuxOwned=true' \
+    "$base/config/systemd/user/ableton-linkd.service" \
+    || fail "Link did not overwrite its canonical unit"
+! grep -qF 'foreign bytes' "$base/config/systemd/user/ableton-linkd.service" \
+    || fail "Link retained the modified canonical unit"
+ok "Link overwrites its generated user service authoritatively"
+
+# Session mode is launched by ableton-linkctl with Live. Its systemd file is
+# only preparation for a possible future background mode, so a local collision
+# there is reported but cannot reject an otherwise complete session setup.
+new_env optional-session-unit
+mkdir -p -- "$base/config/systemd/user/ableton-linkd.service"
+run_link bash "$here/setup-link.sh" enable --mode=session \
+    > "$base/out" 2> "$base/err" \
+    || { sed -n '1,100p' "$base/err" >&2; fail "optional systemd preparation blocks session Link"; }
+grep -qxF 'link_mode=session' "$base/config/ableton-wine/config" \
+    || fail "session Link was not saved after optional systemd preparation failed"
+grep -qF 'Link will still run with Ableton Live' "$base/err" \
+    || fail "optional systemd warning did not state the user-visible outcome"
+ok "session Link does not depend on optional systemd preparation"
+
+# Installed-file inventories and legacy restoration data describe generated
+# local files only. Damage there cannot stop a fresh Link repair.
+new_env malformed-local-records
+printf 'not a valid installed-file record\n' \
+    > "$base/state/ableton-wine/install-manifest.tsv"
+printf 'ambiguous\tlegacy\tdata\textra\n' \
+    > "$base/state/ableton-wine/install-prestate.tsv"
+mkdir -p -- "$base/state/ableton-wine/install-prestate"
+printf 'orphan\n' > "$base/state/ableton-wine/install-prestate/orphan"
+run_link bash "$here/setup-link.sh" enable --mode=session \
+    > "$base/out" 2> "$base/err" \
+    || { sed -n '1,100p' "$base/err" >&2; fail "optional local records block Link repair"; }
+grep -qF 'OK: Ableton Link is enabled' "$base/out" \
+    || fail "Link did not report the successful repair"
+ok "malformed optional local records do not gate Link setup"
+
+# Status is read-only. An interrupted project settings generation can be
+# salvaged for reporting without publishing repaired bytes behind the user's
+# back or hiding all observable Link state.
+new_env status-salvages-project-config
+mkdir -p -- "$base/config/ableton-wine"
+cat > "$base/config/ableton-wine/config" <<EOF
+# ableton-linux installer configuration; managed by the installer
+format=1
+runtime_root=$base/runtime
+prefix=$base/prefix
+link_mode=session
+linkd=$base/data/ableton-wine/ableton-linkd
+interrupted_tail
+EOF
+cp -- "$base/config/ableton-wine/config" "$base/config.before"
+run_link bash "$here/setup-link.sh" status > "$base/out" 2> "$base/err" \
+    || fail "an interrupted project settings file hid read-only Link status"
+grep -qxF 'mode: session (while Ableton Live is running)' "$base/out" \
+    || fail "Link status did not use the unambiguous saved mode"
+grep -qF 'Installer settings need repair; showing Link status' "$base/err" \
+    || fail "Link status did not explain its salvaged settings"
+cmp -s -- "$base/config.before" "$base/config/ableton-wine/config" \
+    || fail "read-only Link status rewrote interrupted project settings"
+ok "Link status salvages interrupted project settings without writing them"
+
+# A valid-looking firewall record is authority only below an exactly marked
+# project state root. Canonical paths and familiar bytes in a foreign directory
+# cannot authorize host firewall changes or deletion.
+new_env foreign-firewall-enable
+rm -f -- "$base/state/ableton-wine/.ableton-linux-state"
+printf 'ufw-added\n' > "$base/state/ableton-wine/link-firewall"
+if run_link bash "$here/setup-link.sh" enable --mode=session \
+        > "$base/out" 2> "$base/err"; then
+    fail "Link enable claimed a foreign state directory before firewall preparation"
+fi
+if ! grep -qxF 'ufw-added' "$base/state/ableton-wine/link-firewall" \
+   || [ -e "$base/state/ableton-wine/.ableton-linux-state" ]; then
+    fail "Link enable changed a foreign firewall record or claimed its directory"
+fi
+
+new_env foreign-firewall-disable
+rm -f -- "$base/state/ableton-wine/.ableton-linux-state"
+printf 'ufw-added\n' > "$base/state/ableton-wine/link-firewall"
+cat > "$base/fakebin/ufw" <<'EOF'
+#!/bin/sh
+: > "${ABLETON_TEST_UFW_RAN:?}"
+exit 0
+EOF
+chmod 755 "$base/fakebin/ufw"
+run_link env ABLETON_TEST_UFW_RAN="$base/ufw-ran" \
+    bash "$here/setup-link.sh" disable > "$base/out" 2> "$base/err" \
+    || fail "a foreign firewall record became a Link-disable gate"
+if ! grep -qxF 'ufw-added' "$base/state/ableton-wine/link-firewall" \
+   || [ -e "$base/ufw-ran" ]; then
+    fail "Link disable trusted or deleted a foreign firewall record"
+fi
+ok "firewall changes require an exactly marked Ableton Linux state root"
+
+# The installer owns its config bytes. If the six path/policy values are still
+# unambiguous, Link rebuilds a malformed generation and preserves those values.
+new_env repairable-config
+mkdir -p -- "$base/config/ableton-wine" "$base/custom"
+printf '#!/bin/sh\nexit 0\n' > "$base/custom/ableton-linkd"
+chmod 755 "$base/custom/ableton-linkd"
+cat > "$base/config/ableton-wine/config" <<EOF
+# ableton-linux installer configuration; managed by the installer
+format=1
+runtime_root=$base/custom/runtime
+prefix=$base/custom/prefix
+live_major=12
+link_mode=session
+linkd=$base/custom/ableton-linkd
+unexpected=old-generated-line
+EOF
+run_link bash "$here/setup-link.sh" disable > /dev/full 2> "$base/err" \
+    || { sed -n '1,100p' "$base/err" >&2; fail "closed repair output blocks Link disable"; }
+grep -qxF '# ableton-linux installer configuration; managed by the installer' \
+    "$base/config/ableton-wine/config" \
+    || fail "Link did not rebuild the malformed generated settings"
+if ! grep -qxF "linkd=$base/custom/ableton-linkd" "$base/config/ableton-wine/config" \
+   || ! grep -qxF 'link_mode=off' "$base/config/ableton-wine/config"; then
+    fail "Link rebuild lost safe existing settings or the requested off mode"
+fi
+grep -qxF '#!/bin/sh' "$base/custom/ableton-linkd" \
+    || fail "Link disable changed an external configured helper"
+ok "repairable generated settings are rebuilt without losing safe values"
+
+# Repair publishes a complete canonical config before any firewall or service
+# mutation. A later real system failure therefore cannot erase the settings it
+# used to locate the existing install.
+new_env repair-before-system-failure
+mkdir -p -- "$base/config/ableton-wine" "$base/custom"
+printf '#!/bin/sh\nexit 0\n' > "$base/custom/ableton-linkd"
+chmod 755 "$base/custom/ableton-linkd"
+cat > "$base/config/ableton-wine/config" <<EOF
+# ableton-linux installer configuration; managed by the installer
+format=1
+runtime_root=$base/custom/runtime
+prefix=$base/custom/prefix
+live_major=12
+link_mode=session
+linkd=$base/custom/ableton-linkd
+obsolete_generated_key=remove-me
+EOF
+cat > "$base/fakebin/grep" <<'EOF'
+#!/bin/sh
+for argument do
+    [ "$argument" != /etc/ufw/ufw.conf ] || exit 0
+done
+exec /usr/bin/grep "$@"
+EOF
+cat > "$base/fakebin/ufw" <<'EOF'
+#!/bin/sh
+[ "$1" != status ] || exit 9
+exit 0
+EOF
+printf '#!/bin/sh\nexec "$@"\n' > "$base/fakebin/sudo"
+chmod 755 "$base/fakebin/grep" "$base/fakebin/ufw" "$base/fakebin/sudo"
+if run_link bash "$here/setup-link.sh" enable --mode=session \
+    > "$base/out" 2> "$base/err"; then
+    fail "an unreadable active firewall was accepted"
+fi
+if ! grep -qxF '# ableton-linux installer configuration; managed by the installer' \
+        "$base/config/ableton-wine/config" \
+   || ! grep -qxF "linkd=$base/custom/ableton-linkd" "$base/config/ableton-wine/config" \
+   || grep -qF obsolete_generated_key "$base/config/ableton-wine/config"; then
+    fail "a later Link failure lost or partially published repaired settings"
+fi
+ok "Link publishes repaired settings before a later system failure"
+
+# Settings are generated local integration. If their atomic publication is
+# unavailable, the requested firewall/service change remains authoritative and
+# the user gets a concrete retry instruction instead of a fake Link failure.
+new_env optional-link-preference-write
+mkdir -p -- "$base/config/ableton-wine"
+cat > "$base/config/ableton-wine/config" <<EOF
+# ableton-linux installer configuration; managed by the installer
+format=1
+runtime_root=$base/runtime
+prefix=$base/prefix
+link_mode=off
+linkd=$base/data/ableton-wine/ableton-linkd
+interrupted_tail
+EOF
+cp -- "$base/config/ableton-wine/config" "$base/config.before"
+cat > "$base/fakebin/mv" <<'EOF'
+#!/bin/sh
+target=""
+for argument do target="$argument"; done
+[ "$target" != "${ABLETON_TEST_CONFIG_TARGET:?}" ] || exit 73
+exec /usr/bin/mv "$@"
+EOF
+chmod 755 "$base/fakebin/mv"
+run_link env ABLETON_TEST_CONFIG_TARGET="$base/config/ableton-wine/config" \
+    bash "$here/setup-link.sh" enable --mode=session > "$base/out" 2> "$base/err" \
+    || { sed -n '1,100p' "$base/err" >&2; fail "optional Link preference publication became an enable gate"; }
+cmp -s -- "$base/config.before" "$base/config/ableton-wine/config" \
+    || fail "failed optional preference publication damaged the prior config"
+grep -qxF 'none' "$base/state/ableton-wine/link-firewall" \
+    || fail "optional preference failure prevented the requested Link system change"
+grep -qF 'run the installer again to save the preference' "$base/out" \
+    || fail "Link preference warning did not give the user a direct next step"
+ok "Link preference persistence is warning-only after the requested system change"
+
+# A foreign file or symlink is not proof of project-owned generated state.
+# Direct Link commands refuse it without deleting or following it.
+new_env foreign-config-preservation
+mkdir -p -- "$base/config/ableton-wine"
+cat > "$base/config/ableton-wine/config" <<EOF
+foreign settings
+format=1
+runtime_root=$base/runtime
+prefix=$base/prefix
+live_major=12
+link_mode=session
+linkd=$base/data/ableton-wine/ableton-linkd
+EOF
+cp -- "$base/config/ableton-wine/config" "$base/foreign.before"
+if run_link bash "$here/setup-link.sh" disable > "$base/out" 2> "$base/err"; then
+    fail "direct Link replaced a foreign settings file"
+fi
+cmp -s -- "$base/foreign.before" "$base/config/ableton-wine/config" \
+    || fail "direct Link changed a foreign settings file"
+ok "direct Link preserves foreign settings"
+
+new_env symlink-config-preservation
+mkdir -p -- "$base/config/ableton-wine" "$base/personal"
+cat > "$base/personal/config" <<EOF
+# ableton-linux installer configuration; managed by the installer
+format=1
+runtime_root=$base/runtime
+prefix=$base/prefix
+live_major=12
+link_mode=session
+linkd=$base/data/ableton-wine/ableton-linkd
+obsolete_generated_key=remove-me
+EOF
+cp -- "$base/personal/config" "$base/symlink-target.before"
+ln -s -- "$base/personal/config" "$base/config/ableton-wine/config"
+if run_link bash "$here/setup-link.sh" disable > "$base/out" 2> "$base/err"; then
+    fail "direct Link followed a settings symlink"
+fi
+if [ ! -L "$base/config/ableton-wine/config" ] \
+   || [ "$(readlink -- "$base/config/ableton-wine/config")" != "$base/personal/config" ] \
+   || ! cmp -s -- "$base/symlink-target.before" "$base/personal/config"; then
+    fail "direct Link changed a settings symlink or its target"
+fi
+ok "direct Link preserves settings symlinks and their targets"
+
+# Once firewall/service state and the saved mode are verified, failure to
+# delete temporary recovery data is cleanup—not failure of Link itself.
+new_env cleanup-after-success
+cat > "$base/fakebin/rm" <<'EOF'
+#!/bin/sh
+for argument do
+    case "$argument" in
+        *.link-enable.*)
+            kill -TERM "$PPID"
+            exit 99 ;;
+    esac
+done
+exec /usr/bin/rm "$@"
+EOF
+chmod 755 "$base/fakebin/rm"
+run_link bash "$here/setup-link.sh" enable --mode=session \
+    > "$base/out" 2> "$base/err" \
+    || { sed -n '1,100p' "$base/err" >&2; fail "temporary cleanup turns successful Link setup into failure"; }
+grep -qF 'temporary recovery files could not be removed' "$base/err" \
+    || fail "Link cleanup warning did not explain what remains"
+grep -qxF 'link_mode=session' "$base/config/ableton-wine/config" \
+    || fail "cleanup warning lost the successful Link mode"
+ok "enable cleanup and a late signal cannot reverse completed Link setup"
+
+# Disable has the same commit boundary: once the helper is stopped and off is
+# saved, a signal raised by generated-file cleanup must not make the public
+# installer roll back a completed result.
+new_env disable-after-success-signal
+run_link bash "$here/setup-link.sh" enable --mode=session \
+    > "$base/enable.out" 2> "$base/enable.err" \
+    || fail "disable signal fixture could not first enable Link"
+printf 'file\t%s\t%s\n' "$base/data/ableton-wine/ableton-linkd" \
+    "$(sha256sum -- "$base/data/ableton-wine/ableton-linkd" | awk '{print $1}')" \
+    > "$base/state/ableton-wine/install-manifest.tsv"
+cat > "$base/fakebin/rm" <<EOF
+#!/bin/sh
+for argument do
+    if [ "\$argument" = "$base/data/ableton-wine/ableton-linkd" ]; then
+        kill -TERM "\$PPID"
+    fi
+done
+exec /usr/bin/rm "\$@"
+EOF
+chmod 755 "$base/fakebin/rm"
+run_link bash "$here/setup-link.sh" disable > "$base/out" 2> "$base/err" \
+    || { sed -n '1,100p' "$base/err" >&2; fail "late cleanup signal reversed completed Link disable"; }
+grep -qxF 'link_mode=off' "$base/config/ableton-wine/config" \
+    || fail "late cleanup signal lost the saved off mode"
+ok "disable cleanup and a late signal cannot reverse completed Link setup"
+
+# The pre-config legacy marker is generated by old releases. Only its two exact
+# one-line values belong to this project, and removing it happens after the new
+# Link mode has already been saved.
+new_env exact-legacy-policy-cleanup
+printf 'configured\n' > "$base/data/ableton-wine/link-configured"
+run_link bash "$here/setup-link.sh" enable --mode=session \
+    > "$base/enable.out" 2> "$base/enable.err" \
+    || fail "an exact old Link setting blocked Link enable"
+[ ! -e "$base/data/ableton-wine/link-configured" ] \
+    && [ ! -L "$base/data/ableton-wine/link-configured" ] \
+    || fail "Link enable retained its exact obsolete setting"
+printf 'declined\n' > "$base/data/ableton-wine/link-configured"
+run_link bash "$here/setup-link.sh" disable > "$base/disable.out" 2> "$base/disable.err" \
+    || fail "an exact old Link setting blocked Link disable"
+[ ! -e "$base/data/ableton-wine/link-configured" ] \
+    && [ ! -L "$base/data/ableton-wine/link-configured" ] \
+    || fail "Link disable retained its exact obsolete setting"
+ok "exact old Link settings are best-effort cleanup after the requested mode is saved"
+
+for foreign_policy_kind in multiline symlink directory; do
+    new_env "foreign-legacy-policy-$foreign_policy_kind"
+    marker="$base/data/ableton-wine/link-configured"
+    case "$foreign_policy_kind" in
+        multiline) printf 'configured\npersonal note\n' > "$marker" ;;
+        symlink)
+            printf 'personal Link note\n' > "$base/personal-link-note"
+            ln -s -- "$base/personal-link-note" "$marker" ;;
+        directory) mkdir -p -- "$marker"; printf 'personal Link note\n' > "$marker/note" ;;
+    esac
+    run_link bash "$here/setup-link.sh" disable > "$base/out" 2> "$base/err" \
+        || fail "a foreign $foreign_policy_kind Link marker became a disable gate"
+    case "$foreign_policy_kind" in
+        multiline) grep -qxF 'personal note' "$marker" \
+            || fail "Link disable removed a foreign multiline marker" ;;
+        symlink)
+            if [ ! -L "$marker" ] \
+               || ! grep -qxF 'personal Link note' "$base/personal-link-note"; then
+                fail "Link disable removed or followed a foreign marker symlink"
+            fi ;;
+        directory) grep -qxF 'personal Link note' "$marker/note" \
+            || fail "Link disable removed a foreign marker directory" ;;
+    esac
+done
+ok "foreign objects at the old Link-setting path are preserved without gating disable"
+
+# Disabling Link may remove only assets proven by their saved digest or an exact
+# historical signature. Canonical-looking paths alone are not ownership proof.
+new_env foreign-link-assets
+unit="$base/config/systemd/user/ableton-linkd.service"
+wants="$base/config/systemd/user/default.target.wants/ableton-linkd.service"
+mkdir -p -- "$(dirname -- "$wants")"
+printf 'foreign unit\n' > "$unit"
+ln -s -- "$unit" "$wants"
+printf 'foreign binary\n' > "$base/data/ableton-wine/ableton-linkd"
+printf 'original controller\n' > "$base/data/ableton-wine/ableton-linkctl"
+printf 'file\t%s\t%s\n' "$base/data/ableton-wine/ableton-linkctl" \
+    "$(sha256sum -- "$base/data/ableton-wine/ableton-linkctl" | awk '{print $1}')" \
+    > "$base/state/ableton-wine/install-manifest.tsv"
+printf 'locally modified controller\n' >> "$base/data/ableton-wine/ableton-linkctl"
+printf 'foreign setup helper\n' > "$base/data/ableton-wine/setup-link.sh"
+printf 'foreign unit template\n' > "$base/data/ableton-wine/ableton-linkd.service"
+run_link bash "$here/setup-link.sh" disable > "$base/out" 2> "$base/err" \
+    || { sed -n '1,100p' "$base/err" >&2; fail "foreign Link assets became a disable gate"; }
+if ! grep -qxF 'foreign unit' "$unit" || [ ! -L "$wants" ] \
+   || ! grep -qxF 'foreign binary' "$base/data/ableton-wine/ableton-linkd" \
+   || ! grep -qxF 'locally modified controller' "$base/data/ableton-wine/ableton-linkctl" \
+   || ! grep -qxF 'foreign setup helper' "$base/data/ableton-wine/setup-link.sh" \
+   || ! grep -qxF 'foreign unit template' "$base/data/ableton-wine/ableton-linkd.service"; then
+    fail "Link disable deleted a foreign or modified object from a canonical path"
+fi
+grep -qxF 'link_mode=off' "$base/config/ableton-wine/config" \
+    || fail "preserving foreign Link assets prevented the requested off mode"
+ok "Link disable preserves foreign and modified assets while saving the requested mode"
+
+# A caller may stop reading progress output (for example, piping it through
+# head). Broken output after the saved result is reporting failure, not an
+# installation failure.
+new_env post-success-broken-output
+if ! run_link bash "$here/setup-link.sh" enable --mode=session 2> "$base/enable.err" \
+        | head -n 2 > /dev/null; then
+    fail "closed progress output reversed completed Link enable"
+fi
+grep -qxF 'link_mode=session' "$base/config/ableton-wine/config" \
+    || fail "closed progress output lost the enabled mode"
+if ! run_link bash "$here/setup-link.sh" disable 2> "$base/disable.err" \
+        | head -n 1 > /dev/null; then
+    fail "closed progress output reversed completed Link disable"
+fi
+grep -qxF 'link_mode=off' "$base/config/ableton-wine/config" \
+    || fail "closed progress output lost the off mode"
+ok "closed progress output cannot reverse completed Link changes"
+
+# The PID record is generated cache, not the Link outcome. A canonical helper
+# can be found again by its exact executable when that cache cannot be written;
+# stopping it also succeeds even when the stale cache object cannot be removed.
+new_env controller-managed-pid-cache
+cp -- "$root/dist/ableton-linkd" "$base/data/ableton-wine/ableton-linkd"
+chmod 755 "$base/data/ableton-wine/ableton-linkd"
+printf 'file\t%s\t%s\n' "$base/data/ableton-wine/ableton-linkd" \
+    "$(sha256sum -- "$base/data/ableton-wine/ableton-linkd" | awk '{print $1}')" \
+    > "$base/state/ableton-wine/install-manifest.tsv"
+mkdir -p -- "$base/run/ableton-wine/linkd.pid"
+run_link env ABLETON_LINK_MODE=session ABLETON_LINKD_LINGER=30 \
+    bash "$here/ableton-linkctl" start > "$base/start.out" 2> "$base/start.err" \
+    || { sed -n '1,100p' "$base/start.err" >&2; fail "a PID-cache write failure misreported a managed Link start"; }
+run_link env ABLETON_LINK_MODE=session bash "$here/ableton-linkctl" status \
+    > "$base/status.out" 2> "$base/status.err" \
+    || fail "managed Link could not be found without its PID cache"
+managed_link_pid="$(sed -n 's/^state: running (process \([0-9][0-9]*\))$/\1/p' "$base/status.out")"
+[ -n "$managed_link_pid" ] && kill -0 "$managed_link_pid" 2>/dev/null \
+    || fail "managed Link start did not leave the requested process running"
+run_link env ABLETON_LINK_MODE=session ABLETON_LINKD_LINGER=30 \
+    bash "$here/ableton-linkctl" start > "$base/restart.out" 2> "$base/restart.err" \
+    || fail "an already-running managed Link was misreported after PID-cache failure"
+run_link env ABLETON_LINK_MODE=session bash "$here/ableton-linkctl" stop \
+    > "$base/stop.out" 2> "$base/stop.err" \
+    || fail "PID-cache removal failure misreported a successful Link stop"
+for _ in {1..50}; do
+    kill -0 "$managed_link_pid" 2>/dev/null || break
+    sleep 0.1
+done
+kill -0 "$managed_link_pid" 2>/dev/null \
+    && fail "managed Link remained running after the cache-independent stop"
+[ -d "$base/run/ableton-wine/linkd.pid" ] \
+    || fail "PID-cache failure fixture did not remain in place"
+ok "managed Link start and stop follow the process outcome when PID cache writes fail"
+
+# An arbitrary configured helper cannot be rediscovered without the recorded
+# PID. If that record cannot be published, reap only the new child and report
+# the genuine safety failure instead of leaving an untracked process running.
+new_env controller-external-pid-record
+external_linkd="$base/external/ableton-linkd"
+mkdir -p -- "$(dirname "$external_linkd")" "$base/run/ableton-wine/linkd.pid"
+cp -- "$root/dist/ableton-linkd" "$external_linkd"
+chmod 755 "$external_linkd"
+if run_link env ABLETON_LINK_MODE=session ABLETON_LINKD="$external_linkd" \
+    ABLETON_LINKD_LINGER=30 bash "$here/ableton-linkctl" start \
+    > "$base/out" 2> "$base/err"; then
+    fail "external Link start succeeded without a safe process record"
+fi
+grep -qF 'was stopped because its process could not be tracked safely' "$base/err" \
+    || fail "external Link PID-record failure did not explain the outcome"
+external_link_running=0
+for proc in /proc/[0-9]*; do
+    [ "$(readlink -f "$proc/exe" 2>/dev/null || true)" != \
+        "$(readlink -f "$external_linkd")" ] || external_link_running=1
+done
+[ "$external_link_running" -eq 0 ] \
+    || fail "external Link PID-record failure left its new process running"
+ok "external Link is reaped when its only safe process record cannot be written"
+
+# A recognisable helper may contain far more printable data after its marker
+# than a pipe buffer can hold. The controller must consume that output before
+# matching it, then select a PID from a complete process list.
+new_env controller-large-helper
+cp -- /bin/sleep "$base/data/ableton-wine/ableton-linkd"
+printf '\nableton-linkd: native Ableton Link session anchor and probe\n' \
+    >> "$base/data/ableton-wine/ableton-linkd"
+awk 'BEGIN { for (i = 0; i < 200000; i++) printf "printable-tail-%06d\\n", i }' \
+    >> "$base/data/ableton-wine/ableton-linkd"
+chmod 755 "$base/data/ableton-wine/ableton-linkd"
+"$base/data/ableton-wine/ableton-linkd" 60 &
+large_helper_pid=$!
+run_link env ABLETON_LINK_MODE=session bash "$here/ableton-linkctl" status \
+    > "$base/out" 2> "$base/err" \
+    || { kill "$large_helper_pid" 2>/dev/null || true; fail "large helper output caused a false controller failure"; }
+grep -qxF "state: running (process $large_helper_pid)" "$base/out" \
+    || { kill "$large_helper_pid" 2>/dev/null || true; fail "controller did not select the owned helper PID"; }
+kill "$large_helper_pid" 2>/dev/null || true
+wait "$large_helper_pid" 2>/dev/null || true
+ok "Link controller fully consumes ownership and PID discovery output"
+
+printf '1..%s\n' "$tests"

--- a/scripts/test-link-boundary.sh
+++ b/scripts/test-link-boundary.sh
@@ -19,6 +19,13 @@ ok()
     echo "ok - $*"
 }
 
+linkd_artifact="$root/dist/ableton-linkd"
+if [ ! -f "$linkd_artifact" ]; then
+    echo "!! missing build artifact: dist/ableton-linkd" >&2
+    echo "!! run ./build.sh first" >&2
+    fail "prerequisite build artifacts are valid"
+fi
+
 new_env()
 {
     local name="$1"
@@ -483,7 +490,7 @@ ok "closed progress output cannot reverse completed Link changes"
 # can be found again by its exact executable when that cache cannot be written;
 # stopping it also succeeds even when the stale cache object cannot be removed.
 new_env controller-managed-pid-cache
-cp -- "$root/dist/ableton-linkd" "$base/data/ableton-wine/ableton-linkd"
+cp -- "$linkd_artifact" "$base/data/ableton-wine/ableton-linkd"
 chmod 755 "$base/data/ableton-wine/ableton-linkd"
 printf 'file\t%s\t%s\n' "$base/data/ableton-wine/ableton-linkd" \
     "$(sha256sum -- "$base/data/ableton-wine/ableton-linkd" | awk '{print $1}')" \
@@ -520,7 +527,7 @@ ok "managed Link start and stop follow the process outcome when PID cache writes
 new_env controller-external-pid-record
 external_linkd="$base/external/ableton-linkd"
 mkdir -p -- "$(dirname "$external_linkd")" "$base/run/ableton-wine/linkd.pid"
-cp -- "$root/dist/ableton-linkd" "$external_linkd"
+cp -- "$linkd_artifact" "$external_linkd"
 chmod 755 "$external_linkd"
 if run_link env ABLETON_LINK_MODE=session ABLETON_LINKD="$external_linkd" \
     ABLETON_LINKD_LINGER=30 bash "$here/ableton-linkctl" start \

--- a/scripts/test-pipeasio-installer.sh
+++ b/scripts/test-pipeasio-installer.sh
@@ -34,6 +34,11 @@ ABLETON_PIPEWIRE_FLOOR=0.3.56
 [ "$ABLETON_PIPEWIRE_FLOOR" = 1.4.2 ] || fail "environment overrode the hard PipeWire floor"
 declare -F ableton_pipewire_preflight >/dev/null || fail "PipeWire preflight API is missing"
 declare -F ableton_pipeasio_validate_runtime >/dev/null || fail "runtime validation API is missing"
+grep -qF 'Install PipeWire 1.4.2 or newer.' "$here/setup-prefix.sh" \
+    || fail "prefix setup does not report the enforced PipeWire floor"
+if grep -qF '0.3.56 or newer' "$here/setup-prefix.sh"; then
+    fail "prefix setup still reports the obsolete PipeWire floor"
+fi
 ok "PipeWire 1.4.2 is a hard release floor"
 
 new_env()
@@ -134,6 +139,22 @@ if invoke_preflight 1.6.8 1.6.8 9 >/dev/null 2>&1; then
 fi
 ok "native probe gates loaded client and daemon without PipeWire CLI utilities"
 
+# Once the native probe and version comparison have succeeded, their terminal
+# report is presentation only. Optional-tool advice is presentation from the
+# outset. A closed stdout must not turn either into a component/rollback error.
+if ! env PATH="$probe_base/core-path" \
+    PROBE_CLIENT=1.6.8 PROBE_DAEMON=1.6.8 PROBE_EXIT=0 \
+    /bin/bash -c '
+        set -euo pipefail
+        . "$1"
+        ableton_pipewire_preflight "$2" >&-
+        ABLETON_PIPEASIO_DIAGNOSTIC_NOTICE_SHOWN=0
+        ableton_pipeasio_optional_tools_advice >&-
+    ' _ "$here/lib/pipeasio.sh" "$probe" 2>/dev/null; then
+    fail "successful PipeWire proof or optional-tool advice inherited terminal output status"
+fi
+ok "successful compatibility proof and optional-tool advice ignore presentation failures"
+
 base="$(new_env mutation-lock)"
 mkdir -p -- "$base/xdg/state/ableton-wine"
 printf 'format=1\nowner=ableton-linux\n' \
@@ -162,7 +183,7 @@ if run_isolated "$base" env -u ABLETON_INSTALL_LOCK_FD \
     >"$base/setup-link.out" 2>"$base/setup-link.err"; then
     fail "direct setup-link mutator bypassed the held installation lock"
 fi
-grep -qF 'another installer, rollback, or uninstall is already running' \
+grep -qF 'Another Ableton Linux install, repair, or removal is already running. Wait for it to finish and try again.' \
     "$base/setup-link.err" || fail "setup-link lock refusal was not explicit"
 [ ! -e "$base/link-transaction" ] \
     || fail "refused setup-link mutator created a transaction snapshot"
@@ -170,6 +191,36 @@ grep -qF 'another installer, rollback, or uninstall is already running' \
     = "$state_marker_digest" ] || fail "refused setup-link mutator changed installer state"
 exec {held_lock_fd}<&-
 ok "one non-persistent lock serializes installer helpers and direct setup-link mutators"
+
+# A forked Bash child shares the parent's open file description. It may close
+# its duplicate, but must never issue LOCK_UN against the parent's lock. The
+# opener may still release it explicitly, including when the opener itself is a
+# subshell (BASHPID, rather than $$, identifies that owner).
+base="$(new_env mutation-lock-owner)"
+run_isolated "$base" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ableton_config_init
+    ableton_install_lock_acquire
+    parent_fd="$ABLETON_INSTALL_LOCK_FD"
+    ( ableton_install_lock_release >/dev/null 2>&1 || true )
+    if (
+        inherited="$parent_fd"
+        exec {inherited}<&-
+        unset ABLETON_INSTALL_LOCK_FD ABLETON_INSTALL_LOCK_OWNER_BASHPID
+        ableton_install_lock_acquire >/dev/null 2>&1
+    ); then
+        echo "forked child unlocked its parent" >&2
+        exit 1
+    fi
+    ableton_install_lock_release
+    (
+        unset ABLETON_INSTALL_LOCK_FD ABLETON_INSTALL_LOCK_OWNER_BASHPID
+        ableton_install_lock_acquire
+        ableton_install_lock_release
+    )
+' _ "$here" || fail "installation lock ownership is not confined to the opening Bash process"
+ok "forked children cannot unlock their parent, while each real lock owner can release"
 
 write_build_info()
 {
@@ -234,12 +285,14 @@ make_runtime()
 
 runtime_validates()
 {
-    ableton_pipeasio_validate_runtime "$1" "$2" >/dev/null 2>&1
+    ableton_pipeasio_validate_runtime "$1" "$2" >/dev/null 2>&1 \
+        && ableton_pipeasio_validate_panel "$1" "$2" >/dev/null 2>&1
 }
 
 runtime_fails_validation()
 {
-    if ableton_pipeasio_validate_runtime "$1" "$2" >/dev/null 2>&1; then
+    if ableton_pipeasio_validate_runtime "$1" "$2" >/dev/null 2>&1 \
+       && ableton_pipeasio_validate_panel "$1" "$2" >/dev/null 2>&1; then
         return 1
     fi
 }
@@ -266,6 +319,8 @@ base="$(new_env artifact-partial)"
 make_runtime "$base/runtime" "$base/BUILD-INFO.txt" built
 rm -f -- "$base/runtime/share/icons/hicolor/scalable/apps/pipeasio.svg"
 runtime_fails_validation "$base/runtime" "$base/BUILD-INFO.txt" || fail "partial built-panel payload was accepted"
+ableton_pipeasio_validate_runtime "$base/runtime" "$base/BUILD-INFO.txt" >/dev/null 2>&1 \
+    || fail "partial optional panel invalidated the core PipeASIO runtime"
 ok "partial panel payload is refused"
 
 base="$(new_env artifact-polluted-skip)"
@@ -436,7 +491,7 @@ run_isolated "$base" env \
 [ ! -e "$base/home/.local/bin/pipeasio-settings" ] \
     && [ ! -e "$base/xdg/data/applications/pipeasio-settings.desktop" ] \
     && [ ! -e "$base/xdg/data/icons/hicolor/scalable/apps/pipeasio.svg" ] \
-    || fail "fresh runtime-only install created panel integration"
+    || fail "direct runtime-only reconcile created previously absent panel shortcuts"
 runtime_only_manifest="$base/xdg/state/ableton-wine/install-manifest.tsv"
 if [ -r "$runtime_only_manifest" ] && awk -F '\t' \
     -v command="$base/home/.local/bin/pipeasio-settings" \
@@ -444,9 +499,311 @@ if [ -r "$runtime_only_manifest" ] && awk -F '\t' \
     -v icon="$base/xdg/data/icons/hicolor/scalable/apps/pipeasio.svg" \
     '$2 == command || $2 == desktop || $2 == icon { found=1 } END { exit !found }' \
     "$runtime_only_manifest"; then
-    fail "fresh runtime-only install claimed absent panel integration"
+    fail "direct runtime-only reconcile claimed absent panel shortcuts"
 fi
-ok "fresh runtime-only install leaves optional panel integration absent"
+grep -qxF 'OK: Installation complete.' "$base/out" \
+    || fail "direct runtime-only install did not print its simple outcome"
+ok "direct runtime-only install completes before reconciling optional panel shortcuts"
+
+# Repair-mode parsing keeps safe, unambiguous values from this project's file
+# even when an obsolete field makes the whole generation invalid. CLI values
+# still win, and the malformed regular file is not replaced until Wine is
+# validated and committed.
+base="$(new_env managed-config-repair)"
+make_runtime_only_kit "$base"
+config_path="$base/xdg/config/ableton-wine/config"
+custom_prefix="$base/custom-prefix"
+mkdir -p -- "$(dirname "$config_path")"
+cat > "$config_path" <<EOF
+# ableton-linux installer configuration; managed by the installer
+format=1
+runtime_root=$base/old-runtime
+prefix=$custom_prefix
+live_major=12
+link_mode=off
+obsolete_field=written-by-an-older-installer
+EOF
+if run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    bash "$base/kit/scripts/installer.sh" update --dry-run \
+    >"$base/update.out" 2>"$base/update.err"; then
+    fail "update fixture unexpectedly passed without an existing custom prefix"
+fi
+grep -qF "update needs an existing prefix at $custom_prefix" "$base/update.err" \
+    || fail "repair mode dropped an unambiguous custom prefix and checked the default instead"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+    bash "$base/kit/scripts/installer.sh" runtime install \
+        --runtime-root "$base/runtime" --yes >"$base/install.out" 2>"$base/install.err" \
+    || fail "runtime install could not repair a project-owned malformed config"
+[ -f "$base/runtime/.ableton-linux-runtime" ] \
+    || fail "managed-config repair did not retain the committed runtime"
+run_isolated "$base" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ableton_config_init strict
+    ableton_managed_config_valid "$ABLETON_CONFIG_FILE"
+' _ "$here" || fail "managed-config repair did not publish a strict valid generation"
+grep -qxF "runtime_root=$base/runtime" "$config_path" \
+    && grep -qxF "prefix=$custom_prefix" "$config_path" \
+    && ! grep -q '^obsolete_field=' "$config_path" \
+    || fail "managed-config repair lost salvaged paths or retained obsolete data"
+ok "coordinator repair salvages custom paths and rewrites malformed project settings only after core success"
+
+for config_kind in foreign-regular symlink directory; do
+    base="$(new_env "config-repair-${config_kind}")"
+    make_runtime_only_kit "$base"
+    config_path="$base/xdg/config/ableton-wine/config"
+    mkdir -p -- "$(dirname "$config_path")"
+    case "$config_kind" in
+        foreign-regular)
+            printf 'foreign arbitrary settings\n' > "$config_path" ;;
+        symlink)
+            printf 'foreign symlink referent\n' > "$base/foreign-config"
+            ln -s -- "$base/foreign-config" "$config_path" ;;
+        directory)
+            mkdir -- "$config_path"
+            printf 'foreign directory sentinel\n' > "$config_path/sentinel" ;;
+    esac
+    run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+        PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+        bash "$base/kit/scripts/installer.sh" runtime install \
+            --runtime-root "$base/runtime" --yes >"$base/out" 2>"$base/err" \
+        || fail "$config_kind installer settings invalidated a runtime install"
+    [ -f "$base/runtime/.ableton-linux-runtime" ] \
+        || fail "$config_kind installer settings displaced the committed runtime"
+    case "$config_kind" in
+        foreign-regular)
+            run_isolated "$base" bash -c '
+                set -euo pipefail
+                . "$1/lib/config.sh"
+                ableton_config_init strict
+                ableton_managed_config_valid "$ABLETON_CONFIG_FILE"
+            ' _ "$here" || fail "arbitrary regular settings were not rebuilt"
+            grep -qxF "runtime_root=$base/runtime" "$config_path" \
+                || fail "arbitrary settings repair did not keep the CLI runtime" ;;
+        symlink)
+            [ -L "$config_path" ] \
+                && [ "$(readlink -- "$config_path")" = "$base/foreign-config" ] \
+                && grep -qxF 'foreign symlink referent' "$base/foreign-config" \
+                || fail "config repair replaced a symlink or changed its referent"
+            grep -qF 'Wine is ready, but installer settings could not be saved.' "$base/err" \
+                || fail "symlink config retention was not a saved-settings warning" ;;
+        directory)
+            [ -d "$config_path" ] && [ ! -L "$config_path" ] \
+                && grep -qxF 'foreign directory sentinel' "$config_path/sentinel" \
+                || fail "config repair replaced a foreign settings directory"
+            grep -qF 'Wine is ready, but installer settings could not be saved.' "$base/err" \
+                || fail "directory config retention was not a saved-settings warning" ;;
+    esac
+done
+ok "arbitrary settings cannot gate Wine, while symlink and directory objects stay unchanged"
+
+# Runtime-only work does not use prefix, desktop-data, installer-settings,
+# persistent-state, or launcher roots for its core promotion. Foreign objects
+# at any of those optional paths must survive while Wine still commits; the
+# post-core panel/config repair may warn and skip them.
+for optional_root in prefix data config state bin; do
+    base="$(new_env "runtime-unrelated-${optional_root}-root")"
+    make_runtime_only_kit "$base"
+    foreign_root="$base/foreign-$optional_root-root"
+    printf 'foreign optional root\n' > "$foreign_root"
+    case "$optional_root" in
+        prefix) root_var=ABLETON_WINEPREFIX ;;
+        data) root_var=ABLETON_DATA_HOME ;;
+        config) root_var=ABLETON_CONFIG_HOME ;;
+        state) root_var=ABLETON_STATE_HOME ;;
+        bin) root_var=ABLETON_BIN_HOME ;;
+    esac
+    run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+        "$root_var=$foreign_root" PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+        bash "$base/kit/scripts/installer.sh" runtime install \
+            --runtime-root "$base/runtime" --yes >"$base/out" 2>"$base/err" \
+        || fail "unrelated $optional_root root blocked runtime-only installation"
+    [ -f "$base/runtime/.ableton-linux-runtime" ] \
+        && grep -qxF 'foreign optional root' "$foreign_root" \
+        || fail "runtime-only installation changed the unrelated $optional_root root"
+done
+ok "unrelated optional root objects cannot gate runtime-only installation"
+
+base="$(new_env coordinator-postcore-output)"
+make_runtime_only_kit "$base"
+cat > "$base/postcore-failure.bash" <<'EOF'
+echo()
+{
+    if [ "$*" = 'OK: the Wine runtime is installed' ]; then
+        return 74
+    fi
+    builtin echo "$@"
+}
+EOF
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    BASH_ENV="$base/postcore-failure.bash" \
+    PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+    bash "$base/kit/scripts/installer.sh" runtime install \
+        --runtime-root "$base/runtime" --yes >"$base/out" 2>"$base/err" \
+    || fail "final output failure reported a committed runtime as failed"
+[ -f "$base/runtime/.ableton-linux-runtime" ] \
+    || fail "final output failure rolled back the committed runtime"
+grep -qxF "  runtime: $base/runtime" "$base/out" \
+    || fail "one failed success line stopped the remaining final presentation"
+ok "coordinator continues final presentation after one output fails"
+
+base="$(new_env child-runtime-only-core)"
+make_runtime_only_kit "$base"
+txn="$base/core-transaction"
+mkdir -p -- "$txn"
+run_isolated "$base" env \
+    PATH="$base/fakebin:$PATH" \
+    ABLETON_WINE_ROOT="$base/runtime" \
+    ABLETON_WINEPREFIX="$base/prefix" \
+    PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+    bash "$base/kit/scripts/install.sh" --runtime-only --transaction-dir "$txn" --yes \
+    >"$base/out" 2>"$base/err" || fail "parent-owned runtime core phase failed"
+[ -f "$base/runtime/.ableton-linux-runtime" ] \
+    || fail "parent-owned runtime core phase did not promote Wine"
+[ -s "$txn/runtime.tsv" ] \
+    || fail "parent-owned runtime core phase omitted its directory rollback record"
+[ -f "$txn/files.tsv" ] && [ ! -s "$txn/files.tsv" ] \
+    || fail "parent-owned runtime core phase journalled ancillary files"
+[ ! -e "$base/home/.local/bin/pipeasio-settings" ] \
+    && [ ! -e "$base/xdg/data/applications/pipeasio-settings.desktop" ] \
+    && [ ! -e "$base/xdg/data/icons/hicolor/scalable/apps/pipeasio.svg" ] \
+    || fail "parent-owned runtime core phase changed panel shortcuts"
+if grep -q '^OK:' "$base/out"; then
+    fail "parent-owned runtime core phase printed a child success line"
+fi
+ok "parent-owned runtime core phase records only Wine and leaves panel repair to the parent"
+
+base="$(new_env direct-runtime-panel-warning)"
+make_runtime_only_kit "$base"
+mkdir -p -- "$base/home/.local/bin/pipeasio-settings"
+printf 'foreign directory sentinel\n' > "$base/home/.local/bin/pipeasio-settings/sentinel"
+run_isolated "$base" env \
+    PATH="$base/fakebin:$PATH" \
+    ABLETON_WINE_ROOT="$base/runtime" \
+    ABLETON_WINEPREFIX="$base/prefix" \
+    PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+    bash "$base/kit/scripts/install.sh" --runtime-only --yes \
+    >"$base/out" 2>"$base/err" \
+    || fail "postcommit panel repair failure invalidated a runtime install"
+[ -f "$base/runtime/.ableton-linux-runtime" ] \
+    || fail "panel repair warning displaced the committed runtime"
+grep -qxF 'foreign directory sentinel' "$base/home/.local/bin/pipeasio-settings/sentinel" \
+    || fail "panel repair warning corrupted a foreign directory"
+grep -qF 'Wine was installed, but the PipeASIO settings shortcut could not be updated.' \
+    "$base/err" || fail "postcommit panel repair failure was not a plain warning"
+ok "direct runtime panel repair is postcommit and warning-only"
+
+base="$(new_env optional-panel-payload-warning)"
+make_runtime_only_kit "$base"
+runtime_name=wine-d2d1-nspa-11.13
+version=2026.08.12.999
+rm -f -- "$base/payload/$runtime_name/share/icons/hicolor/scalable/apps/pipeasio.svg"
+tar -C "$base/payload" -I zstd -cf \
+    "$base/kit/dist/$runtime_name-$version.tar.zst" "$runtime_name"
+(
+    cd "$base/kit/dist"
+    sha256sum "$runtime_name-$version.tar.zst" > "$runtime_name-$version.tar.zst.sha256"
+)
+mkdir -p -- "$base/home/.local/bin"
+printf 'foreign panel command\n' > "$base/home/.local/bin/pipeasio-settings"
+run_isolated "$base" env \
+    PATH="$base/fakebin:$PATH" \
+    ABLETON_WINE_ROOT="$base/runtime" \
+    ABLETON_WINEPREFIX="$base/prefix" \
+    PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+    bash "$base/kit/scripts/install.sh" --runtime-only --yes \
+    >"$base/out" 2>"$base/err" \
+    || fail "incomplete optional panel payload invalidated a core runtime install"
+[ -f "$base/runtime/.ableton-linux-runtime" ] \
+    && [ -f "$base/runtime/lib/wine/x86_64-windows/pipeasio64.dll" ] \
+    && [ -f "$base/runtime/lib/wine/x86_64-unix/pipeasio64.dll.so" ] \
+    || fail "optional panel warning did not preserve the promoted core runtime and driver"
+grep -qxF 'foreign panel command' "$base/home/.local/bin/pipeasio-settings" \
+    || fail "invalid optional panel payload changed an existing panel command"
+grep -qF 'Wine and PipeASIO passed their checks, but PipeASIO Settings is incomplete.' \
+    "$base/err" || fail "invalid optional panel payload did not produce its plain warning"
+ok "invalid optional panel payload warns without invalidating Wine or changing panel shortcuts"
+
+base="$(new_env runtime-validator-command-failure)"
+make_runtime_only_kit "$base"
+cat > "$base/fakebin/readelf" <<'EOF'
+#!/bin/sh
+cat <<'OUT'
+  Shared library: [libusb-1.0.so.0]
+  Shared library: [libpipewire-0.3.so.0]
+  Shared library: [libgstreamer-1.0.so.0]
+OUT
+exit 93
+EOF
+chmod 755 "$base/fakebin/readelf"
+if run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
+    PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+    bash "$base/kit/scripts/install.sh" --runtime-only --yes \
+    >"$base/out" 2>"$base/err"; then
+    fail "runtime install ignored a failed payload validator"
+fi
+[ ! -e "$base/runtime" ] \
+    || fail "failed payload validation promoted a runtime"
+grep -qF 'runtime Push bridge dependency validation failed' "$base/err" \
+    || fail "failed payload validator was replaced by a later misleading error"
+ok "runtime payload validator failures stop before promotion with their original cause"
+
+base="$(new_env runtime-foreign-client-stop)"
+make_runtime_only_kit "$base"
+mkdir -p -- "$base/runtime/bin"
+cp -- /bin/sleep "$base/runtime/bin/wine-client"
+printf 'format=1\nname=wine-d2d1-nspa-11.13\n' > "$base/runtime/.ableton-linux-runtime"
+printf 'old runtime generation\n' > "$base/runtime/old-generation"
+env WINEPREFIX="$base/foreign-prefix" "$base/runtime/bin/wine-client" 60 &
+foreign_runtime_pid=$!
+sleep 0.1
+runtime_update_succeeded=0
+if run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
+    PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+    bash "$base/kit/scripts/install.sh" --runtime-only --yes \
+    >"$base/out" 2>"$base/err"; then
+    runtime_update_succeeded=1
+fi
+kill -0 "$foreign_runtime_pid" 2>/dev/null \
+    || fail "runtime refusal killed a foreign-prefix process"
+kill "$foreign_runtime_pid" 2>/dev/null || true
+wait "$foreign_runtime_pid" 2>/dev/null || true
+[ "$runtime_update_succeeded" -eq 0 ] \
+    || fail "runtime promotion continued after refusing a foreign-prefix client"
+[ -f "$base/runtime/old-generation" ] \
+    || fail "foreign-prefix refusal replaced the live runtime anyway"
+grep -qF 'runtime is used by another Wine prefix' "$base/err" \
+    || fail "foreign-prefix runtime refusal lost its original cause"
+ok "runtime-client refusal cannot be ignored by a later promotion"
+
+base="$(new_env runtime-scratch-cleanup-warning)"
+make_runtime_only_kit "$base"
+real_rm="$(command -v rm)"
+cat > "$base/fakebin/rm" <<EOF
+#!/bin/sh
+for argument do
+    case "\$argument" in */.ableton-runtime-stage.*) exit 94 ;; esac
+done
+exec "$real_rm" "\$@"
+EOF
+chmod 755 "$base/fakebin/rm"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
+    PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+    bash "$base/kit/scripts/install.sh" --runtime-only --yes \
+    >"$base/out" 2>"$base/err" \
+    || fail "runtime scratch cleanup failure rolled back a valid installation"
+[ -f "$base/runtime/.ableton-linux-runtime" ] \
+    || fail "scratch cleanup warning displaced the promoted runtime"
+grep -qF 'Wine was installed, but temporary files remain at' "$base/err" \
+    || fail "retained runtime scratch was not reported"
+find "$base" -mindepth 1 -maxdepth 1 -type d -name '.ableton-runtime-stage.*' \
+    -print -quit | grep -q . \
+    || fail "runtime scratch failure fixture did not retain its target"
+ok "post-success scratch cleanup cannot manufacture an installation rollback"
 
 prepare_runtime_metadata_fixture()
 {
@@ -480,6 +837,456 @@ EOF
         > "$base/xdg/config/pipeasio/config.ini"
 }
 
+prepare_mixed_component_kit()
+{
+    local base="$1" repo_root
+    repo_root="$(cd "$here/.." && pwd)"
+    cp -- "$here/ableton-live" "$here/max9" "$here/detect-scale.sh" \
+        "$here/detect-theme.sh" "$here/shortcut-hold.sh" \
+        "$here/setup-realtime.sh" "$here/audio-report.sh" \
+        "$here/check-ntsync.sh" "$here/rollback.sh" "$base/kit/scripts/"
+    mkdir -p -- "$base/kit/desktop/icons" \
+        "$base/kit/beta/tester-kit/probes/windows"
+    cp -- "$repo_root/desktop/ableton-live.desktop.in" \
+        "$repo_root/desktop/ableton-linux-protocol.desktop.in" \
+        "$repo_root/desktop/ableton-linux-auz.desktop.in" \
+        "$repo_root/desktop/x-wine-extension-auz.xml" \
+        "$repo_root/desktop/max9.desktop.in" \
+        "$repo_root/desktop/wine-protocol-c74max.desktop.in" \
+        "$base/kit/desktop/"
+    cp -- "$repo_root/desktop/icons/application-ableton-live.xml" \
+        "$base/kit/desktop/icons/"
+    cp -- "$repo_root/beta/tester-kit/probes/windows/ntsyncprobe.exe" \
+        "$base/kit/beta/tester-kit/probes/windows/"
+}
+
+# Exercise the EXIT trap itself by injecting an otherwise unhandled command
+# failure immediately after the direct runtime's private transaction has been
+# retired. The promoted tree is authoritative and no active recovery marker may
+# remain for a launcher to mistake for an incomplete core install.
+base="$(new_env direct-runtime-core-ready-exit)"
+prepare_runtime_metadata_fixture "$base"
+sed -i "/        finish_direct_runtime_transaction/a\\
+        : > \"$base/core-tail-failure-fired\"\\
+        false # injected verified-core tail failure" "$base/kit/scripts/install.sh"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
+    PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+    bash "$base/kit/scripts/install.sh" --runtime-only --yes \
+    >"$base/out" 2>"$base/err" \
+    || fail "verified-core EXIT catch-all reported the promoted runtime as failed"
+[ -e "$base/core-tail-failure-fired" ] \
+    || fail "verified-core EXIT fixture did not reach the injected tail failure"
+[ -f "$base/runtime/.ableton-linux-runtime" ] \
+    && [ ! -e "$base/runtime/.ableton-linux-rollback/old-sentinel" ] \
+    || fail "verified-core EXIT catch-all restored the previous runtime"
+catchall_saved=""
+for candidate in "$base"/runtime-rollback-*; do
+    [ -d "$candidate" ] || continue
+    catchall_saved="$candidate"
+    break
+done
+[ -n "$catchall_saved" ] \
+    && grep -qxF 'old metadata generation' \
+        "$catchall_saved/.ableton-linux-rollback/old-sentinel" \
+    || fail "verified-core EXIT catch-all lost the saved previous runtime"
+if find "$base/tmp" "$base/xdg/state/ableton-wine/transactions" \
+    -type f -name active -print -quit 2>/dev/null | grep -q .; then
+    fail "verified-core EXIT catch-all left a launcher-blocking active transaction"
+fi
+grep -qF 'Wine is ready. Run the installer again to retry shortcuts or Ableton Link files.' \
+    "$base/err" || fail "verified-core EXIT catch-all did not report optional retry"
+grep -qxF 'OK: Installation complete.' "$base/out" \
+    || fail "verified-core EXIT catch-all omitted the direct success outcome"
+ok "the EXIT catch-all cannot fail or roll back a finally validated runtime"
+
+# A direct mixed invocation must close its runtime transaction before generated
+# desktop work starts. Inject a failure in the first optional file publication:
+# Wine stays live, the previous generation stays available for rollback, and no
+# active core marker is left for launchers to reject.
+base="$(new_env direct-mixed-optional-failure)"
+prepare_runtime_metadata_fixture "$base"
+prepare_mixed_component_kit "$base"
+foreign_optional="$base/xdg/data/ableton-wine/lib/config.sh"
+mkdir -p -- "$(dirname "$foreign_optional")"
+printf 'foreign optional config helper\n' > "$foreign_optional"
+cp -a -- "$foreign_optional" "$base/foreign-optional.before"
+real_install="$(command -v install)"
+cat > "$base/fakebin/install" <<EOF
+#!/bin/sh
+for argument do
+    case "\$argument" in
+        */.ableton-install.*)
+            if [ -f "$base/runtime/.ableton-linux-runtime" ] \
+               && [ ! -e "$base/mixed-optional-failure-fired" ]; then
+                : > "$base/mixed-optional-failure-fired"
+                exit 74
+            fi ;;
+    esac
+done
+exec "$real_install" "\$@"
+EOF
+chmod 755 "$base/fakebin/install"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
+    PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+    bash "$base/kit/scripts/install.sh" --runtime-only --integration-only --yes \
+    >"$base/out" 2>"$base/err" \
+    || fail "optional mixed-mode failure invalidated a committed runtime"
+[ -e "$base/mixed-optional-failure-fired" ] \
+    || fail "mixed-mode fixture did not reach optional file publication"
+cmp -s -- "$base/foreign-optional.before" "$foreign_optional" \
+    || fail "failed optional publication changed the existing support file"
+cmp -s -- "$base/kit/scripts/lib/lifecycle.sh" \
+    "$base/xdg/data/ableton-wine/lib/lifecycle.sh" \
+    || fail "one failed support file blocked a later independent repair"
+prestate_index="$base/xdg/state/ableton-wine/install-prestate.tsv"
+prestate_dir="$base/xdg/state/ableton-wine/install-prestate"
+[ ! -e "$prestate_index" ] && [ ! -L "$prestate_index" ] \
+    || fail "mixed-mode optional rollback left an unindexed prestate inventory"
+if [ -d "$prestate_dir" ] \
+   && find "$prestate_dir" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+    fail "mixed-mode optional rollback stranded a saved foreign object"
+fi
+[ -f "$base/runtime/.ableton-linux-runtime" ] \
+    && [ ! -e "$base/runtime/.ableton-linux-rollback/old-sentinel" ] \
+    || fail "mixed-mode optional failure restored the previous runtime"
+mixed_saved=""
+for candidate in "$base"/runtime-rollback-*; do
+    [ -d "$candidate" ] || continue
+    mixed_saved="$candidate"
+    break
+done
+[ -n "$mixed_saved" ] \
+    && grep -qxF 'old metadata generation' \
+        "$mixed_saved/.ableton-linux-rollback/old-sentinel" \
+    || fail "mixed-mode optional failure lost the saved previous runtime"
+if find "$base/tmp" "$base/xdg/state/ableton-wine/transactions" \
+    -type f -name active -print -quit 2>/dev/null | grep -q .; then
+    fail "mixed-mode optional failure left an active core transaction"
+fi
+run_isolated "$base" env \
+    ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
+    bash -c '
+        set -euo pipefail
+        . "$1/lib/config.sh"
+        ableton_config_init
+        . "$1/lib/manifest.sh"
+        ! ableton_install_state_has_active_transaction
+    ' _ "$here" || fail "mixed-mode optional failure left the launcher recovery gate closed"
+[ "$(grep -cF 'Some shortcuts or support files could not be updated. Run the installer again to retry them.' \
+        "$base/err")" -eq 1 ] \
+    || fail "mixed-mode optional failure did not produce one plain retry warning"
+grep -qxF 'OK: Installation complete.' "$base/out" \
+    || fail "mixed-mode optional failure omitted the direct success outcome"
+ok "direct mixed mode commits Wine before warning-only generated-file work"
+
+# The public wrapper needs an internal advisory result so its final summary can
+# say that desktop repair needs a retry without treating the installed core as
+# failed. Direct component use above still exits successfully.
+rm -f -- "$base/mixed-optional-failure-fired"
+advisory_status=0
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
+    ABLETON_INTERNAL_OPTIONAL_STATUS=1 \
+    bash "$base/kit/scripts/install.sh" --integration-only \
+    >"$base/advisory.out" 2>"$base/advisory.err" \
+    || advisory_status=$?
+[ "$advisory_status" -eq 3 ] \
+    || fail "internal desktop repair result did not distinguish a retry warning"
+[ -e "$base/mixed-optional-failure-fired" ] \
+    || fail "internal desktop repair fixture did not reach its injected warning"
+! grep -qF 'OK: Installation complete.' "$base/advisory.out" \
+    || fail "internal retry result also printed a complete result"
+ok "desktop repair warnings have an internal advisory result for the final summary"
+
+# Each completed generated-file repair is final. Break stderr and fail after
+# the first repair; later failure handling must leave that valid repair in
+# place and must not strand obsolete recovery data.
+base="$(new_env component-recovery-broken-stderr)"
+make_runtime_only_kit "$base"
+prepare_mixed_component_kit "$base"
+make_runtime "$base/runtime" "$base/BUILD-INFO.txt" built
+foreign_optional="$base/xdg/data/ableton-wine/lib/config.sh"
+mkdir -p -- "$(dirname "$foreign_optional")"
+printf 'foreign helper before failed component\n' > "$foreign_optional"
+cp -a -- "$foreign_optional" "$base/foreign-helper.before"
+sed -i '/ableton_try_publish_file 644 "$here\/lib\/$tool" "$data\/lib\/$tool" file replace-generated/a\
+        if [ "$tool" = config.sh ]; then exec 2>/dev/full; false; fi' \
+    "$base/kit/scripts/install.sh"
+if run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
+    bash "$base/kit/scripts/install.sh" --integration-only \
+    >"$base/out" 2>"$base/err"; then
+    fail "injected component failure unexpectedly reported success"
+fi
+cmp -s -- "$base/kit/scripts/lib/config.sh" "$foreign_optional" \
+    || fail "a later optional failure undid an earlier generated-file repair"
+prestate_index="$base/xdg/state/ableton-wine/install-prestate.tsv"
+prestate_dir="$base/xdg/state/ableton-wine/install-prestate"
+[ ! -e "$prestate_index" ] && [ ! -L "$prestate_index" ] \
+    || fail "broken recovery diagnostics left a prestate index behind"
+if [ -d "$prestate_dir" ] \
+   && find "$prestate_dir" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+    fail "broken recovery diagnostics left an unindexed foreign backup"
+fi
+if find "$base/tmp" -type f -name active -print -quit 2>/dev/null | grep -q .; then
+    fail "broken component diagnostics left its private transaction active"
+fi
+ok "later optional failures retain earlier generated-file repairs even when stderr is broken"
+
+# The coordinator has the same requirement across its runtime and prefix
+# domains. Its first rollback message is deliberately sent to /dev/full; both
+# child restorations must still run before the trap returns the original error.
+base="$(new_env coordinator-recovery-broken-stderr)"
+mkdir -p -- "$base/kit/scripts/lib" "$base/kit/bin"
+cp -- "$here/installer.sh" "$base/kit/scripts/"
+cp -- "$here/lib/config.sh" "$here/lib/lifecycle.sh" \
+    "$here/lib/live-options.sh" "$here/lib/manifest.sh" \
+    "$here/lib/pipeasio.sh" "$base/kit/scripts/lib/"
+cp -- "$here/../VERSION" "$base/kit/VERSION"
+cat > "$base/kit/bin/pipewire-version-probe" <<'EOF'
+#!/bin/sh
+printf 'client=1.6.8\ndaemon=1.6.8\n'
+EOF
+cat > "$base/kit/scripts/install.sh" <<'EOF'
+#!/bin/sh
+set -eu
+case " $* " in
+    *' --preflight-rollback '*) exit 0 ;;
+    *' --rollback '*)
+        printf 'old runtime state\n' > "${TEST_RUNTIME_STATE:?}"
+        : > "${TEST_RUNTIME_ROLLBACK_CALLED:?}"
+        exit 0 ;;
+    *' --preflight-commit '*|*' --commit '*) exit 0 ;;
+esac
+txn=""
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = --transaction-dir ]; then txn="$2"; shift; fi
+    shift
+done
+[ -z "$txn" ] || : > "$txn/active"
+printf 'new runtime state\n' > "${TEST_RUNTIME_STATE:?}"
+EOF
+cat > "$base/kit/scripts/setup-prefix.sh" <<'EOF'
+#!/bin/sh
+set -eu
+case " $* " in
+    *' --validate '*) exit 0 ;;
+    *' --preflight-rollback '*) exit 0 ;;
+    *' --rollback '*)
+        printf 'old prefix state\n' > "${TEST_PREFIX_STATE:?}"
+        : > "${TEST_PREFIX_ROLLBACK_CALLED:?}"
+        exit 0 ;;
+    *' --preflight-commit '*|*' --commit '*) exit 0 ;;
+esac
+printf 'new prefix state\n' > "${TEST_PREFIX_STATE:?}"
+exit 71
+EOF
+chmod 755 "$base/kit/bin/pipewire-version-probe" \
+    "$base/kit/scripts/install.sh" "$base/kit/scripts/setup-prefix.sh"
+printf 'old runtime state\n' > "$base/runtime.state"
+printf 'old prefix state\n' > "$base/prefix.state"
+if run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    TEST_RUNTIME_STATE="$base/runtime.state" \
+    TEST_PREFIX_STATE="$base/prefix.state" \
+    TEST_RUNTIME_ROLLBACK_CALLED="$base/runtime.rollback-called" \
+    TEST_PREFIX_ROLLBACK_CALLED="$base/prefix.rollback-called" \
+    bash "$base/kit/scripts/installer.sh" install --skip-live-install --yes \
+        --link=off --runtime-root "$base/runtime" --prefix "$base/prefix" \
+        >"$base/out" 2>/dev/full; then
+    fail "coordinator failure fixture unexpectedly reported success"
+fi
+grep -qxF 'old runtime state' "$base/runtime.state" \
+    && grep -qxF 'old prefix state' "$base/prefix.state" \
+    && [ -e "$base/runtime.rollback-called" ] \
+    && [ -e "$base/prefix.rollback-called" ] \
+    || fail "broken coordinator diagnostics skipped runtime or prefix restoration"
+ok "coordinator recovery restores every core domain even when stderr is broken"
+
+# Once the Live executable has been found in the selected prefix, every
+# terminal message, helper-stop narrative, and timeout explanation is
+# presentation only. Break both output streams at that exact boundary and make
+# wineserver report a timeout: the coordinator must still commit both core
+# domains and must never call either rollback child.
+base="$(new_env live-valid-postcore-broken-output)"
+mkdir -p -- "$base/kit/scripts/lib" "$base/kit/bin" "$base/runtime/bin"
+cp -- "$here/installer.sh" "$base/kit/scripts/"
+cp -- "$here/lib/config.sh" "$here/lib/lifecycle.sh" \
+    "$here/lib/live-options.sh" "$here/lib/manifest.sh" \
+    "$here/lib/pipeasio.sh" "$base/kit/scripts/lib/"
+cp -- "$here/../VERSION" "$base/kit/VERSION"
+cat > "$base/kit/bin/pipewire-version-probe" <<'EOF'
+#!/bin/sh
+printf 'client=1.6.8\ndaemon=1.6.8\n'
+EOF
+cat > "$base/kit/scripts/install.sh" <<'EOF'
+#!/bin/sh
+set -eu
+case " $* " in
+    *' --preflight-rollback '*) exit 0 ;;
+    *' --rollback '*) : > "${TEST_RUNTIME_ROLLBACK_CALLED:?}"; exit 0 ;;
+    *' --preflight-commit '*) exit 0 ;;
+    *' --commit '*) : > "${TEST_RUNTIME_COMMIT_CALLED:?}"; exit 0 ;;
+esac
+txn=""
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = --transaction-dir ]; then txn="$2"; shift; fi
+    shift
+done
+[ -z "$txn" ] || : > "$txn/active"
+exit 0
+EOF
+cat > "$base/kit/scripts/setup-prefix.sh" <<'EOF'
+#!/bin/sh
+set -eu
+case " $* " in
+    *' --validate '*) exit 0 ;;
+    *' --preflight-rollback '*) exit 0 ;;
+    *' --rollback '*) : > "${TEST_PREFIX_ROLLBACK_CALLED:?}"; exit 0 ;;
+    *' --preflight-commit '*) exit 0 ;;
+    *' --commit '*) : > "${TEST_PREFIX_COMMIT_CALLED:?}"; exit 0 ;;
+esac
+mkdir -p -- "${ABLETON_WINEPREFIX:?}"
+: > "$ABLETON_WINEPREFIX/system.reg"
+exit 0
+EOF
+cat > "$base/kit/scripts/setup-link.sh" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+cat > "$base/runtime/bin/wine" <<'EOF'
+#!/bin/sh
+case " $* " in
+    *' ./Ableton Live 12 Installer.exe '*)
+        target="${WINEPREFIX:?}/drive_c/ProgramData/Ableton/Live 12 Suite/Program/Ableton Live 12 Suite.exe"
+        mkdir -p -- "$(dirname "$target")"
+        printf 'installed Live fixture\n' > "$target" ;;
+esac
+exit 0
+EOF
+cat > "$base/runtime/bin/wineserver" <<'EOF'
+#!/bin/sh
+[ "${1:-}" != -w ] || exit 124
+exit 0
+EOF
+chmod 755 "$base/kit/bin/pipewire-version-probe" \
+    "$base/kit/scripts/install.sh" "$base/kit/scripts/setup-prefix.sh" \
+    "$base/kit/scripts/setup-link.sh" "$base/runtime/bin/wine" \
+    "$base/runtime/bin/wineserver"
+printf 'Inno Setup fixture\n' > "$base/Ableton Live 12 Installer.exe"
+sed -i '/live_install_result_valid "$ABLETON_LIVE_VERSION" || return 1/a\
+    exec 1>/dev/full 2>/dev/full # injected post-Live output failure' \
+    "$base/kit/scripts/installer.sh"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    TEST_RUNTIME_ROLLBACK_CALLED="$base/runtime.rollback-called" \
+    TEST_PREFIX_ROLLBACK_CALLED="$base/prefix.rollback-called" \
+    TEST_RUNTIME_COMMIT_CALLED="$base/runtime.commit-called" \
+    TEST_PREFIX_COMMIT_CALLED="$base/prefix.commit-called" \
+    bash "$base/kit/scripts/installer.sh" install --yes --link=off \
+        --live-installer "$base/Ableton Live 12 Installer.exe" \
+        --runtime-root "$base/runtime" --prefix "$base/prefix" \
+        >"$base/out" 2>"$base/err" \
+    || fail "closed post-Live output reported a valid core installation as failed"
+[ -f "$base/prefix/drive_c/ProgramData/Ableton/Live 12 Suite/Program/Ableton Live 12 Suite.exe" ] \
+    || fail "post-Live output fixture did not cross the Live executable postcondition"
+[ -e "$base/runtime.commit-called" ] && [ -e "$base/prefix.commit-called" ] \
+    || fail "closed post-Live output stopped a core commit"
+[ ! -e "$base/runtime.rollback-called" ] && [ ! -e "$base/prefix.rollback-called" ] \
+    || fail "closed post-Live output invoked core rollback"
+if find "$base/xdg/state/ableton-wine/transactions" -type f -name active \
+    -print -quit 2>/dev/null | grep -q .; then
+    fail "closed post-Live output left a launcher-blocking core transaction"
+fi
+ok "valid Live and registry state commit even when every later output fails"
+
+# Direct runtime installation is complete once the promoted tree passes its
+# final validation. Failure to publish the old tree under a public rollback
+# name may retain that private generation, but must not restore it over Wine.
+base="$(new_env direct-runtime-rollback-publication-warning)"
+prepare_runtime_metadata_fixture "$base"
+real_mv="$(command -v mv)"
+cat > "$base/fakebin/mv" <<EOF
+#!/bin/sh
+last=""
+for argument do last="\$argument"; done
+case "\$last" in
+    */runtime-rollback-path)
+        : > "$base/rollback-publication-failed"
+        exit 95
+        ;;
+esac
+exec "$real_mv" "\$@"
+EOF
+chmod 755 "$base/fakebin/mv"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
+    PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+    bash "$base/kit/scripts/install.sh" --runtime-only --yes \
+    >"$base/out" 2>"$base/err" \
+    || fail "rollback-name publication failure invalidated a verified runtime"
+[ -e "$base/rollback-publication-failed" ] \
+    || fail "rollback-name publication failure fixture did not reach its boundary"
+[ -f "$base/runtime/.ableton-linux-runtime" ] \
+    && [ ! -e "$base/runtime/.ableton-linux-rollback/old-sentinel" ] \
+    || fail "rollback-name publication warning restored the previous runtime"
+private_saved=""
+for candidate in "$base"/runtime.transaction-*; do
+    [ -d "$candidate" ] || continue
+    private_saved="$candidate"
+    break
+done
+[ -n "$private_saved" ] \
+    && grep -qxF 'old metadata generation' \
+        "$private_saved/.ableton-linux-rollback/old-sentinel" \
+    || fail "rollback-name publication warning lost the private previous runtime"
+if find "$base" -mindepth 1 -maxdepth 1 -type d -name 'runtime-rollback-*' \
+    -print -quit | grep -q .; then
+    fail "failed rollback-name publication exposed a partial public candidate"
+fi
+grep -qF 'Wine is ready, but the installer may not be able to restore the previous Wine version automatically. Temporary recovery files may remain.' \
+    "$base/err" || fail "rollback-name publication failure was not a plain warning"
+grep -qxF 'OK: Installation complete.' "$base/out" \
+    || fail "runtime with a rollback-name warning omitted its simple outcome"
+ok "direct runtime rollback publication is warning-only after final validation"
+
+runtime_cleanup_real_rm="$(command -v rm)"
+for cleanup_failure in active directory; do
+    base="$(new_env "direct-runtime-cleanup-$cleanup_failure")"
+    make_runtime_only_kit "$base"
+    cat > "$base/fakebin/rm" <<EOF
+#!/bin/sh
+for argument do
+    case "\${ABLETON_TEST_CLEANUP_FAILURE:-}:\$argument" in
+        active:*/tmp/ableton-install-plan.*/active) exit 96 ;;
+        directory:*/tmp/ableton-install-plan.*) exit 97 ;;
+    esac
+done
+exec "$runtime_cleanup_real_rm" "\$@"
+EOF
+    chmod 755 "$base/fakebin/rm"
+    run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+        ABLETON_TEST_CLEANUP_FAILURE="$cleanup_failure" \
+        ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
+        PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+        bash "$base/kit/scripts/install.sh" --runtime-only --yes \
+        >"$base/out" 2>"$base/err" \
+        || fail "$cleanup_failure cleanup failure invalidated a verified runtime"
+    [ -f "$base/runtime/.ableton-linux-runtime" ] \
+        || fail "$cleanup_failure cleanup warning removed the promoted runtime"
+    case "$cleanup_failure" in
+        active)
+            grep -qF 'Wine is ready, but the installer may not be able to restore the previous Wine version automatically. Temporary recovery files may remain.' \
+                "$base/err" || fail "runtime active cleanup failure was not a plain warning" ;;
+        directory)
+            grep -qF 'Wine is ready, but temporary installer data remains at ' \
+                "$base/err" || fail "runtime directory cleanup failure was not a plain warning" ;;
+    esac
+    grep -qxF 'OK: Installation complete.' "$base/out" \
+        || fail "runtime $cleanup_failure cleanup warning omitted the simple outcome"
+done
+ok "direct runtime activity/directory cleanup is warning-only after final validation"
+
 run_runtime_installer_fixture()
 {
     local base="$1"
@@ -510,7 +1317,7 @@ if ! run_runtime_installer_fixture "$base" >"$base/out" 2>"$base/err"; then
     sed -n '1,120p' "$base/err" >&2
     fail "runtime update failed while replacing rollback metadata"
 fi
-[ "$(grep -c '^== validate runtime payload:' "$base/out")" -eq 1 ] \
+[ "$(grep -c '^== Check the Wine package:' "$base/out")" -eq 1 ] \
     || fail "runtime install validates and extracts its payload more than once"
 saved_runtime="$(find_saved_runtime "$base")" \
     || fail "runtime update did not retain a saved runtime"
@@ -548,11 +1355,15 @@ esac
 exec "$real_cp" "\$@"
 EOF
 chmod 755 "$base/fakebin/cp"
-if run_runtime_installer_fixture "$base" >"$base/out" 2>"$base/err"; then
-    fail "injected rollback snapshot-copy failure reported success"
-fi
+run_runtime_installer_fixture "$base" >"$base/out" 2>"$base/err" \
+    || fail "optional rollback snapshot-copy failure invalidated the installed runtime"
+[ -f "$base/runtime/.ableton-linux-runtime" ] \
+    && [ ! -e "$base/runtime/.ableton-linux-rollback/old-sentinel" ] \
+    || fail "rollback snapshot-copy warning restored the previous runtime"
+grep -qF 'The install is ready, but old recovery files could not be removed.' "$base/err" \
+    || fail "rollback snapshot-copy failure was not reported as a cleanup warning"
 saved_runtime="$(find_saved_runtime "$base")" \
-    || fail "committed runtime update lost its saved runtime after metadata failure"
+    || fail "runtime update lost its saved runtime after optional metadata failure"
 saved_meta="$saved_runtime/.ableton-linux-rollback"
 [ -e "$saved_runtime/.ableton-linux-rollback-incomplete" ] \
     || fail "metadata copy failure published a rollback candidate as complete"
@@ -573,9 +1384,9 @@ if run_isolated "$base" env \
     bash "$here/rollback.sh" >"$base/rollback.out" 2>"$base/rollback.err"; then
     fail "rollback selected a candidate with incomplete metadata"
 fi
-grep -qF 'no completed runtime rollback is available' "$base/rollback.err" \
+grep -qF 'There is no previous Wine version to restore.' "$base/rollback.err" \
     || fail "incomplete metadata candidate refusal was not explicit"
-ok "snapshot-copy failure preserves old metadata and leaves an unselectable incomplete candidate"
+ok "snapshot-copy warning keeps the new runtime and leaves the old candidate safely unselectable"
 
 base="$(new_env rollback-marker-permission-failure)"
 prepare_runtime_metadata_fixture "$base"
@@ -621,6 +1432,12 @@ install_fake_host_tools()
     mkdir -p -- "$base/fakebin"
     cat > "$base/fakebin/systemctl" <<'EOF'
 #!/bin/sh
+# Most fixtures need a reachable user manager but do not create a Link service.
+# Mutating and reload commands succeed; status checks accurately report that
+# the service is neither enabled nor active.
+case " $* " in
+    *' is-enabled '*|*' is-active '*) exit 1 ;;
+esac
 exit 0
 EOF
     cat > "$base/fakebin/xdg-mime" <<'EOF'
@@ -688,6 +1505,46 @@ manifest_has_path()
     awk -F '\t' -v wanted="$wanted" '$2 == wanted { found=1 } END { exit !found }' "$manifest"
 }
 
+# A top-level coordinator owns an explicitly supplied transaction directory.
+# Component success, commit, and rollback may finish their own domain, but may
+# not make unfinished sibling domains look inactive. A standalone invocation,
+# on the other hand, must retire the transaction it created for itself.
+base="$(new_env component-outer-active-owner)"
+install_fake_host_tools "$base"
+make_runtime "$base/runtime" "$base/BUILD-INFO.txt" built
+printf 'format=1\nname=wine-d2d1-nspa-11.13\n' > "$base/runtime/.ableton-linux-runtime"
+outer="$base/coordinator-transaction"
+mkdir -p -- "$outer"
+run_component_install "$base" "$base/runtime" --integration-only \
+    --transaction-dir "$outer" >"$base/install.out" 2>"$base/install.err" \
+    || fail "external component transaction could not complete"
+[ -f "$outer/active" ] && [ ! -L "$outer/active" ] \
+    || fail "external component completion retired the coordinator active marker"
+run_component_install "$base" "$base/runtime" --commit "$outer" \
+    >"$base/commit.out" 2>"$base/commit.err" \
+    || fail "external component transaction could not commit"
+[ -f "$outer/active" ] && [ ! -L "$outer/active" ] \
+    || fail "component --commit retired the coordinator active marker"
+run_component_install "$base" "$base/runtime" --rollback "$outer" \
+    >"$base/rollback.out" 2>"$base/rollback.err" \
+    || fail "external component transaction could not roll back"
+[ -f "$outer/active" ] && [ ! -L "$outer/active" ] \
+    || fail "component --rollback retired the coordinator active marker"
+
+base="$(new_env component-own-active-owner)"
+install_fake_host_tools "$base"
+make_runtime "$base/runtime" "$base/BUILD-INFO.txt" built
+printf 'format=1\nname=wine-d2d1-nspa-11.13\n' > "$base/runtime/.ableton-linux-runtime"
+run_component_install "$base" "$base/runtime" --integration-only \
+    >"$base/install.out" 2>"$base/install.err" \
+    || fail "standalone component transaction could not complete"
+transactions="$base/xdg/state/ableton-wine/transactions"
+if [ -d "$transactions" ] \
+   && find "$transactions" -mindepth 1 -print -quit | grep -q .; then
+    fail "standalone component completion retained its own transaction or active marker"
+fi
+ok "only the coordinator retires external active markers; standalone components retire their own transaction"
+
 base="$(new_env panel-lifecycle)"
 install_fake_host_tools "$base"
 make_runtime "$base/runtime" "$base/BUILD-INFO.txt" built
@@ -741,12 +1598,8 @@ run_component_install "$base" "$base/runtime" --integration-only \
     || fail "integration left drift in the panel desktop entry"
 grep -qF '# local panel launcher drift' "${panel_desktop}.bak" \
     || fail "panel desktop backup does not contain the displaced entry"
-grep -qF "The installer replaced a launcher because its saved checksum differed: $panel_command" \
-    "$base/install-drift.out" \
-    || fail "panel command replacement was not reported"
-grep -qF "The installer replaced a launcher because its saved checksum differed: $panel_desktop" \
-    "$base/install-drift.out" \
-    || fail "panel desktop replacement was not reported"
+! grep -qF 'saved checksum differed' "$base/install-drift.out" \
+    || fail "ordinary panel repair printed internal checksum details"
 for launcher in "$panel_command" "$panel_desktop"; do
     recorded="$(awk -F '\t' -v wanted="$launcher" '$2 == wanted { print $3; exit }' "$manifest")"
     current="$(
@@ -769,7 +1622,7 @@ grep -qF "Audio report: $base/xdg/data/ableton-wine/audio-report.sh" "$base/inst
     || fail "install did not print the durable audio-report path"
 grep -qF "Realtime setup: $base/xdg/data/ableton-wine/setup-realtime.sh" "$base/install-built.out" \
     || fail "install did not print the durable realtime-setup path"
-grep -qF "Runtime rollback: $base/xdg/data/ableton-wine/rollback.sh" "$base/install-built.out" \
+grep -qF "Restore previous Wine version: $base/xdg/data/ableton-wine/rollback.sh" "$base/install-built.out" \
     || fail "install did not print the durable rollback path"
 ok "integration persists and reports durable diagnostic and recovery tools"
 
@@ -811,9 +1664,12 @@ mkdir -p -- "$txn"
 run_component_install "$base" "$base/runtime" --integration-only --transaction-dir "$txn" \
     >"$base/install-skipped-txn.out" 2>"$base/install-skipped-txn.err" \
     || { sed -n '1,120p' "$base/install-skipped-txn.err" >&2; fail "built-to-skipped transactional transition failed"; }
-[ ! -e "$panel_command" ] && [ ! -L "$panel_command" ] \
-    && [ ! -e "$panel_desktop" ] && [ ! -e "$panel_icon" ] \
-    || fail "skipped panel left managed host artifacts"
+[ -L "$panel_command" ] && [ "$(readlink -- "$panel_command")" = "$user_panel_target" ] \
+    && grep -qF '# local panel launcher drift' "$panel_desktop" \
+    && [ ! -e "${panel_command}.bak" ] && [ ! -L "${panel_command}.bak" ] \
+    && [ ! -e "${panel_desktop}.bak" ] && [ ! -L "${panel_desktop}.bak" ] \
+    && [ ! -e "$panel_icon" ] \
+    || fail "skipped panel did not restore and consume displaced foreign launchers"
 ! manifest_has_path "$manifest" "$panel_command" || fail "skipped panel retained command ownership"
 
 # Put the runtime payload back before restoring its host projections. Runtime
@@ -822,22 +1678,29 @@ write_build_info "$base/runtime" "$base/BUILD-INFO.txt" built
 run_component_install "$base" "$base/runtime" --rollback "$txn" \
     >"$base/rollback.out" 2>"$base/rollback.err" \
     || fail "panel integration rollback failed"
-[ -L "$panel_command" ] && [ -f "$panel_desktop" ] && [ -f "$panel_icon" ] \
+[ -L "$panel_command" ] && [ "$(readlink -- "$panel_command")" = "$base/runtime/bin/pipeasio-settings" ] \
+    && [ -f "$panel_desktop" ] && [ -f "$panel_icon" ] \
+    && [ -L "${panel_command}.bak" ] \
+    && [ "$(readlink -- "${panel_command}.bak")" = "$user_panel_target" ] \
+    && grep -qF '# local panel launcher drift' "${panel_desktop}.bak" \
     || fail "rollback did not restore panel host projections"
-manifest_has_path "$manifest" "$panel_command" || fail "rollback did not restore panel ownership"
-ok "panel transition participates in component rollback lifecycle"
+! manifest_has_path "$manifest" "$panel_command" \
+    || fail "component rollback rewound disposable installed-file inventory"
+ok "panel files participate in component rollback without rewinding uninstall inventory"
 
 write_build_info "$base/runtime" "$base/BUILD-INFO.txt" skipped
 run_component_install "$base" "$base/runtime" --integration-only \
     >"$base/install-skipped.out" 2>"$base/install-skipped.err" \
     || fail "committed built-to-skipped transition failed"
 [ ! -e "$panel_command" ] && [ ! -L "$panel_command" ] \
-    && [ ! -e "$panel_desktop" ] && [ ! -e "$panel_icon" ] \
-    || fail "committed skipped panel left managed artifacts"
+    && [ ! -e "$panel_desktop" ] && [ -f "$panel_icon" ] \
+    || fail "committed skipped panel did not remove recognised launchers and preserve its unverified icon"
+grep -qF "preserved your existing $panel_icon" "$base/install-skipped.out" \
+    || fail "unverified panel icon preservation was not reported"
 ! manifest_has_path "$manifest" "$panel_command" || fail "built-to-skipped transition left stale command ownership"
 ! manifest_has_path "$manifest" "$panel_desktop" || fail "built-to-skipped transition left stale desktop ownership"
 ! manifest_has_path "$manifest" "$panel_icon" || fail "built-to-skipped transition left stale icon ownership"
-ok "built-to-skipped transition removes and de-owns all panel projections"
+ok "built-to-skipped transition removes recognised launchers and preserves an unverified icon"
 
 base="$(new_env panel-desktop-escaping)"
 install_fake_host_tools "$base"
@@ -1058,9 +1921,12 @@ foreign_manifest="$base/xdg/state/ableton-wine/install-manifest.tsv"
 manifest_has_path "$foreign_manifest" "$base/home/.local/bin/pipeasio-settings" \
     || fail "installed pipeasio-settings command was not claimed in the manifest"
 foreign_id="$(printf '%s' "$base/home/.local/bin/pipeasio-settings" | sha256sum | awk '{print $1}')"
-grep -qxF 'echo foreign-settings-command' \
-    "$base/xdg/state/ableton-wine/install-prestate/$foreign_id" \
-    || fail "foreign panel command was not retained as uninstall prestate"
+[ ! -e "$base/xdg/state/ableton-wine/install-prestate/$foreign_id" ] \
+    && { [ ! -r "$base/xdg/state/ableton-wine/install-prestate.tsv" ] \
+         || ! awk -F '\t' -v p="$base/home/.local/bin/pipeasio-settings" \
+                '$2==p { found=1 } END { exit !found }' \
+                "$base/xdg/state/ableton-wine/install-prestate.tsv"; } \
+    || fail "fresh panel repair duplicated its adjacent backup in legacy prestate"
 write_build_info "$base/runtime" "$base/BUILD-INFO.txt" skipped
 run_component_install "$base" "$base/runtime" --integration-only \
     >"$base/skipped.out" 2>"$base/skipped.err" \
@@ -1070,7 +1936,103 @@ run_component_install "$base" "$base/runtime" --integration-only \
     || fail "skipped-panel transition did not restore the displaced command"
 ! manifest_has_path "$foreign_manifest" "$base/home/.local/bin/pipeasio-settings" \
     || fail "restored panel command remained claimed in the manifest"
-ok "foreign pipeasio-settings command is backed up, replaced, and restored"
+! manifest_has_path "$foreign_manifest" "$base/home/.local/bin/pipeasio-settings.bak" \
+    || fail "consumed adjacent panel backup remained claimed in the manifest"
+[ ! -e "$base/home/.local/bin/pipeasio-settings.bak" ] \
+    && [ ! -L "$base/home/.local/bin/pipeasio-settings.bak" ] \
+    || fail "skipped-panel transition retained its consumed adjacent backup"
+run_component_install "$base" "$base/runtime" --integration-only \
+    >"$base/retry.out" 2>"$base/retry.err" \
+    || fail "repeated skipped-panel repair rejected the already-restored command"
+[ ! -L "$base/home/.local/bin/pipeasio-settings" ] \
+    && [ "$(sha256sum -- "$base/home/.local/bin/pipeasio-settings" | awk '{print $1}')" = "$foreign_digest" ] \
+    && [ ! -e "$base/home/.local/bin/pipeasio-settings.bak" ] \
+    || fail "repeated skipped-panel repair changed the restored foreign command"
+ok "foreign pipeasio-settings command is backed up, restored once, and remains stable on retry"
+
+base="$(new_env modified-panel-command-with-backup)"
+install_fake_host_tools "$base"
+make_runtime "$base/runtime" "$base/BUILD-INFO.txt" built
+panel_command="$base/home/.local/bin/pipeasio-settings"
+mkdir -p -- "$(dirname "$panel_command")"
+printf 'foreign panel bytes\n' > "$panel_command"
+run_component_install "$base" "$base/runtime" --integration-only \
+    >"$base/install.out" 2>"$base/install.err" \
+    || fail "modified-panel fixture could not install its managed projection"
+rm -f -- "$panel_command"
+printf 'user modified panel bytes\n' > "$panel_command"
+write_build_info "$base/runtime" "$base/BUILD-INFO.txt" skipped
+run_component_install "$base" "$base/runtime" --integration-only \
+    >"$base/skipped.out" 2>"$base/skipped.err" \
+    || fail "modified panel command made skipped-panel repair fatal"
+grep -qxF 'user modified panel bytes' "$panel_command" \
+    && grep -qxF 'foreign panel bytes' "$panel_command.bak" \
+    || fail "skipped-panel repair changed a modified command or its saved foreign copy"
+[ "$(grep -cF "Kept both $panel_command and $panel_command.bak because the current shortcut was changed." \
+        "$base/skipped.err")" -eq 1 ] \
+    || fail "modified command and saved copy did not produce exactly one plain warning"
+ok "skipped-panel repair preserves a modified command and its saved foreign copy with one warning"
+
+base="$(new_env panel-command-missing-backup)"
+install_fake_host_tools "$base"
+make_runtime "$base/runtime" "$base/BUILD-INFO.txt" built
+panel_command="$base/home/.local/bin/pipeasio-settings"
+mkdir -p -- "$(dirname "$panel_command")"
+printf 'foreign panel bytes\n' > "$panel_command"
+run_component_install "$base" "$base/runtime" --integration-only \
+    >"$base/install.out" 2>"$base/install.err" \
+    || fail "missing-backup fixture could not install its managed projection"
+rm -f -- "$panel_command.bak"
+write_build_info "$base/runtime" "$base/BUILD-INFO.txt" skipped
+run_component_install "$base" "$base/runtime" --integration-only \
+    >"$base/skipped.out" 2>"$base/skipped.err" \
+    || fail "missing saved panel command made skipped-panel repair fatal"
+[ -L "$panel_command" ] \
+    && [ "$(readlink -- "$panel_command")" = "$base/runtime/bin/pipeasio-settings" ] \
+    && [ ! -e "$panel_command.bak" ] && [ ! -L "$panel_command.bak" ] \
+    || fail "skipped-panel repair changed the live command after its saved copy disappeared"
+[ "$(grep -cF "Kept $panel_command because its saved earlier shortcut is missing." \
+        "$base/skipped.err")" -eq 1 ] \
+    || fail "missing saved panel command did not produce one accurate warning"
+if manifest_has_path "$base/xdg/state/ableton-wine/install-manifest.tsv" "$panel_command" \
+   || manifest_has_path "$base/xdg/state/ableton-wine/install-manifest.tsv" "$panel_command.bak"; then
+    fail "missing saved panel command left an unsafe adjacent ownership claim"
+fi
+ok "skipped-panel repair keeps the live command and accurately reports a missing saved copy"
+
+base="$(new_env panel-adjacent-stale-prestate)"
+install_fake_host_tools "$base"
+make_runtime "$base/runtime" "$base/BUILD-INFO.txt" built
+panel_command="$base/home/.local/bin/pipeasio-settings"
+mkdir -p -- "$(dirname "$panel_command")"
+printf 'foreign panel bytes\n' > "$panel_command"
+run_component_install "$base" "$base/runtime" --integration-only \
+    >"$base/install.out" 2>"$base/install.err" \
+    || fail "stale-prestate fixture could not install its managed projection"
+cp -a -- "$panel_command" "$base/current.before"
+cp -a -- "$panel_command.bak" "$base/saved.before"
+printf 'present\t%s\t/tmp/untrusted-panel-backup\n' "$base/unrelated-path" \
+    > "$base/xdg/state/ableton-wine/install-prestate.tsv"
+if ! run_isolated "$base" env \
+    ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
+    bash -c '
+        set -euo pipefail
+        . "$1/lib/config.sh"
+        ableton_config_init
+        . "$1/lib/manifest.sh"
+        . "$1/lib/pipeasio.sh"
+        rc=0
+        ableton_pipeasio_restore_adjacent_backup "$2" || rc=$?
+        [ "$rc" -eq 2 ]
+    ' _ "$here" "$panel_command"; then
+    fail "adjacent panel recovery trusted a pair while legacy prestate was unverifiable"
+fi
+cmp -s -- "$base/current.before" "$panel_command" \
+    && cmp -s -- "$base/saved.before" "$panel_command.bak" \
+    && grep -qxF $'present\t'"$base/unrelated-path"$'\t/tmp/untrusted-panel-backup' \
+        "$base/xdg/state/ableton-wine/install-prestate.tsv" \
+    || fail "refusing ambiguous adjacent recovery changed live or legacy recovery data"
+ok "adjacent panel recovery defers when any legacy prestate inventory is unverifiable"
 
 install_managed_link()
 {
@@ -1087,6 +2049,23 @@ install_managed_link()
         ableton_write_ownership_manifest
         rm -f -- "$ABLETON_TRANSACTION_DIR/active"
     ' _ "$here" "$link_text" "$target"
+}
+
+install_managed_file()
+{
+    local base="$1" source="$2" target="$3" txn="$4"
+    mkdir -p -- "$txn"
+    # shellcheck disable=SC2016
+    run_isolated "$base" env ABLETON_TRANSACTION_DIR="$txn" bash -c '
+        set -euo pipefail
+        . "$1/lib/config.sh"
+        ableton_config_init
+        . "$1/lib/manifest.sh"
+        ableton_txn_init
+        ableton_install_file 755 "$2" "$3"
+        ableton_write_ownership_manifest
+        rm -f -- "$ABLETON_TRANSACTION_DIR/active"
+    ' _ "$here" "$source" "$target"
 }
 
 run_minimal_uninstall()
@@ -1123,6 +2102,28 @@ run_minimal_uninstall "$base" >"$base/uninstall.out" 2>"$base/uninstall.err" \
     || fail "uninstall did not restore the original relative foreign symlink"
 ok "two managed symlink updates retain and restore relative foreign prestate"
 
+base="$(new_env regular-file-prestate)"
+managed_file="$base/home/.local/bin/pipeasio-settings"
+mkdir -p -- "$(dirname "$managed_file")"
+printf '#!/bin/sh\necho original-foreign-file\n' > "$managed_file"
+printf '#!/bin/sh\necho managed-v1\n' > "$base/managed-file-v1"
+printf '#!/bin/sh\necho managed-v2\n' > "$base/managed-file-v2"
+chmod 755 "$managed_file" "$base/managed-file-v1" "$base/managed-file-v2"
+cp -a -- "$managed_file" "$base/original-foreign-file.before"
+install_managed_file "$base" "$base/managed-file-v1" "$managed_file" "$base/file-txn-v1" \
+    || fail "first managed regular-file update failed"
+cmp -s -- "$base/managed-file-v1" "$managed_file" \
+    || fail "first managed regular-file update did not take effect"
+install_managed_file "$base" "$base/managed-file-v2" "$managed_file" "$base/file-txn-v2" \
+    || fail "second managed regular-file update failed"
+cmp -s -- "$base/managed-file-v2" "$managed_file" \
+    || fail "second managed regular-file update did not take effect"
+run_minimal_uninstall "$base" >"$base/uninstall.out" 2>"$base/uninstall.err" \
+    || fail "uninstall failed while restoring regular-file prestate"
+cmp -s -- "$base/original-foreign-file.before" "$managed_file" \
+    || fail "uninstall did not restore the original foreign regular file"
+ok "two managed regular-file updates retain and restore foreign prestate"
+
 base="$(new_env retargeted-managed-link)"
 managed_link="$base/home/.local/bin/pipeasio-settings"
 install_managed_link "$base" "$base/managed-panel" "$managed_link" "$base/txn" \
@@ -1134,7 +2135,7 @@ run_minimal_uninstall "$base" >"$base/uninstall.out" 2>"$base/uninstall.err" \
 [ -L "$managed_link" ] \
     && [ "$(readlink -- "$managed_link")" = "$base/user-retargeted-panel" ] \
     || fail "uninstall removed a user-retargeted managed link"
-grep -qF "kept user-owned link $managed_link" "$base/uninstall.out" \
+grep -qF "kept a link at $managed_link because it was changed or points somewhere else" "$base/uninstall.err" \
     || fail "preserved retargeted link was not reported"
 ok "uninstall preserves a user-retargeted managed symlink"
 
@@ -1177,7 +2178,7 @@ run_minimal_uninstall "$base" >"$base/out" 2>"$base/err" \
     && [ ! -e "$base/xdg/data/applications/pipeasio-settings.desktop" ] \
     && [ ! -e "$base/xdg/data/icons/hicolor/scalable/apps/pipeasio.svg" ] \
     || fail "uninstall left a recognisable legacy panel projection"
-grep -qF 'removed legacy PipeASIO panel file' "$base/out" \
+grep -qF 'removed a PipeASIO Settings file from an older release:' "$base/out" \
     || fail "legacy panel cleanup was not reported"
 ok "uninstall removes exact pre-manifest PipeASIO panel projections"
 
@@ -1189,8 +2190,8 @@ run_minimal_uninstall "$base" >"$base/out" 2>"$base/err" \
     && [ "$(readlink -- "$base/home/.local/bin/pipeasio-settings")" \
         = "$base/foreign-panel-command" ] \
     || fail "uninstall removed a foreign panel symlink"
-grep -qF "kept independently installed PipeASIO panel file $base/home/.local/bin/pipeasio-settings" \
-    "$base/out" || fail "foreign legacy panel symlink preservation was not reported"
+grep -qF "kept an independently installed PipeASIO panel file at $base/home/.local/bin/pipeasio-settings" \
+    "$base/err" || fail "foreign legacy panel symlink preservation was not reported"
 ok "legacy cleanup preserves an independently targeted panel symlink"
 
 base="$(new_env unsafe-uninstall-no-state)"
@@ -1208,7 +2209,7 @@ fi
     || fail "unsafe uninstall refusal created an installer state marker"
 [ -f "$base/unrecognised-runtime/foreign" ] \
     || fail "unsafe uninstall refusal changed the unrecognised runtime"
-grep -qF 'refusing to delete unrecognised custom runtime' "$base/err" \
+grep -qF 'The Wine runtime was not deleted because the installer could not confirm that it created it:' "$base/err" \
     || fail "unsafe uninstall refusal was not explicit"
 ok "unsafe uninstall refuses before creating or claiming installer state"
 
@@ -1228,18 +2229,6 @@ make_registry_runtime()
     cat > "$runtime/bin/wine" <<'EOF'
 #!/bin/bash
 printf '%s\t%s\n' "${WINEPREFIX:-}" "$*" >> "${ABLETON_TEST_REGISTRY_LOG:?}"
-corrupt_rollback_snapshots()
-{
-    local txn
-    [ "${ABLETON_TEST_CORRUPT_ROLLBACK_SNAPSHOTS:-0}" -eq 1 ] || return 0
-    [ ! -e "${ABLETON_TEST_CORRUPTION_MARKER:?}" ] || return 0
-    for txn in "${XDG_STATE_HOME:?}"/ableton-wine/transactions/rollback.*; do
-        [ -r "$txn/files.tsv" ] || continue
-        /bin/rm -rf -- "$txn/files"
-        : > "${ABLETON_TEST_CORRUPTION_MARKER:?}"
-        return 0
-    done
-}
 case "${1:-}" in
     reg)
         case "${2:-}" in
@@ -1255,7 +2244,6 @@ case "${1:-}" in
                 ;;
             delete)
                 if [ "${ABLETON_TEST_REGISTRY_STICKY:-0}" -ne 0 ]; then
-                    corrupt_rollback_snapshots
                     exit 1
                 fi
                 /bin/rm -f -- "${ABLETON_TEST_REGISTRY_STATE:?}"
@@ -1365,7 +2353,6 @@ run_user_rollback()
         ABLETON_LINK_MODE=off \
         ABLETON_TEST_REGISTRY_LOG="$base/registry.log" \
         ABLETON_TEST_REGISTRY_STATE="$base/registry-present" \
-        ABLETON_TEST_CORRUPTION_MARKER="$base/corruption-fired" \
         PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
         "$@" bash "$here/rollback.sh"
 }
@@ -1447,6 +2434,135 @@ registered_clsids="$(grep -Eo '\{[0-9A-Fa-f-]{36}\}' "$base/registry.log" | sort
     || fail "registration lifecycle touched an unexpected CLSID"
 ok "registration deletes, registers, and queries only PipeASIO in the selected prefix"
 
+base="$(new_env rollback-stale-host-probe)"
+make_rollback_fixture "$base"
+mkdir -p -- "$base/xdg/data/ableton-wine"
+cat > "$base/xdg/data/ableton-wine/pipewire-version-probe" <<'EOF'
+#!/bin/sh
+echo 'stale generated host probe must not run' >&2
+exit 99
+EOF
+chmod 755 "$base/xdg/data/ableton-wine/pipewire-version-probe"
+run_user_rollback "$base" env ABLETON_TEST_REGISTRY_STICKY=0 \
+    >"$base/out" 2>"$base/err" \
+    || fail "stale generated host probe rejected valid current and restored runtimes"
+[ -f "$base/runtime/previous-generation" ] \
+    || fail "stale generated host probe prevented runtime rollback"
+! grep -qF 'stale generated host probe must not run' "$base/err" \
+    || fail "rollback executed the stale generated host probe"
+ok "rollback uses each sealed runtime probe instead of stale generated host copies"
+
+base="$(new_env rollback-postcore-output)"
+make_rollback_fixture "$base"
+cat > "$base/postcore-failure.bash" <<'EOF'
+echo()
+{
+    if [ "$*" = '== Restore saved settings ==' ]; then
+        return 74
+    fi
+    builtin echo "$@"
+}
+EOF
+run_user_rollback "$base" env BASH_ENV="$base/postcore-failure.bash" \
+    ABLETON_TEST_REGISTRY_STICKY=0 >"$base/out" 2>"$base/err" \
+    || fail "post-core output failure reported a committed rollback as failed"
+[ -f "$base/runtime/previous-generation" ] \
+    || fail "post-core output failure reversed a committed runtime rollback"
+grep -qxF 'live_major=11' "$ROLLBACK_INSTALLER_CONFIG" \
+    && grep -qxF 'buffer_size = 883' "$ROLLBACK_PIPEASIO_CONFIG" \
+    || fail "post-core output failure stopped recorded settings restoration"
+[ -L "$base/home/.local/bin/pipeasio-settings" ] \
+    && [ "$(readlink -- "$base/home/.local/bin/pipeasio-settings")" \
+        = "$base/runtime/bin/pipeasio-settings" ] \
+    || fail "post-core output failure stopped panel repair"
+if find "$base/xdg/state/ableton-wine/transactions" -type f -name active \
+    -print -quit 2>/dev/null | grep -q .; then
+    fail "post-core output failure stopped rollback cleanup"
+fi
+ok "runtime rollback continues optional repair and cleanup after output fails"
+
+# The runtime swap has no host-file mutations to put in manifest.sh's file
+# journal. Neither that empty journal nor a failed progress write may become a
+# prerequisite for restoring the previous Wine version.
+base="$(new_env rollback-no-empty-file-journal)"
+make_rollback_fixture "$base"
+real_mkdir="$(command -v mkdir)"
+cat > "$base/fakebin/mkdir" <<EOF
+#!/bin/bash
+for argument do
+    case "\$argument" in
+        */transactions/rollback.*/files)
+            : > "\${ABLETON_TEST_EMPTY_JOURNAL_ATTEMPT:?}"
+            exit 79
+            ;;
+    esac
+done
+exec "$real_mkdir" "\$@"
+EOF
+chmod 755 "$base/fakebin/mkdir"
+cat > "$base/precore-output-failure.bash" <<'EOF'
+echo()
+{
+    if [ "$*" = '== Restore the previous Wine version ==' ]; then
+        return 74
+    fi
+    builtin echo "$@"
+}
+EOF
+run_user_rollback "$base" env BASH_ENV="$base/precore-output-failure.bash" \
+    ABLETON_TEST_EMPTY_JOURNAL_ATTEMPT="$base/empty-journal-attempt" \
+    ABLETON_TEST_REGISTRY_STICKY=0 >"$base/out" 2>"$base/err" \
+    || fail "progress output or an unused file journal blocked runtime restore"
+[ -f "$base/runtime/previous-generation" ] \
+    || fail "progress output failure prevented the runtime swap"
+[ ! -e "$base/empty-journal-attempt" ] \
+    || fail "runtime restore initialized an unused host-file journal"
+if find "$base/xdg/state/ableton-wine/transactions" -type f \
+    \( -name active -o -name files.tsv \) -print -quit 2>/dev/null | grep -q .; then
+    fail "runtime restore left an empty host-file transaction"
+fi
+ok "runtime restore has no empty file-journal or progress-output gate"
+
+# Persistent recovery metadata is optional to the runtime/registry operation.
+# If its state directory cannot be created, rollback uses private scratch and
+# still completes the validated swap.
+base="$(new_env rollback-state-scratch-unavailable)"
+make_rollback_fixture "$base"
+real_mkdir="$(command -v mkdir)"
+real_mktemp="$(command -v mktemp)"
+cat > "$base/fakebin/mkdir" <<EOF
+#!/bin/bash
+for argument do
+    if [ "\$argument" = "\${XDG_STATE_HOME:?}/ableton-wine/transactions" ]; then
+        : > "\${ABLETON_TEST_STATE_SCRATCH_REFUSED:?}"
+        exit 80
+    fi
+done
+exec "$real_mkdir" "\$@"
+EOF
+cat > "$base/fakebin/mktemp" <<EOF
+#!/bin/bash
+for argument do
+    case "\$argument" in
+        */ableton-runtime-restore.XXXXXX)
+            : > "\${ABLETON_TEST_TEMP_SCRATCH_USED:?}"
+            ;;
+    esac
+done
+exec "$real_mktemp" "\$@"
+EOF
+chmod 755 "$base/fakebin/mkdir" "$base/fakebin/mktemp"
+run_user_rollback "$base" env \
+    ABLETON_TEST_STATE_SCRATCH_REFUSED="$base/state-scratch-refused" \
+    ABLETON_TEST_TEMP_SCRATCH_USED="$base/temp-scratch-used" \
+    ABLETON_TEST_REGISTRY_STICKY=0 >"$base/out" 2>"$base/err" \
+    || fail "unavailable persistent recovery scratch blocked runtime restore"
+[ -e "$base/state-scratch-refused" ] && [ -e "$base/temp-scratch-used" ] \
+    || fail "unavailable persistent recovery scratch did not exercise the temporary fallback"
+[ -f "$base/runtime/previous-generation" ] \
+    || fail "unavailable persistent recovery scratch prevented the runtime swap"
+ok "persistent failure-record scratch is not a runtime restore gate"
+
 base="$(new_env rollback-saved-runtime-busy)"
 make_rollback_fixture "$base"
 cp -- /bin/sleep "$ROLLBACK_SAVED/bin/rollback-busy-client"
@@ -1463,7 +2579,7 @@ kill "$saved_busy_pid" 2>/dev/null || true
 wait "$saved_busy_pid" 2>/dev/null || true
 [ -f "$base/runtime/current-generation" ] && [ -f "$ROLLBACK_SAVED/previous-generation" ] \
     || fail "saved-runtime busy refusal changed the runtime layout"
-grep -Eq 'Wine client is running|another Wine prefix is using this runtime' "$base/err" \
+grep -Eq 'Close Live, Max|Close the listed program using this Wine runtime' "$base/err" \
     || fail "saved-runtime busy refusal was not explicit"
 # "close Live" is unactionable when the holder is a windowless agent, so the
 # refusal names what it found rather than guessing at it.
@@ -1489,6 +2605,9 @@ case "${1:-}" in
 esac
 EOF
 chmod 755 "$base/runtime/bin/pipewire-version-probe"
+probe_hash="$(sha256sum -- "$base/runtime/bin/pipewire-version-probe" | awk '{print $1}')"
+sed -i "s/^pipewire-version-probe: .*/pipewire-version-probe: $probe_hash/" \
+    "$base/runtime/ABLETON-WINE-BUILD-INFO.txt"
 if run_user_rollback "$base" env \
     ABLETON_TEST_REGISTRY_STICKY=0 \
     ABLETON_TEST_LATE_CLIENT="$base/runtime/bin/late-runtime-client" \
@@ -1502,7 +2621,7 @@ kill "$late_runtime_pid" 2>/dev/null || true
 wait "$late_runtime_pid" 2>/dev/null || true
 [ -f "$base/runtime/current-generation" ] && [ -f "$ROLLBACK_SAVED/previous-generation" ] \
     || fail "late-runtime recheck occurred after the runtime swap"
-grep -Eq 'Wine client is running|another Wine prefix is using this runtime' "$base/err" \
+grep -Eq 'Close Live, Max|Close the listed program using this Wine runtime' "$base/err" \
     || fail "late-runtime recheck refusal was not explicit"
 ok "rollback rechecks current and saved runtime users immediately before swap"
 
@@ -1622,6 +2741,8 @@ manifest_has_path "$rollback_manifest" "$rollback_panel" \
     || fail "user-facing rollback did not update panel ownership"
 grep -Fq "$base/prefix"$'\tregsvr32 /s pipeasio64.dll' "$base/registry.log" \
     || fail "user-facing rollback did not register the restored driver in its prefix"
+! grep -qF 'rerun the installer to finish optional setup' "$base/rollback.err" \
+    || fail "successful rollback printed a false optional-setup warning"
 ok "user-facing rollback restores marked runtime, config, panel, and registration under custom XDG"
 
 cp -a -- "$base/runtime/.ableton-linux-rollback" "$base/active-rollback-metadata.before"
@@ -1652,6 +2773,9 @@ failed_record="$(find "$base/xdg/state/ableton-wine/transactions" -mindepth 2 \
     -maxdepth 2 -type f -name FAILURE -print | head -n 1)"
 [ -n "$failed_record" ] \
     || fail "failed original registration did not retain a failure record"
+failed_txn="$(dirname "$failed_record")"
+[ ! -e "$failed_txn/files.tsv" ] && [ ! -e "$failed_txn/active" ] \
+    || fail "pre-commit registration failure created an empty host-file transaction"
 grep -qxF 'runtime_restored=yes' "$failed_record" \
     || fail "failed original registration obscured the restored runtime layout"
 if ! grep -qxF 'restoration_complete=no' "$failed_record"; then
@@ -1659,36 +2783,120 @@ if ! grep -qxF 'restoration_complete=no' "$failed_record"; then
     sed -n '1,120p' "$base/failed-rollback.err" >&2
     fail "failed original registration was not recorded as incomplete restoration"
 fi
-grep -qF 'automatic runtime restoration is incomplete: original PipeASIO registration could not be restored' \
+grep -qF 'The previous Wine version could not be restored automatically: original PipeASIO registration could not be restored' \
     "$base/failed-rollback.err" \
     || fail "failed original registration was not reported as incomplete restoration"
-! grep -qF 'previous runtime and files were restored' "$base/failed-rollback.err" \
+! grep -qF 'Wine version from before this attempt is back in place' "$base/failed-rollback.err" \
     || fail "failed original registration printed a false restored claim"
-ok "post-swap failure restores files atomically and records failed re-registration"
+ok "post-swap failure restores the runtime layout and records failed re-registration"
 
-base="$(new_env rollback-host-restore-failure)"
+# Change optional installer settings during the final desktop refresh, after
+# the runtime swap and PipeASIO registration have committed. The concurrent
+# settings generation must be preserved and must not turn a valid runtime
+# rollback into a failure or start a second restoration pass.
+base="$(new_env rollback-post-core-config-drift)"
 make_rollback_fixture "$base"
-if run_user_rollback "$base" env \
-    ABLETON_TEST_REGISTRY_STICKY=1 \
-    ABLETON_TEST_CORRUPT_ROLLBACK_SNAPSHOTS=1 \
-    >"$base/out" 2>"$base/err"; then
-    fail "rollback succeeded after injected host-file restoration failure"
+cp -- "$ROLLBACK_INSTALLER_CONFIG" "$base/installer-config.before"
+cp -- "$ROLLBACK_PIPEASIO_CONFIG" "$base/pipeasio-config.before"
+printf '0\n' > "$base/update-desktop-count"
+cat > "$base/fakebin/update-desktop-database" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+count="$(cat "${ABLETON_TEST_UPDATE_COUNT:?}")"
+count=$((count + 1))
+printf '%s\n' "$count" > "$ABLETON_TEST_UPDATE_COUNT"
+if [ "$count" -ge 2 ] && [ ! -e "${ABLETON_TEST_COMMIT_DRIFT_FIRED:?}" ]; then
+    cp -- "${ABLETON_TEST_COMMIT_DRIFT_SOURCE:?}" \
+        "${ABLETON_TEST_COMMIT_DRIFT_TARGET:?}"
+    : > "$ABLETON_TEST_COMMIT_DRIFT_FIRED"
 fi
-[ -e "$base/corruption-fired" ] \
-    || fail "host-file restoration failure fixture did not corrupt its snapshots"
-failed_record="$(find "$base/xdg/state/ableton-wine/transactions" -mindepth 2 \
-    -maxdepth 2 -type f -name FAILURE -print | head -n 1)"
-[ -n "$failed_record" ] \
-    || fail "host-file restoration failure did not retain a failure record"
-grep -qxF 'runtime_restored=yes' "$failed_record" \
-    || fail "host-file restoration failure obscured the restored runtime layout"
-grep -qxF 'restoration_complete=no' "$failed_record" \
-    || fail "host-file restoration failure was not recorded as incomplete"
-grep -qF 'automatic runtime restoration is incomplete: host file restoration failed' "$base/err" \
-    || fail "host-file restoration failure was not reported as incomplete"
-! grep -qF 'previous runtime and files were restored' "$base/err" \
-    || fail "host-file restoration failure printed a false restored claim"
-ok "host-file rollback failure records incomplete restoration without a false success claim"
+exit 0
+EOF
+chmod 755 "$base/fakebin/update-desktop-database"
+run_user_rollback "$base" env \
+    ABLETON_TEST_REGISTRY_STICKY=0 \
+    ABLETON_TEST_UPDATE_COUNT="$base/update-desktop-count" \
+    ABLETON_TEST_COMMIT_DRIFT_FIRED="$base/commit-drift-fired" \
+    ABLETON_TEST_COMMIT_DRIFT_SOURCE="$base/installer-config.before" \
+    ABLETON_TEST_COMMIT_DRIFT_TARGET="$ROLLBACK_INSTALLER_CONFIG" \
+    >"$base/out" 2>"$base/err" \
+    || fail "post-core installer-settings drift invalidated a restored runtime"
+[ -e "$base/commit-drift-fired" ] \
+    || fail "post-core installer-settings drift fixture did not mutate its destination"
+[ -f "$base/runtime/previous-generation" ] \
+    && [ ! -e "$ROLLBACK_SAVED" ] && [ ! -L "$ROLLBACK_SAVED" ] \
+    && [ -e "$base/registry-present" ] \
+    && cmp -s -- "$ROLLBACK_INSTALLER_CONFIG" "$base/installer-config.before" \
+    && grep -qF 'buffer_size = 883' "$ROLLBACK_PIPEASIO_CONFIG" \
+    || fail "post-core installer-settings drift reversed Wine or changed the concurrent settings generation"
+! find "$base/xdg/state/ableton-wine/transactions" -mindepth 2 \
+    -maxdepth 2 -type f -name FAILURE -print -quit | grep -q . \
+    || fail "post-core installer-settings drift invented a rollback failure"
+! find "$base/xdg/state/ableton-wine/transactions" -mindepth 2 \
+    -maxdepth 2 -type f -name active -print -quit | grep -q . \
+    || fail "post-core installer-settings drift retained an active rollback"
+grep -qxF 'OK: The previous Wine version is restored.' "$base/out" \
+    || fail "post-core installer-settings drift hid the restored runtime outcome"
+ok "post-core installer-settings drift is preserved without invalidating the restored runtime"
+
+# Once the runtime swap and PipeASIO registration have committed, cleanup
+# errors are not rollback errors.
+# Fail each cleanup boundary independently: the restored runtime/configuration
+# must stay committed and the command must remain successful. The retained
+# transaction preserves the cleanup evidence; no extra failure record or
+# restoration pass should be invented after the core result commits.
+real_rm="$(command -v rm)"
+for cleanup_failure in directory; do
+    base="$(new_env "rollback-committed-cleanup-$cleanup_failure")"
+    make_rollback_fixture "$base"
+    cat > "$base/fakebin/rm" <<EOF
+#!/bin/bash
+set -euo pipefail
+transaction_root="\${XDG_STATE_HOME:?}/ableton-wine/transactions"
+for argument do
+    if [ "\${ABLETON_TEST_CLEANUP_FAILURE:?}" = directory ]; then
+        case "\$argument" in
+            "\$transaction_root"/rollback.*)
+                if [ "\${argument%/*}" = "\$transaction_root" ]; then
+                    printf 'directory\n' > "\${ABLETON_TEST_CLEANUP_ATTEMPT:?}"
+                    exit 89
+                fi
+                ;;
+        esac
+    fi
+done
+exec "$real_rm" "\$@"
+EOF
+    chmod 755 "$base/fakebin/rm"
+    run_user_rollback "$base" env \
+        ABLETON_TEST_REGISTRY_STICKY=0 \
+        ABLETON_TEST_CLEANUP_FAILURE="$cleanup_failure" \
+        ABLETON_TEST_CLEANUP_ATTEMPT="$base/cleanup-attempt" \
+        >"$base/out" 2>"$base/err" \
+        || fail "committed $cleanup_failure cleanup failure invalidated the restored runtime"
+    grep -qxF "$cleanup_failure" "$base/cleanup-attempt" \
+        || fail "committed $cleanup_failure cleanup fixture did not reach its boundary"
+    cleanup_txn="$(find "$base/xdg/state/ableton-wine/transactions" -mindepth 1 \
+        -maxdepth 1 -type d -name 'rollback.*' -print | head -n 1)"
+    [ -n "$cleanup_txn" ] \
+        || fail "committed $cleanup_failure cleanup did not retain its recovery directory"
+    [ ! -e "$cleanup_txn/COMMITTED_CLEANUP_FAILURE" ] \
+        || fail "committed $cleanup_failure cleanup invented a failure record"
+    [ ! -e "$cleanup_txn/active" ] && [ ! -e "$cleanup_txn/files.tsv" ] \
+        || fail "cleanup-only directory contains an unused host-file transaction"
+    [ ! -e "$cleanup_txn/FAILURE" ] \
+        || fail "committed $cleanup_failure cleanup incorrectly entered restoration recovery"
+    [ -f "$base/runtime/previous-generation" ] \
+        && [ ! -e "$ROLLBACK_SAVED" ] && [ ! -L "$ROLLBACK_SAVED" ] \
+        && grep -qF 'live_major=11' "$ROLLBACK_INSTALLER_CONFIG" \
+        && grep -qF 'buffer_size = 883' "$ROLLBACK_PIPEASIO_CONFIG" \
+        || fail "committed $cleanup_failure cleanup failure reversed successful state"
+    grep -qF "The previous Wine version is restored, but temporary files remain at $cleanup_txn." "$base/err" \
+        || fail "committed $cleanup_failure cleanup was not reported as cleanup-only"
+    ! grep -Eq 'could not be restored automatically|Wine version from before this attempt is back in place' "$base/err" \
+        || fail "committed $cleanup_failure cleanup printed a restoration claim"
+done
+ok "postcommit recovery-directory cleanup failures preserve committed state and never claim restoration"
 
 base="$(new_env retained-prefix-unregister)"
 make_registry_runtime "$base"
@@ -1739,17 +2947,16 @@ install_managed_link "$base" "$base/managed-panel" "$managed_link" "$base/txn" \
 prestate_id="$(printf '%s' "$managed_link" | sha256sum | awk '{print $1}')"
 prestate_backup="$base/xdg/state/ableton-wine/install-prestate/$prestate_id"
 rm -f -- "$prestate_backup"
-if run_minimal_uninstall "$base" >"$base/out" 2>"$base/err"; then
-    fail "uninstall succeeded with a missing recorded pre-install backup"
-fi
+run_minimal_uninstall "$base" >"$base/out" 2>"$base/err" \
+    || fail "a missing optional pre-install backup made uninstall fail"
 [ -L "$managed_link" ] && [ "$(readlink -- "$managed_link")" = "$base/managed-panel" ] \
-    || fail "missing prestate validation occurred after managed target removal"
+    || fail "missing optional prestate did not preserve the managed target"
 [ -r "$base/xdg/state/ableton-wine/install-manifest.tsv" ] \
     && [ -r "$base/xdg/state/ableton-wine/install-prestate.tsv" ] \
-    || fail "missing prestate failure discarded ownership or prestate records"
-grep -Eq 'cannot safely restore the recorded pre-install file|pre-install backup is missing or misplaced' "$base/err" \
-    || fail "missing prestate refusal was not explicit"
-ok "uninstall validates recorded prestate before removing a managed path"
+    || fail "missing optional prestate discarded the records needed for inspection"
+grep -qF "Desktop shortcuts, file-opening settings, and older Wine runtimes were left unchanged because the installer's file list could not be trusted" \
+    "$base/err" || fail "missing optional prestate warning was not explicit"
+ok "missing optional prestate preserves integration records without failing uninstall"
 
 base="$(new_env literal-runtime-sibling)"
 literal_runtime="$base/runtime[1]"
@@ -1929,7 +3136,7 @@ ok "file and symlink directory refusals leave transaction and prestate journals 
 
 run_guarded_file_install()
 {
-    local base="$1" txn="$2" target="$3"
+    local base="$1" txn="$2" target="$3" policy="${4:-preserve-local}"
     mkdir -p -- "$txn"
     mkdir -p -- "$txn"
     # shellcheck disable=SC2016
@@ -1939,8 +3146,8 @@ run_guarded_file_install()
         ableton_config_init
         . "$1/lib/manifest.sh"
         ableton_txn_init
-        ableton_install_file 600 "$2" "$3"
-    ' _ "$here" "$base/replacement" "$target"
+        ableton_install_file 600 "$2" "$3" file "$4"
+    ' _ "$here" "$base/replacement" "$target" "$policy"
 }
 
 for journal in manifest prestate; do
@@ -1950,9 +3157,15 @@ for journal in manifest prestate; do
         txn="$base/txn"
         target="$base/xdg/data/ableton-wine/setup-realtime.sh"
         mkdir -p -- "$state" "$(dirname "$target")"
+        printf 'format=1\nowner=ableton-linux\n' > "$state/.ableton-linux-state"
         printf 'foreign live bytes\n' > "$target"
         printf 'replacement bytes\n' > "$base/replacement"
         printf 'external journal bytes\n' > "$base/external-journal"
+        if [ "$journal" = prestate ]; then
+            printf 'file\t%s\t%s\n' "$target" \
+                "$(sha256sum -- "$target" | awk '{print $1}')" \
+                > "$state/install-manifest.tsv"
+        fi
         path="$state/install-$journal.tsv"
         case "$corrupt_kind" in
             symlink) ln -s -- "$base/external-journal" "$path" ;;
@@ -1960,21 +3173,101 @@ for journal in manifest prestate; do
             malformed) printf 'not-a-valid-record\n' > "$path" ;;
             nul) printf '\0' > "$path" ;;
         esac
-        if run_guarded_file_install "$base" "$txn" "$target" \
-            >"$base/out" 2>"$base/err"; then
-            chmod 600 "$path" 2>/dev/null || true
-            fail "install accepted a $corrupt_kind $journal journal"
-        fi
+        run_guarded_file_install "$base" "$txn" "$target" \
+            >"$base/out" 2>"$base/err" \
+            || { chmod 600 "$path" 2>/dev/null || true; \
+                 fail "repair install consulted a $corrupt_kind legacy $journal journal"; }
         chmod 600 "$path" 2>/dev/null || true
-        grep -qxF 'foreign live bytes' "$target" \
-            || fail "$corrupt_kind $journal refusal overwrote a foreign target"
+        grep -qxF 'replacement bytes' "$target" \
+            || fail "$corrupt_kind legacy $journal journal blocked canonical repair"
         grep -qxF 'external journal bytes' "$base/external-journal" \
-            || fail "$corrupt_kind $journal refusal changed a symlink referent"
-        [ -f "$txn/files.tsv" ] && [ ! -s "$txn/files.tsv" ] \
-            || fail "$corrupt_kind $journal refusal mutated its transaction journal"
+            || fail "$corrupt_kind legacy $journal journal changed a symlink referent"
     done
 done
-ok "install refuses unsafe manifest and prestate journals without touching foreign data"
+ok "repair installs ignore malformed legacy inventory and prestate without touching external data"
+
+# Both optional bookkeeping files can be damaged at once. Files published from
+# the current installer payload are still authoritative; their immediate
+# transaction copy is sufficient to restore this attempt if a later step fails.
+base="$(new_env generated-repair-both-journals-damaged)"
+state="$base/xdg/state/ableton-wine"
+txn="$base/txn"
+target="$base/xdg/data/ableton-wine/setup-realtime.sh"
+mkdir -p -- "$state/install-prestate" "$(dirname "$target")"
+printf 'format=1\nowner=ableton-linux\n' > "$state/.ableton-linux-state"
+printf 'older generated bytes\n' > "$target"
+printf 'replacement bytes\n' > "$base/replacement"
+printf 'not-a-valid-installed-file-list\n' > "$state/install-manifest.tsv"
+printf 'not-a-valid-saved-copy-list\n' > "$state/install-prestate.tsv"
+printf 'stale saved-copy sentinel\n' > "$state/install-prestate/not-a-valid-slot"
+cp -a -- "$state/install-manifest.tsv" "$base/manifest.before"
+cp -a -- "$state/install-prestate.tsv" "$base/prestate.before"
+run_guarded_file_install "$base" "$txn" "$target" replace-generated \
+    >"$base/out" 2>"$base/err" \
+    || fail "damaged optional bookkeeping blocked generated-file repair"
+grep -qxF 'replacement bytes' "$target" \
+    || fail "generated-file repair retained its old bytes"
+cmp -s -- "$state/install-manifest.tsv" "$base/manifest.before" \
+    && cmp -s -- "$state/install-prestate.tsv" "$base/prestate.before" \
+    && grep -qxF 'stale saved-copy sentinel' \
+        "$state/install-prestate/not-a-valid-slot" \
+    || fail "generated-file repair consumed damaged optional bookkeeping"
+run_isolated "$base" env ABLETON_TRANSACTION_DIR="$txn" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ableton_config_init
+    . "$1/lib/manifest.sh"
+    ableton_txn_rollback_files "$2"
+' _ "$here" "$txn" \
+    || fail "generated-file repair lost same-run rollback"
+grep -qxF 'older generated bytes' "$target" \
+    || fail "same-run rollback did not restore the replaced generated file"
+ok "generated files ignore damaged optional bookkeeping and keep same-run rollback"
+
+# The authoritative overwrite policy is deliberately narrow. Shared desktop
+# names still preserve unrelated local files and cannot opt into private-file
+# replacement through a future call-site mistake.
+base="$(new_env replace-generated-shared-path)"
+target="$base/xdg/data/icons/hicolor/scalable/apps/live-suite.svg"
+mkdir -p -- "$(dirname "$target")"
+printf 'foreign shared icon\n' > "$target"
+printf 'replacement bytes\n' > "$base/replacement"
+if run_guarded_file_install "$base" "$base/txn" "$target" replace-generated \
+    >"$base/out" 2>"$base/err"; then
+    fail "private-file overwrite policy accepted a shared desktop path"
+fi
+grep -qxF 'foreign shared icon' "$target" \
+    || fail "rejected private-file policy changed a shared desktop path"
+[ -f "$base/txn/files.tsv" ] && [ ! -s "$base/txn/files.tsv" ] \
+    || fail "rejected private-file policy changed transaction recovery data"
+ok "private generated-file replacement is enforced by an exact path allowlist"
+
+# Once a generated file has reached its final path, optional recovery metadata
+# cannot turn that valid repair into a failure or block the next independent
+# repair. Force the post-publication check to fail after the first atomic move.
+base="$(new_env publication-checkpoint-warning)"
+mkdir -p -- "$base/txn" "$base/xdg/data/ableton-wine/lib"
+printf 'first replacement\n' > "$base/first"
+printf 'second replacement\n' > "$base/second"
+run_isolated "$base" env ABLETON_TRANSACTION_DIR="$base/txn" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ableton_config_init
+    . "$1/lib/manifest.sh"
+    ableton_txn_init
+    ableton_txn_preflight_commit_files() { return 1; }
+    ableton_publish_file 644 "$2" "$4/lib/config.sh" file replace-generated
+    [ "$ABLETON_PUBLICATION_JOURNAL_BROKEN" -eq 1 ]
+    ableton_publish_file 644 "$3" "$4/lib/lifecycle.sh" file replace-generated
+' _ "$here" "$base/first" "$base/second" "$base/xdg/data/ableton-wine" \
+    >"$base/out" 2>"$base/err" \
+    || fail "recovery bookkeeping failure became a generated-file gate"
+grep -qxF 'first replacement' "$base/xdg/data/ableton-wine/lib/config.sh" \
+    && grep -qxF 'second replacement' "$base/xdg/data/ableton-wine/lib/lifecycle.sh" \
+    || fail "recovery bookkeeping failure blocked an independent repair"
+grep -qF 'Continuing with the installed file.' "$base/err" \
+    || fail "post-publication recovery warning was not plain"
+ok "post-publication bookkeeping cannot invalidate or block generated-file repairs"
 
 base="$(new_env manifest-external-path)"
 state="$base/xdg/state/ableton-wine"
@@ -1983,13 +3276,16 @@ external_target="$base/external-valid-digest"
 printf 'external valid digest bytes\n' > "$external_target"
 printf 'file\t%s\t%s\n' "$external_target" \
     "$(sha256sum -- "$external_target" | awk '{print $1}')" > "$state/install-manifest.tsv"
-if run_guarded_file_install "$base" "$base/txn" \
-    "$base/xdg/data/ableton-wine/setup-realtime.sh" >"$base/out" 2>"$base/err"; then
-    fail "install accepted a valid-digest arbitrary external manifest path"
-fi
+repair_target="$base/xdg/data/ableton-wine/setup-realtime.sh"
+printf 'replacement bytes\n' > "$base/replacement"
+run_guarded_file_install "$base" "$base/txn" "$repair_target" \
+    >"$base/out" 2>"$base/err" \
+    || fail "arbitrary legacy inventory row vetoed canonical generated-file repair"
+grep -qxF 'replacement bytes' "$repair_target" \
+    || fail "arbitrary legacy inventory row blocked canonical repair"
 grep -qxF 'external valid digest bytes' "$external_target" \
-    || fail "external manifest-path refusal changed the external file"
-ok "valid digest cannot authorize an arbitrary external manifest path"
+    || fail "repair followed an arbitrary path from legacy inventory"
+ok "legacy inventory never authorizes or vetoes generated-file repair targets"
 
 run_direct_uninstall()
 {
@@ -1999,7 +3295,10 @@ run_direct_uninstall()
     fi
     run_isolated "$base" env PATH="$base/fakebin:$PATH" \
         ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
-        ABLETON_LINK_MODE=off bash "$here/uninstall.sh" "$mode" --yes
+        ABLETON_LINK_MODE=off \
+        ABLETON_TEST_REGISTRY_LOG="$base/registry.log" \
+        ABLETON_TEST_REGISTRY_STATE="$base/registry-present" \
+        bash "$here/uninstall.sh" "$mode" --yes
 }
 
 for marker_kind in runtime prefix state; do
@@ -2014,16 +3313,28 @@ for marker_kind in runtime prefix state; do
         prefix) printf '\0' >> "$base/prefix/.ableton-linux-prefix"; mode=--delete-prefix ;;
         state) printf '\0' >> "$base/xdg/state/ableton-wine/.ableton-linux-state" ;;
     esac
-    if run_direct_uninstall "$base" "$mode" >"$base/out" 2>"$base/err"; then
-        fail "uninstall accepted a runtime/prefix/state $marker_kind marker with trailing NUL"
-    fi
-    if ! grep -qxF 'runtime sentinel' "$base/runtime/sentinel" \
-       || ! grep -qxF 'prefix sentinel' "$base/prefix/sentinel" \
-       || ! grep -qxF 'state sentinel' "$base/xdg/state/ableton-wine/sentinel"; then
-        fail "$marker_kind marker refusal changed an owned tree"
+    if [ "$marker_kind" = state ]; then
+        run_direct_uninstall "$base" "$mode" >"$base/out" 2>"$base/err" \
+            || fail "damaged optional state marker blocked exact runtime removal"
+        [ ! -e "$base/runtime" ] && [ ! -L "$base/runtime" ] \
+            || fail "damaged optional state marker retained the configured runtime"
+        grep -qxF 'prefix sentinel' "$base/prefix/sentinel" \
+            && grep -qxF 'state sentinel' "$base/xdg/state/ableton-wine/sentinel" \
+            || fail "damaged optional state marker changed retained prefix or support data"
+        grep -qF 'Ableton Linux support files were left unchanged because their directory is not recognised:' \
+            "$base/err" || fail "damaged optional state marker did not produce its warning"
+    else
+        if run_direct_uninstall "$base" "$mode" >"$base/out" 2>"$base/err"; then
+            fail "uninstall accepted a $marker_kind marker with trailing NUL"
+        fi
+        if ! grep -qxF 'runtime sentinel' "$base/runtime/sentinel" \
+           || ! grep -qxF 'prefix sentinel' "$base/prefix/sentinel" \
+           || ! grep -qxF 'state sentinel' "$base/xdg/state/ableton-wine/sentinel"; then
+            fail "$marker_kind marker refusal changed an owned tree"
+        fi
     fi
 done
-ok "trailing NUL bytes invalidate every recursive-deletion ownership marker"
+ok "runtime and prefix markers remain fatal while damaged optional state is retained with a warning"
 
 for journal in manifest prestate mime; do
     for corrupt_kind in symlink unreadable nul; do
@@ -2046,17 +3357,17 @@ for journal in manifest prestate mime; do
             unreadable) printf 'unreadable\n' > "$path"; chmod 000 "$path" ;;
             nul) printf '\0' >> "$path" ;;
         esac
-        if run_direct_uninstall "$base" >"$base/out" 2>"$base/err"; then
-            chmod 600 "$path" 2>/dev/null || true
-            fail "uninstall accepted a $corrupt_kind $journal journal"
-        fi
+        run_direct_uninstall "$base" >"$base/out" 2>"$base/err" \
+            || { chmod 600 "$path" 2>/dev/null || true; \
+                 fail "$corrupt_kind optional $journal journal blocked runtime removal"; }
         chmod 600 "$path" 2>/dev/null || true
-        grep -qxF 'runtime sentinel' "$base/runtime/sentinel" \
+        [ ! -e "$base/runtime" ] && [ ! -L "$base/runtime" ] \
             && grep -qxF 'prefix sentinel' "$base/prefix/sentinel" \
-            && [ -e "$base/registry-present" ] \
-            || fail "$corrupt_kind $journal refusal mutated runtime, prefix, or registry"
+            || fail "$corrupt_kind $journal state blocked runtime removal or changed the kept prefix"
         grep -qxF 'external uninstall journal' "$base/external-journal" \
-            || fail "$corrupt_kind $journal refusal changed an external referent"
+            || fail "$corrupt_kind $journal warning changed an external referent"
+        grep -qF '!! warning:' "$base/err" \
+            || fail "$corrupt_kind $journal state did not produce an optional-cleanup warning"
     done
 done
 
@@ -2069,12 +3380,15 @@ printf 'invalid runtime prestate\n' > "$state/install-prestate/$runtime_id"
 printf 'present\t%s\t%s\n' "$base/runtime" "$state/install-prestate/$runtime_id" \
     > "$state/install-prestate.tsv"
 printf 'runtime sentinel\n' > "$base/runtime/sentinel"
-if run_direct_uninstall "$base" >"$base/out" 2>"$base/err"; then
-    fail "uninstall accepted file prestate claimed for a runtime record"
-fi
-[ -f "$base/runtime/sentinel" ] && [ -e "$base/registry-present" ] \
-    || fail "runtime prestate claim was rejected after mutation"
-ok "uninstall preflights unsafe journals and rejects prestate attached to runtime ownership"
+run_direct_uninstall "$base" >"$base/out" 2>"$base/err" \
+    || fail "invalid optional prestate attached to a runtime blocked runtime removal"
+[ ! -e "$base/runtime" ] && [ ! -L "$base/runtime" ] \
+    && [ -f "$state/install-prestate/$runtime_id" ] \
+    && [ -f "$state/install-prestate.tsv" ] \
+    || fail "runtime removal did not preserve the invalid optional prestate for inspection"
+grep -qF '!! warning:' "$base/err" \
+    || fail "invalid runtime prestate did not produce an optional-cleanup warning"
+ok "uninstall leaves unsafe optional journals untouched while removing the exact configured runtime"
 
 base="$(new_env uninstall-late-missing-prestate)"
 make_registry_runtime "$base"
@@ -2096,15 +3410,16 @@ printf 'present\t%s\t%s\npresent\t%s\t%s\n' \
     "$first" "$state/install-prestate/$first_id" \
     "$second" "$state/install-prestate/$second_id" > "$state/install-prestate.tsv"
 printf 'runtime sentinel\n' > "$base/runtime/sentinel"
-if run_direct_uninstall "$base" >"$base/out" 2>"$base/err"; then
-    fail "uninstall accepted a later missing prestate backup"
-fi
+run_direct_uninstall "$base" >"$base/out" 2>"$base/err" \
+    || fail "later missing optional prestate blocked runtime removal"
 if ! grep -qxF 'first managed bytes' "$first" \
    || ! grep -qxF 'second managed bytes' "$second" \
-   || ! grep -qxF 'runtime sentinel' "$base/runtime/sentinel"; then
-    fail "late prestate failure occurred after an earlier managed target changed"
+   || { [ -e "$base/runtime" ] || [ -L "$base/runtime" ]; }; then
+    fail "late missing prestate changed optional files or retained the configured runtime"
 fi
-ok "uninstall fully preflights later prestate failures before files or runtime change"
+grep -qF '!! warning:' "$base/err" \
+    || fail "late missing prestate did not produce an optional-cleanup warning"
+ok "late missing prestate leaves optional files untouched without blocking runtime removal"
 
 make_mime_failure_fixture()
 {
@@ -2131,12 +3446,15 @@ case "${1:-}" in
 esac
 EOF
 chmod 755 "$base/fakebin/xdg-mime"
-if run_direct_uninstall "$base" >"$base/out" 2>"$base/err"; then
-    fail "MIME default restoration failure reported uninstall success"
-fi
+run_direct_uninstall "$base" >"$base/out" 2>"$base/err" \
+    || fail "MIME default restoration failure blocked runtime removal"
+[ ! -e "$base/runtime" ] && [ ! -L "$base/runtime" ] \
+    || fail "MIME default restoration failure retained the configured runtime"
 [ -r "$base/xdg/state/ableton-wine/mime-prestate.tsv" ] \
     && [ -r "$base/xdg/state/ableton-wine/.ableton-linux-state" ] \
     || fail "MIME default restoration failure discarded retry state"
+grep -qF '!! warning:' "$base/err" \
+    || fail "MIME default restoration failure did not produce a retry warning"
 
 base="$(new_env mime-clear-failure)"
 make_mime_failure_fixture "$base" ''
@@ -2164,13 +3482,16 @@ done
 exec "$real_awk" "\$@"
 EOF
 chmod 755 "$base/fakebin/xdg-mime" "$base/fakebin/awk"
-if run_direct_uninstall "$base" >"$base/out" 2>"$base/err"; then
-    fail "MIME clear failure reported uninstall success"
-fi
+run_direct_uninstall "$base" >"$base/out" 2>"$base/err" \
+    || fail "MIME clear failure blocked runtime removal"
+[ ! -e "$base/runtime" ] && [ ! -L "$base/runtime" ] \
+    || fail "MIME clear failure retained the configured runtime"
 [ -r "$base/xdg/state/ableton-wine/mime-prestate.tsv" ] \
     && [ -r "$base/xdg/state/ableton-wine/.ableton-linux-state" ] \
     || fail "MIME clear failure discarded retry state"
-ok "MIME command and mimeapps restoration failures return nonzero with retry state retained"
+grep -qF '!! warning:' "$base/err" \
+    || fail "MIME clear failure did not produce a retry warning"
+ok "MIME command and mimeapps restoration failures warn while runtime removal succeeds"
 
 base="$(new_env mime-post-lock-mutation)"
 make_mime_failure_fixture "$base" foreign.desktop
@@ -2187,18 +3508,20 @@ if [ ! -e "$base/mime-mutated" ]; then
 fi
 EOF
 chmod 755 "$base/fakebin/flock"
-if run_direct_uninstall "$base" >"$base/out" 2>"$base/err"; then
-    fail "uninstall accepted MIME restoration state changed while waiting for its lock"
-fi
-[ -e "$base/mime-mutated" ] && [ -f "$base/runtime/sentinel" ] \
+run_direct_uninstall "$base" >"$base/out" 2>"$base/err" \
+    || fail "post-lock MIME mutation blocked runtime removal"
+[ -e "$base/mime-mutated" ] && [ ! -e "$base/runtime" ] \
     && [ -f "$state/.ableton-linux-state" ] \
-    || fail "post-lock MIME mutation fixture did not fire before a no-mutation refusal"
-grep -qF 'MIME restoration state changed; retry uninstall' "$base/err" \
-    || fail "post-lock MIME mutation refusal was not explicit"
-ok "uninstall hashes and fully revalidates MIME restoration state after locking"
+    || fail "post-lock MIME mutation did not preserve support state while removing runtime"
+grep -qF 'File-opening defaults were left unchanged because their saved settings changed while uninstall was starting' \
+    "$base/err" || fail "post-lock MIME mutation warning was not explicit"
+ok "uninstall revalidates changed MIME state, retains it, and still removes the runtime"
 
 base="$(new_env partial-uninstall-retry)"
 mkdir -p -- "$base/runtime" "$base/xdg/state/ableton-wine/install-prestate"
+install_fake_host_tools "$base"
+mkdir -p -- "$base/xdg/config/ableton-wine"
+printf 'unrelated user settings\n' > "$base/xdg/config/ableton-wine/user-notes"
 printf 'format=1\nname=wine-d2d1-nspa-11.13\n' > "$base/runtime/.ableton-linux-runtime"
 printf 'format=1\nowner=ableton-linux\n' \
     > "$base/xdg/state/ableton-wine/.ableton-linux-state"
@@ -2223,13 +3546,15 @@ printf 'present\t%s\t%s\npresent\t%s\t%s\n' \
     "$first" "$base/xdg/state/ableton-wine/install-prestate/$first_id" \
     "$second" "$base/xdg/state/ableton-wine/install-prestate/$second_id" \
     > "$base/xdg/state/ableton-wine/install-prestate.tsv"
-if run_direct_uninstall "$base" >"$base/first.out" 2>"$base/first.err"; then
-    fail "partial uninstall fixture unexpectedly succeeded before conflict resolution"
-fi
+run_direct_uninstall "$base" >"$base/first.out" 2>"$base/first.err" \
+    || fail "optional file conflict blocked configured runtime removal"
 grep -qxF 'first previous bytes' "$first" \
     && grep -qxF 'user conflict bytes' "$second" \
-    && [ -d "$base/runtime" ] && [ -d "$base/xdg/state/ableton-wine" ] \
-    || fail "partial uninstall did not retain restored file, conflict, runtime, and state"
+    && [ ! -e "$base/runtime" ] && [ ! -L "$base/runtime" ] \
+    && [ -d "$base/xdg/state/ableton-wine" ] \
+    || fail "partial uninstall did not remove Wine while retaining the file conflict and retry state"
+grep -qF 'kept an unrecognised or user-modified file at' "$base/first.err" \
+    || fail "optional file conflict was not reported"
 cp -- "$second_managed" "$second"
 if ! run_direct_uninstall "$base" >"$base/retry.out" 2>"$base/retry.err"; then
     sed -n '1,120p' "$base/retry.err" >&2
@@ -2240,10 +3565,12 @@ if ! grep -qxF 'first previous bytes' "$first" \
     fail "partial uninstall retry did not preserve/restore exact prestate"
 fi
 [ ! -e "$base/runtime" ] && [ ! -e "$base/xdg/state/ableton-wine" ] \
+    && grep -qxF 'unrelated user settings' \
+        "$base/xdg/config/ableton-wine/user-notes" \
     || fail "successful partial-uninstall retry retained runtime or ownership state"
-grep -qF "kept already-restored pre-install file $first" "$base/retry.out" \
+grep -qF "kept your already-restored earlier file at $first" "$base/retry.out" \
     || fail "partial uninstall retry did not recognize its already-restored file"
-ok "partial uninstall retry accepts exact already-restored prestate and completes"
+ok "optional uninstall conflicts preserve retry state without retaining the runtime"
 
 for snapshot in installer-config pipeasio-config.ini; do
     base="$(new_env "rollback-directory-${snapshot//./-}")"
@@ -2252,16 +3579,19 @@ for snapshot in installer-config pipeasio-config.ini; do
     mkdir -p -- "$ROLLBACK_SAVED/.ableton-linux-rollback/$snapshot"
     printf 'directory snapshot sentinel\n' \
         > "$ROLLBACK_SAVED/.ableton-linux-rollback/$snapshot/sentinel"
-    if run_user_rollback "$base" env ABLETON_TEST_REGISTRY_STICKY=0 \
-        >"$base/out" 2>"$base/err"; then
-        fail "rollback accepted a directory $snapshot snapshot"
-    fi
-    [ -f "$base/runtime/current-generation" ] \
-        && [ -f "$ROLLBACK_SAVED/previous-generation" ] \
-        && [ -f "$ROLLBACK_SAVED/.ableton-linux-rollback/$snapshot/sentinel" ] \
-        || fail "directory $snapshot refusal occurred after runtime mutation"
+    run_user_rollback "$base" env ABLETON_TEST_REGISTRY_STICKY=0 \
+        >"$base/out" 2>"$base/err" \
+        || fail "unavailable saved $snapshot settings blocked runtime rollback"
+    [ -f "$base/runtime/previous-generation" ] \
+        && [ ! -e "$ROLLBACK_SAVED" ] && [ ! -L "$ROLLBACK_SAVED" ] \
+        && [ -f "$base/runtime/.ableton-linux-rollback/$snapshot/sentinel" ] \
+        && grep -qF 'live_major=12' "$ROLLBACK_INSTALLER_CONFIG" \
+        && grep -qF 'buffer_size = 512' "$ROLLBACK_PIPEASIO_CONFIG" \
+        || fail "unavailable saved $snapshot settings changed current settings or blocked Wine"
+    grep -qF 'The saved runtime is usable, but its saved settings are unavailable. Current settings will stay in place.' \
+        "$base/err" || fail "unavailable saved $snapshot settings warning was not explicit"
 done
-ok "rollback rejects directory configuration snapshots before the runtime swap"
+ok "unavailable saved settings warn without blocking runtime rollback"
 
 run_txn_init_only()
 {
@@ -2379,7 +3709,7 @@ run_isolated "$base" env ABLETON_TRANSACTION_DIR="$txn" bash -c '
 if run_txn_commit_preflight_only "$base" "$txn" >"$base/out" 2>"$base/err"; then
     fail "commit preflight accepted a pending transaction row"
 fi
-grep -qF "file transaction has an unfinished mutation: $target" "$base/err" \
+grep -qF "A file update stopped before it finished: $target" "$base/err" \
     || fail "pending commit refusal was not explicit"
 grep -qxF 'live pending bytes' "$target" \
     || fail "pending commit refusal changed the live target"
@@ -2404,7 +3734,7 @@ printf 'third-party bytes\n' > "$target"
 if run_txn_commit_preflight_only "$base" "$txn" >"$base/out" 2>"$base/err"; then
     fail "commit preflight accepted a present target replaced by a third party"
 fi
-grep -qF "file transaction destination no longer matches its committed object: $target" "$base/err" \
+grep -qF "A file changed while the installer was updating it: $target" "$base/err" \
     || fail "present changed commit refusal was not explicit"
 grep -qxF 'third-party bytes' "$target" \
     || fail "present changed commit refusal rewrote the live target"
@@ -2426,11 +3756,281 @@ printf 'third-party appeared\n' > "$target"
 if run_txn_commit_preflight_only "$base" "$txn" >"$base/out" 2>"$base/err"; then
     fail "commit preflight accepted an absent target recreated by a third party"
 fi
-grep -qF "file transaction destination no longer matches its committed object: $target" "$base/err" \
+grep -qF "A file changed while the installer was updating it: $target" "$base/err" \
     || fail "absent changed commit refusal was not explicit"
 grep -qxF 'third-party appeared' "$target" \
     || fail "absent changed commit refusal rewrote the recreated target"
 ok "commit preflight requires exact committed post-operation objects and rejects pending or third-party rows"
+
+# A journal row can be rebound more than once before the outer transaction
+# closes.  The immediately preceding installer generation is rollback-safe
+# while a new atomic publication is pending; only the last token may commit.
+base="$(new_env txn-generation-chain)"
+txn="$base/txn"
+target="$base/xdg/data/ableton-wine/detect-theme.sh"
+mkdir -p -- "$txn" "$(dirname "$target")"
+printf 'original generation\n' > "$target"
+printf 'installer generation A\n' > "$base/generation-a"
+printf 'installer generation B\n' > "$base/generation-b"
+printf 'installer generation C\n' > "$base/generation-c"
+printf 'third-party generation\n' > "$base/third-party"
+run_isolated "$base" env ABLETON_TRANSACTION_DIR="$txn" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ableton_config_init
+    . "$1/lib/manifest.sh"
+    ableton_txn_init
+    target="$2"
+    token_a="$(ableton_regular_source_token "$3")"
+    token_b="$(ableton_regular_source_token "$4")"
+    token_c="$(ableton_regular_source_token "$5")"
+    ableton_txn_snapshot "$target"
+    ableton_txn_expect "$target" "$token_a"
+    ableton_atomic_restore_object "$3" "$target"
+    ableton_txn_expect "$target" "$token_b"
+    [ "$(cut -f4 "$6/files.tsv")" = "$token_a,$token_b" ]
+    ableton_txn_preflight_rollback_files "$6"
+    if ableton_txn_preflight_commit_files "$6" >/dev/null 2>&1; then exit 81; fi
+    ableton_atomic_restore_object "$4" "$target"
+    ableton_txn_preflight_commit_files "$6"
+    ableton_txn_expect "$target" "$token_c"
+    [ "$(cut -f4 "$6/files.tsv")" = "$token_b,$token_c" ]
+    ableton_txn_preflight_rollback_files "$6"
+    if ableton_txn_preflight_commit_files "$6" >/dev/null 2>&1; then exit 82; fi
+    ableton_atomic_restore_object "$5" "$target"
+    ableton_txn_preflight_commit_files "$6"
+    ableton_atomic_restore_object "$7" "$target"
+    if ableton_txn_preflight_commit_files "$6" >/dev/null 2>&1; then exit 83; fi
+    if ableton_txn_preflight_rollback_files "$6" >/dev/null 2>&1; then exit 84; fi
+    ableton_atomic_restore_object "$5" "$target"
+    ableton_txn_rollback_files "$6"
+' _ "$here" "$target" "$base/generation-a" "$base/generation-b" \
+    "$base/generation-c" "$txn" "$base/third-party" \
+    || fail "two-generation transaction chain rejected an installer-owned transition"
+grep -qxF 'original generation' "$target" \
+    || fail "two-generation transaction rollback did not restore the original object"
+
+base="$(new_env txn-generation-schema)"
+txn="$base/txn"
+target="$base/xdg/data/ableton-wine/detect-scale.sh"
+mkdir -p -- "$txn" "$(dirname "$target")"
+token_a="file:$(printf 'schema A\n' | sha256sum | awk '{print $1}')"
+token_b="file:$(printf 'schema B\n' | sha256sum | awk '{print $1}')"
+run_isolated "$base" env ABLETON_TRANSACTION_DIR="$txn" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ableton_config_init
+    . "$1/lib/manifest.sh"
+    ableton_txn_init
+    target="$2"
+    token_a="$3"
+    token_b="$4"
+    good=(pending absent "$token_a" "absent,$token_a" "$token_a,$token_b")
+    bad=(",$token_a" "$token_a," "$token_a,,$token_b" \
+        "$token_a,$token_a" "$token_a,$token_b,absent" \
+        "pending,$token_a" file:abc arbitrary)
+    for post in "${good[@]}"; do
+        printf "absent\\t%s\\t-\\t%s\\n" "$target" "$post" > "$5/files.tsv"
+        ableton_txn_validate_files "$5"
+    done
+    for post in "${bad[@]}"; do
+        printf "absent\\t%s\\t-\\t%s\\n" "$target" "$post" > "$5/files.tsv"
+        if ableton_txn_validate_files "$5" >/dev/null 2>&1; then exit 85; fi
+    done
+' _ "$here" "$target" "$token_a" "$token_b" "$txn" \
+    || fail "transaction generation-token schema accepted an ambiguous chain"
+ok "transaction generations keep one rollback-safe predecessor, commit only the final token, and reject ambiguous chains"
+
+# The in-process snapshot cache must include the journal identity.  Component
+# and prefix phases can switch transaction directories without starting a new
+# shell; the same target still needs an independent prestate row in each one.
+base="$(new_env txn-snapshot-cache-journal-scope)"
+first_txn="$base/first-transaction"
+second_txn="$base/second-transaction"
+target="$base/xdg/data/ableton-wine/detect-theme.sh"
+mkdir -p -- "$first_txn" "$second_txn" "$(dirname "$target")"
+printf 'shared original bytes\n' > "$target"
+# shellcheck disable=SC2016
+run_isolated "$base" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ableton_config_init
+    . "$1/lib/manifest.sh"
+    ABLETON_TRANSACTION_DIR="$3"
+    export ABLETON_TRANSACTION_DIR
+    ableton_txn_init
+    ableton_txn_snapshot "$2"
+    ABLETON_TRANSACTION_DIR="$4"
+    export ABLETON_TRANSACTION_DIR
+    ableton_txn_init
+    ableton_txn_snapshot "$2"
+' _ "$here" "$target" "$first_txn" "$second_txn" \
+    || fail "same-shell snapshot could not switch transaction journals"
+for txn in "$first_txn" "$second_txn"; do
+    [ "$(wc -l < "$txn/files.tsv")" -eq 1 ] \
+        || fail "same-shell snapshot omitted or duplicated the target in $txn"
+    backup="$(awk -F '\t' -v p="$target" '$2==p { print $3 }' "$txn/files.tsv")"
+    if [ -z "$backup" ] || ! cmp -s -- "$backup" "$target"; then
+        fail "same-shell snapshot did not preserve exact prestate in $txn"
+    fi
+done
+ok "snapshot caching is scoped by transaction directory as well as target path"
+
+# The installed-file list is disposable uninstall inventory, not integrity
+# state. Component and prefix phases may rewrite it sequentially, but neither
+# the outer core journal nor the prefix-host journal may claim it (issue #280).
+base="$(new_env shared-ownership-manifest)"
+outer="$base/outer-transaction"
+prefix_host="$outer/prefix-host"
+version_source="$base/version-source"
+pipeasio_source="$base/pipeasio-source"
+mkdir -p -- "$outer" "$prefix_host"
+printf 'component version\n' > "$version_source"
+printf '[pipeasio]\nbuffer_size = 256\n' > "$pipeasio_source"
+run_isolated "$base" env ABLETON_TRANSACTION_DIR="$outer" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ableton_config_init
+    . "$1/lib/manifest.sh"
+    ableton_mark_state_home
+    ableton_txn_init
+    ableton_install_file 644 "$2" "$ABLETON_DATA_HOME/VERSION"
+    ableton_write_ownership_manifest
+' _ "$here" "$version_source" \
+    || fail "component phase could not create the shared-manifest fixture"
+manifest="$base/xdg/state/ableton-wine/install-manifest.tsv"
+manifest_before="file:$(sha256sum -- "$manifest" | awk '{print $1}')"
+run_isolated "$base" env ABLETON_TRANSACTION_DIR="$prefix_host" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ableton_config_init
+    . "$1/lib/manifest.sh"
+    ableton_txn_init
+    ableton_install_file 600 "$2" "$XDG_CONFIG_HOME/pipeasio/config.ini" config
+    ableton_write_ownership_manifest "$3"
+' _ "$here" "$pipeasio_source" "$outer" \
+    || fail "prefix phase could not extend the shared ownership manifest"
+manifest_after="file:$(sha256sum -- "$manifest" | awk '{print $1}')"
+[ "$manifest_before" != "$manifest_after" ] \
+    || fail "prefix fixture did not exercise a real installed-file-list rewrite"
+version_target="$base/xdg/data/ableton-wine/VERSION"
+pipeasio_target="$base/xdg/config/pipeasio/config.ini"
+version_digest="$(sha256sum -- "$version_target" | awk '{print $1}')"
+pipeasio_digest="$(sha256sum -- "$pipeasio_target" | awk '{print $1}')"
+awk -F '\t' -v p="$version_target" -v d="$version_digest" \
+    '$1=="file" && $2==p && $3==d { n++ } END { exit n != 1 }' "$manifest" \
+    || fail "installed-file list lost the component VERSION row"
+awk -F '\t' -v p="$pipeasio_target" -v d="$pipeasio_digest" \
+    '$1=="config" && $2==p && $3==d { n++ } END { exit n != 1 }' "$manifest" \
+    || fail "installed-file list lost the prefix PipeASIO row"
+for journal in "$outer/files.tsv" "$prefix_host/files.tsv"; do
+    ! awk -F '\t' -v p="$manifest" '$2==p { found=1 } END { exit !found }' "$journal" \
+        || fail "installed-file list was recorded in $journal"
+done
+run_txn_commit_preflight_only "$base" "$prefix_host" \
+    || fail "prefix-host preflight rejected its own completed work"
+run_txn_commit_preflight_only "$base" "$outer" \
+    || fail "outer preflight inspected the installed-file list"
+for txn in "$prefix_host" "$outer"; do
+    run_isolated "$base" env ABLETON_TRANSACTION_DIR="$txn" bash -c '
+        set -euo pipefail
+        . "$1/lib/config.sh"
+        ableton_config_init
+        . "$1/lib/manifest.sh"
+        ableton_txn_preflight_rollback_files "$2"
+    ' _ "$here" "$txn" \
+        || fail "rollback preflight inspected installed-file inventory in $txn"
+done
+run_isolated "$base" bash "$here/setup-prefix.sh" --rollback "$outer" \
+    || fail "prefix rollback rejected the independent-inventory fixture"
+run_isolated "$base" bash "$here/install.sh" --rollback "$outer" \
+    || fail "component rollback rejected the independent-inventory fixture"
+[ ! -e "$pipeasio_target" ] && [ ! -e "$version_target" ] \
+    || fail "ordered prefix/component rollback did not restore generated-file prestate"
+[ "file:$(sha256sum -- "$manifest" | awk '{print $1}')" = "$manifest_after" ] \
+    || fail "core rollback rewound disposable installed-file inventory"
+ok "component and prefix phases share current uninstall inventory outside both journals"
+
+# A failed second inventory publication leaves the prior inventory generation
+# intact. Because neither journal owns it, that warning cannot poison core
+# commit or rollback checks.
+base="$(new_env shared-manifest-publish-failure)"
+outer="$base/outer-transaction"
+prefix_host="$outer/prefix-host"
+version_source="$base/version-source"
+pipeasio_source="$base/pipeasio-source"
+mkdir -p -- "$outer" "$prefix_host"
+printf 'component version\n' > "$version_source"
+printf '[pipeasio]\nbuffer_size = 256\n' > "$pipeasio_source"
+run_isolated "$base" env ABLETON_TRANSACTION_DIR="$outer" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ableton_config_init
+    . "$1/lib/manifest.sh"
+    ableton_mark_state_home
+    ableton_txn_init
+    ableton_install_file 644 "$2" "$ABLETON_DATA_HOME/VERSION"
+    ableton_write_ownership_manifest
+' _ "$here" "$version_source" \
+    || fail "component phase could not create the failed-manifest fixture"
+manifest="$base/xdg/state/ableton-wine/install-manifest.tsv"
+manifest_before="file:$(sha256sum -- "$manifest" | awk '{print $1}')"
+run_isolated "$base" env ABLETON_TRANSACTION_DIR="$prefix_host" \
+    INJECT_MANIFEST="$manifest" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ableton_config_init
+    . "$1/lib/manifest.sh"
+    ableton_txn_init
+    ableton_install_file 600 "$2" "$XDG_CONFIG_HOME/pipeasio/config.ini" config
+    mv()
+    {
+        [ "${@: -1}" != "$INJECT_MANIFEST" ] || return 88
+        command mv "$@"
+    }
+    set +e
+    ableton_write_ownership_manifest "$3"
+    rc=$?
+    set -e
+    [ "$rc" -ne 0 ]
+' _ "$here" "$pipeasio_source" "$outer" \
+    || fail "manifest publication failure fixture did not stop at the injected rename"
+[ "file:$(sha256sum -- "$manifest" | awk '{print $1}')" = "$manifest_before" ] \
+    || fail "failed second manifest publication changed the first generation"
+for journal in "$outer/files.tsv" "$prefix_host/files.tsv"; do
+    ! awk -F '\t' -v p="$manifest" '$2==p { found=1 } END { exit !found }' "$journal" \
+        || fail "failed inventory publication added the list to $journal"
+done
+run_txn_commit_preflight_only "$base" "$prefix_host" \
+    || fail "prefix-host commit preflight rejected work completed before manifest failure"
+run_txn_commit_preflight_only "$base" "$outer" \
+    || fail "outer commit preflight was poisoned by optional inventory failure"
+run_isolated "$base" env ABLETON_TRANSACTION_DIR="$prefix_host" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ableton_config_init
+    . "$1/lib/manifest.sh"
+    ableton_txn_preflight_rollback_files "$2"
+' _ "$here" "$prefix_host" \
+    || fail "prefix-host rollback preflight rejected completed config work"
+run_isolated "$base" env ABLETON_TRANSACTION_DIR="$outer" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ableton_config_init
+    . "$1/lib/manifest.sh"
+    ableton_txn_preflight_rollback_files "$2"
+' _ "$here" "$outer" \
+    || fail "outer rollback preflight was poisoned by optional inventory failure"
+run_isolated "$base" bash "$here/setup-prefix.sh" --rollback "$outer" \
+    || fail "prefix rollback failed after interrupted manifest publication"
+run_isolated "$base" bash "$here/install.sh" --rollback "$outer" \
+    || fail "component rollback failed after interrupted manifest publication"
+[ ! -e "$base/xdg/config/pipeasio/config.ini" ] \
+    && [ ! -e "$base/xdg/data/ableton-wine/VERSION" ] \
+    || fail "inventory warning prevented exact generated-file rollback"
+[ "file:$(sha256sum -- "$manifest" | awk '{print $1}')" = "$manifest_before" ] \
+    || fail "rollback changed the prior installed-file inventory generation"
+ok "failed installed-file-list publication leaves prior inventory and cannot poison core checks"
 
 for corrupt_kind in symlink-dir orphan-slot; do
     base="$(new_env "persistent-prestate-$corrupt_kind")"
@@ -2438,7 +4038,8 @@ for corrupt_kind in symlink-dir orphan-slot; do
     txn="$base/txn"
     target="$base/xdg/data/ableton-wine/detect-scale.sh"
     mkdir -p -- "$state" "$txn" "$(dirname "$target")"
-    printf 'foreign target sentinel\n' > "$target"
+    printf 'format=1\nowner=ableton-linux\n' > "$state/.ableton-linux-state"
+    cp -- "$here/detect-scale.sh" "$target"
     printf 'replacement bytes\n' > "$base/replacement"
     if [ "$corrupt_kind" = symlink-dir ]; then
         mkdir -p -- "$base/external-prestate-dir"
@@ -2451,38 +4052,47 @@ for corrupt_kind in symlink-dir orphan-slot; do
         printf 'external orphan sentinel\n' > "$base/external-orphan"
         ln -s -- "$base/external-orphan" "$state/install-prestate/$id"
     fi
-    if run_guarded_file_install "$base" "$txn" "$target" \
-        >"$base/out" 2>"$base/err"; then
-        fail "file install accepted persistent prestate $corrupt_kind"
-    fi
-    grep -qxF 'foreign target sentinel' "$target" \
-        || fail "persistent prestate $corrupt_kind refusal overwrote the live target"
+    run_guarded_file_install "$base" "$txn" "$target" \
+        >"$base/out" 2>"$base/err" \
+        || fail "repair install consulted stale persistent prestate $corrupt_kind"
+    grep -qxF 'replacement bytes' "$target" \
+        || fail "stale persistent prestate $corrupt_kind blocked the canonical replacement"
+    run_txn_commit_preflight_only "$base" "$txn" \
+        || fail "stale persistent prestate $corrupt_kind poisoned commit preflight"
     if [ "$corrupt_kind" = symlink-dir ]; then
         grep -qxF 'external prestate directory sentinel' \
             "$base/external-prestate-dir/sentinel" \
-            || fail "persistent prestate symlink-directory refusal changed its referent"
+            || fail "repair install changed a stale prestate symlink referent"
     else
         grep -qxF 'external orphan sentinel' "$base/external-orphan" \
-            || fail "persistent orphan-slot refusal changed its referent"
+            || fail "repair install changed a stale orphan backup referent"
     fi
 done
-ok "persistent prestate rejects symlink directories and unindexed exact backup slots"
+ok "repair installs ignore stale persistent prestate while leaving legacy recovery objects untouched"
 
 base="$(new_env atomic-install-failure)"
 txn="$base/txn"
-target="$base/xdg/data/ableton-wine/install-target"
-mkdir -p -- "$txn" "$base/fakebin" "$(dirname "$target")"
+state="$base/xdg/state/ableton-wine"
+target="$base/xdg/data/ableton-wine/detect-scale.sh"
+mkdir -p -- "$txn" "$base/fakebin" "$state" "$(dirname "$target")"
+printf 'format=1\nowner=ableton-linux\n' > "$state/.ableton-linux-state"
 printf 'stable original bytes\n' > "$base/source"
 cp -- "$base/source" "$target"
+printf 'file\t%s\t%s\n' "$target" \
+    "$(sha256sum -- "$target" | awk '{print $1}')" \
+    > "$state/install-manifest.tsv"
 cat > "$base/fakebin/install" <<'EOF'
 #!/bin/bash
 target="${@: -1}"
+: > "${ABLETON_TEST_INSTALL_CALLED:?}"
 printf 'partial replacement\n' > "$target"
 exit 99
 EOF
 chmod 755 "$base/fakebin/"*
 # shellcheck disable=SC2016
-if run_isolated "$base" env PATH="$base/fakebin:$PATH" ABLETON_TRANSACTION_DIR="$txn" bash -c '
+if run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_TRANSACTION_DIR="$txn" \
+    ABLETON_TEST_INSTALL_CALLED="$base/install-called" bash -c '
     set -euo pipefail
     . "$1/lib/config.sh"
     ableton_config_init
@@ -2492,24 +4102,158 @@ if run_isolated "$base" env PATH="$base/fakebin:$PATH" ABLETON_TRANSACTION_DIR="
 ' _ "$here" "$base/source" "$target" >"$base/out" 2>"$base/err"; then
     fail "install helper unexpectedly succeeded after its staged writer failed"
 fi
+[ -e "$base/install-called" ] \
+    || fail "atomic install failure fixture never reached the staged writer"
 grep -qxF 'stable original bytes' "$target" \
     || fail "install helper destroyed the original target after a staged write failure"
 ok "atomic file installers keep the original target when a staged write fails"
+
+# Refreshing already-owned generated files does not create new persistent
+# prestate. Faults aimed at that legacy path therefore never fire, and ordinary
+# transaction rollback still restores both prior managed generations.
+for failure in backup-copy index-publish; do
+    base="$(new_env "prestate-second-generation-$failure")"
+    txn="$base/txn"
+    state="$base/xdg/state/ableton-wine"
+    prestate_dir="$state/install-prestate"
+    first="$base/xdg/data/ableton-wine/detect-theme.sh"
+    second="$base/xdg/data/ableton-wine/detect-scale.sh"
+    mkdir -p -- "$txn" "$state" "$(dirname "$first")"
+    printf 'format=1\nowner=ableton-linux\n' > "$state/.ableton-linux-state"
+    printf 'first user original\n' > "$first"
+    printf 'second user original\n' > "$second"
+    cp -- "$first" "$base/first.original"
+    cp -- "$second" "$base/second.original"
+    printf 'file\t%s\t%s\nfile\t%s\t%s\n' \
+        "$first" "$(sha256sum -- "$first" | awk '{print $1}')" \
+        "$second" "$(sha256sum -- "$second" | awk '{print $1}')" \
+        > "$state/install-manifest.tsv"
+    printf 'first installer replacement\n' > "$base/first.replacement"
+    printf 'second installer replacement\n' > "$base/second.replacement"
+    # shellcheck disable=SC2016
+    run_isolated "$base" env ABLETON_TRANSACTION_DIR="$txn" \
+        INJECT_PRESTATE_FAILURE="$failure" bash -c '
+        set -euo pipefail
+        . "$1/lib/config.sh"
+        ableton_config_init
+        . "$1/lib/manifest.sh"
+        ableton_txn_init
+        ableton_install_file 644 "$4" "$2"
+        injection_marker="$7"
+        cp()
+        {
+            if [ "$INJECT_PRESTATE_FAILURE" = backup-copy ]; then
+                case "${@: -1}" in
+                    "$ABLETON_STATE_HOME/install-prestate/.ableton-restore."*)
+                        : > "$injection_marker"
+                        return 88 ;;
+                esac
+            fi
+            command cp "$@"
+        }
+        mv()
+        {
+            if [ "$INJECT_PRESTATE_FAILURE" = index-publish ] \
+               && [ "${@: -1}" = "$ABLETON_STATE_HOME/install-prestate.tsv" ]; then
+                : > "$injection_marker"
+                return 88
+            fi
+            command mv "$@"
+        }
+        ableton_install_file 644 "$5" "$3"
+        [ ! -e "$injection_marker" ]
+        ableton_txn_preflight_commit_files "$6"
+        ableton_txn_preflight_rollback_files "$6"
+    ' _ "$here" "$first" "$second" "$base/first.replacement" \
+        "$base/second.replacement" "$txn" "$base/prestate-injection-fired" \
+        || fail "repair install reached obsolete prestate $failure publication"
+    index="$state/install-prestate.tsv"
+    [ ! -e "$index" ] && [ ! -L "$index" ] \
+        || fail "repair install created a legacy prestate index during $failure fixture"
+    [ ! -e "$prestate_dir" ] && [ ! -L "$prestate_dir" ] \
+        || fail "repair install created a legacy prestate directory during $failure fixture"
+    grep -qxF 'first installer replacement' "$first" \
+        && grep -qxF 'second installer replacement' "$second" \
+        || fail "repair install did not publish both canonical generations during $failure fixture"
+    run_txn_file_rollback "$base" "$txn" \
+        || fail "full rollback failed after ignored prestate $failure injection"
+    if ! cmp -s -- "$first" "$base/first.original" \
+       || ! cmp -s -- "$second" "$base/second.original"; then
+        fail "full rollback after ignored prestate $failure injection changed an original target"
+    fi
+done
+ok "repair installs bypass obsolete prestate publication and remain transaction-rollback-safe"
+
+# Restoring a user's saved object must be one atomic replacement. A failed
+# restore may not delete the managed live object and thereby invalidate the
+# rollback token recorded immediately beforehand.
+base="$(new_env managed-removal-restore-failure)"
+txn="$base/txn"
+state="$base/xdg/state/ableton-wine"
+target="$base/xdg/data/ableton-wine/detect-theme.sh"
+id="$(printf '%s' "$target" | sha256sum | awk '{print $1}')"
+backup="$state/install-prestate/$id"
+index="$state/install-prestate.tsv"
+mkdir -p -- "$txn" "$(dirname "$target")" "$(dirname "$backup")"
+printf 'format=1\nowner=ableton-linux\n' > "$state/.ableton-linux-state"
+printf 'managed live generation\n' > "$target"
+printf 'saved user generation\n' > "$backup"
+printf 'present\t%s\t%s\n' "$target" "$backup" > "$index"
+cp -- "$target" "$base/target.before"
+cp -- "$backup" "$base/backup.before"
+cp -- "$index" "$base/index.before"
+# shellcheck disable=SC2016
+run_isolated "$base" env ABLETON_TRANSACTION_DIR="$txn" \
+    INJECT_RESTORE_SOURCE="$backup" INJECT_RESTORE_TARGET="$target" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ableton_config_init
+    . "$1/lib/manifest.sh"
+    eval "$(declare -f ableton_atomic_restore_object \
+        | sed "1s/^ableton_atomic_restore_object/ableton_atomic_restore_object_real/")"
+    ableton_atomic_restore_object()
+    {
+        if [ "$1" = "$INJECT_RESTORE_SOURCE" ] \
+           && [ "$2" = "$INJECT_RESTORE_TARGET" ]; then
+            return 88
+        fi
+        ableton_atomic_restore_object_real "$@"
+    }
+    ableton_txn_init
+    set +e
+    ableton_remove_managed_file "$2"
+    rc=$?
+    set -e
+    [ "$rc" -ne 0 ]
+    cmp -s -- "$2" "$3"
+    ableton_txn_preflight_rollback_files "$4"
+' _ "$here" "$target" "$base/target.before" "$txn" \
+    || fail "failed managed restore deleted its live object or poisoned rollback"
+run_txn_file_rollback "$base" "$txn" \
+    || fail "full rollback failed after the managed restore injection"
+if ! cmp -s -- "$target" "$base/target.before" \
+   || ! cmp -s -- "$backup" "$base/backup.before" \
+   || ! cmp -s -- "$index" "$base/index.before"; then
+    fail "managed restore failure rollback did not restore exact target and prestate"
+fi
+ok "failed managed-file restoration leaves the live object intact and fully rollback-safe"
 
 base="$(new_env rollback-current-config-directory)"
 make_rollback_fixture "$base"
 rm -f -- "$ROLLBACK_INSTALLER_CONFIG"
 mkdir -p -- "$ROLLBACK_INSTALLER_CONFIG"
 printf 'current config directory sentinel\n' > "$ROLLBACK_INSTALLER_CONFIG/sentinel"
-if run_user_rollback "$base" env ABLETON_TEST_REGISTRY_STICKY=0 \
-    >"$base/out" 2>"$base/err"; then
-    fail "rollback accepted a directory current installer configuration target"
-fi
-[ -f "$base/runtime/current-generation" ] \
-    && [ -f "$ROLLBACK_SAVED/previous-generation" ] \
+run_user_rollback "$base" env ABLETON_TEST_REGISTRY_STICKY=0 \
+    >"$base/out" 2>"$base/err" \
+    || fail "current installer-settings directory blocked runtime rollback"
+[ -f "$base/runtime/previous-generation" ] \
+    && [ ! -e "$ROLLBACK_SAVED" ] && [ ! -L "$ROLLBACK_SAVED" ] \
     && [ -f "$ROLLBACK_INSTALLER_CONFIG/sentinel" ] \
-    || fail "current configuration directory refusal occurred after mutation"
-ok "rollback refuses a current configuration directory without swapping the runtime"
+    && grep -qF 'buffer_size = 883' "$ROLLBACK_PIPEASIO_CONFIG" \
+    || fail "current installer-settings directory was changed or blocked the restored runtime"
+grep -qF 'The previous Wine version is restored, but its installer settings could not be restored.' \
+    "$base/err" || fail "current installer-settings directory warning was not explicit"
+ok "current installer-settings conflicts warn without blocking runtime rollback"
 
 make_legacy_project_evidence()
 {
@@ -2586,14 +4330,71 @@ if [ -z "$legacy_saved" ] || ! cmp -s -- "$legacy_saved/.ableton-linux-runtime" 
     fail "runtime update did not retain its adopted legacy generation safely"
 fi
 
+# Canonical legacy-runtime adoption is a committed safety migration, not an
+# ancillary host-file mutation. Runtime-only promotion therefore keeps its file
+# journal empty; rollback restores every original runtime object and retains the
+# newly valid ownership marker.
+base="$(new_env legacy-runtime-promotion-rollback)"
+make_legacy_default_runtime "$base"
+make_runtime_only_kit "$base"
+legacy_runtime="$base/home/.local/opt/wine-d2d1-nspa-11.13"
+cp -a -- "$legacy_runtime" "$base/legacy-runtime.before"
+txn="$base/runtime-transaction"
+private_backup="$legacy_runtime.transaction-${txn##*/}"
+mkdir -p -- "$txn"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_WINE_ROOT="$legacy_runtime" ABLETON_WINEPREFIX="$base/prefix" \
+    PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+    bash "$base/kit/scripts/install.sh" --runtime-only \
+        --transaction-dir "$txn" --yes >"$base/install.out" 2>"$base/install.err" \
+    || fail "external legacy runtime promotion fixture failed"
+[ ! -e "$legacy_runtime/legacy-sentinel" ] \
+    && [ -f "$private_backup/legacy-sentinel" ] \
+    && [ -f "$private_backup/.ableton-linux-runtime" ] \
+    && [ -f "$txn/runtime.tsv" ] && [ -f "$txn/files.tsv" ] \
+    && [ ! -s "$txn/files.tsv" ] && [ -f "$txn/active" ] \
+    || fail "legacy runtime promotion did not preserve its adopted private generation"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_WINE_ROOT="$legacy_runtime" ABLETON_WINEPREFIX="$base/prefix" \
+    bash "$base/kit/scripts/install.sh" --preflight-rollback "$txn" \
+    >"$base/preflight.out" 2>"$base/preflight.err" \
+    || fail "legacy runtime promotion was rejected by aggregate rollback preflight"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_WINE_ROOT="$legacy_runtime" ABLETON_WINEPREFIX="$base/prefix" \
+    bash "$base/kit/scripts/install.sh" --rollback "$txn" \
+    >"$base/rollback.out" 2>"$base/rollback.err" \
+    || fail "legacy runtime promotion could not fully roll back"
+cmp -s -- "$legacy_runtime/.ableton-linux-runtime" \
+    <(printf 'format=1\nname=wine-d2d1-nspa-11.13\n') \
+    || fail "legacy runtime rollback lost its committed ownership migration"
+diff -qr --no-dereference --exclude=.ableton-linux-runtime \
+    "$base/legacy-runtime.before" "$legacy_runtime" \
+    >"$base/runtime.diff" \
+    || fail "runtime rollback changed legacy content beyond the committed marker migration"
+[ ! -e "$private_backup" ] && [ ! -L "$private_backup" ] \
+    && [ ! -e "$txn/runtime.tsv" ] && [ -f "$txn/active" ] \
+    || fail "legacy runtime rollback retained promotion state or retired the outer marker"
+ok "runtime promotion rollback preserves committed legacy adoption and restores every other runtime object"
+
 base="$(new_env legacy-runtime-uninstall)"
 make_legacy_default_runtime "$base"
 install_fake_host_tools "$base"
 run_isolated "$base" env PATH="$base/fakebin:$PATH" ABLETON_LINK_MODE=off \
     bash "$here/uninstall.sh" --keep-prefix --yes >"$base/out" 2>"$base/err" \
-    || fail "uninstall did not adopt a canonical legacy runtime"
+    || fail "optional support-state cleanup reported failure after removing a canonical legacy runtime"
 [ ! -e "$base/home/.local/opt/wine-d2d1-nspa-11.13" ] \
     || fail "uninstall retained the adopted canonical legacy runtime"
+legacy_uninstall_state="$base/xdg/state/ableton-wine"
+if [ -e "$legacy_uninstall_state" ] || [ -L "$legacy_uninstall_state" ]; then
+    [ -d "$legacy_uninstall_state" ] && [ ! -L "$legacy_uninstall_state" ] \
+        && cmp -s -- "$legacy_uninstall_state/.ableton-linux-state" \
+            <(printf 'format=1\nowner=ableton-linux\n') \
+        || fail "optional legacy-uninstall cleanup retained unsafe unmarked state"
+    grep -Eq 'Ableton Linux support (files|state).*(remain|retained)|support directory changed.*retained' \
+        "$base/out" "$base/err" \
+        || fail "retained optional legacy-uninstall state was not reported"
+fi
+ok "canonical legacy-runtime removal succeeds even when optional support-state cleanup remains"
 
 base="$(new_env legacy-partial-uninstall-retry)"
 make_legacy_default_runtime "$base"
@@ -2608,25 +4409,28 @@ printf 'file\t%s\t%s\n' "$conflict" \
     "$(sha256sum -- "$base/managed-reference" | awk '{print $1}')" \
     > "$state/install-manifest.tsv"
 install_fake_host_tools "$base"
-if run_isolated "$base" env PATH="$base/fakebin:$PATH" ABLETON_LINK_MODE=off \
-    bash "$here/uninstall.sh" --keep-prefix --yes >"$base/first.out" 2>"$base/first.err"; then
-    fail "legacy partial-uninstall fixture unexpectedly succeeded with a conflict"
-fi
-if ! cmp -s -- "$legacy_runtime/.ableton-linux-runtime" \
-        <(printf 'format=1\nname=wine-d2d1-nspa-11.13\n') \
-   || [ ! -f "$legacy_runtime/legacy-sentinel" ] \
-   || [ ! -f "$state/.ableton-linux-state" ]; then
+run_isolated "$base" env PATH="$base/fakebin:$PATH" ABLETON_LINK_MODE=off \
+    bash "$here/uninstall.sh" --keep-prefix --yes >"$base/first.out" 2>"$base/first.err" \
+    || fail "a preserved modified integration file made core legacy uninstall report failure"
+if [ -e "$legacy_runtime" ] || [ -L "$legacy_runtime" ] \
+   || ! grep -qxF 'user conflict bytes' "$conflict" \
+   || ! cmp -s -- "$state/.ableton-linux-state" \
+        <(printf 'format=1\nowner=ableton-linux\n') \
+   || [ ! -f "$state/install-manifest.tsv" ]; then
     sed -n '1,160p' "$base/first.out" >&2
     sed -n '1,160p' "$base/first.err" >&2
     find "$base" -maxdepth 6 -printf '%y %p -> %l\n' >&2
-    fail "partial legacy uninstall did not retain committed marker, runtime, and state"
+    fail "core legacy uninstall did not remove Wine while preserving the conflict and safe retry state"
 fi
+grep -qF "kept an unrecognised or user-modified file at $conflict" "$base/first.err" \
+    || fail "preserved modified integration file was not reported"
 cp -- "$base/managed-reference" "$conflict"
 run_isolated "$base" env PATH="$base/fakebin:$PATH" ABLETON_LINK_MODE=off \
     bash "$here/uninstall.sh" --keep-prefix --yes >"$base/retry.out" 2>"$base/retry.err" \
     || fail "legacy partial uninstall did not complete on retry without legacy evidence"
-[ ! -e "$legacy_runtime" ] && [ ! -e "$state" ] \
-    || fail "legacy partial-uninstall retry retained runtime or ownership state"
+[ ! -e "$conflict" ] && [ ! -e "$legacy_runtime" ] && [ ! -e "$state" ] \
+    || fail "legacy partial-uninstall retry retained the resolved conflict or ownership state"
+ok "legacy uninstall removes core Wine, preserves modified integration, and supports optional cleanup retry"
 
 base="$(new_env legacy-prefix-adopt)"
 make_legacy_default_prefix "$base"
@@ -2682,15 +4486,22 @@ external_digest="$(sha256sum -- "$external_linkd" | awk '{print $1}')"
 printf 'file\t%s\t%s\nruntime\t%s\twine-d2d1-nspa-11.13\n' \
     "$external_linkd" "$external_digest" "$base/runtime" \
     > "$base/xdg/state/ableton-wine/install-manifest.tsv"
-if run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
     ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
     ABLETON_LINKD="$external_linkd" ABLETON_LINK_MODE=off \
-    bash "$here/uninstall.sh" --keep-prefix --yes >"$base/out" 2>"$base/err"; then
-    fail "forged manifest claimed an external configured Link daemon"
-fi
+    ABLETON_TEST_REGISTRY_LOG="$base/registry.log" \
+    ABLETON_TEST_REGISTRY_STATE="$base/registry-present" \
+    bash "$here/uninstall.sh" --keep-prefix --yes >"$base/out" 2>"$base/err" \
+    || fail "forged optional inventory blocked configured runtime removal"
 grep -qxF 'external Link daemon' "$external_linkd" \
-    || fail "external Link daemon refusal happened after deletion"
-ok "configured external Link daemon can be executed but never claimed or removed"
+    || fail "forged optional inventory changed the external Link daemon"
+[ ! -e "$base/runtime" ] && [ ! -L "$base/runtime" ] \
+    && [ -f "$base/prefix/system.reg" ] && [ ! -e "$base/registry-present" ] \
+    && [ -r "$base/xdg/state/ableton-wine/install-manifest.tsv" ] \
+    || fail "forged optional inventory retained Wine or discarded its inspection record"
+grep -qF "Desktop shortcuts, file-opening settings, and older Wine runtimes were left unchanged because the installer's file list could not be trusted" \
+    "$base/err" || fail "forged optional inventory warning was not explicit"
+ok "external Link helpers are never claimed, while invalid inventory cannot retain Wine"
 
 base="$(new_env transaction-external-target)"
 txn="$base/txn"
@@ -2758,32 +4569,6 @@ grep -qxF 'new prefix' "$base/prefix/generation" \
     || fail "prefix rollback mutated layout before full preflight"
 ok "runtime and prefix rollback preflight every journal before layout mutation"
 
-base="$(new_env link-external-snapshot)"
-txn="$base/txn"
-snap="$txn/link"
-mkdir -p -- "$snap"
-printf 'off\n' > "$snap/policy"
-: > "$snap/ready"; : > "$snap/firewall.absent"; : > "$snap/unit.absent"
-: > "$snap/prestate.absent"; : > "$snap/prestate-dir.absent"
-for label in 0 1 2 3; do
-    case "$label" in
-        0) path="$base/xdg/data/ableton-wine/ableton-linkd" ;;
-        1) path="$base/xdg/data/ableton-wine/ableton-linkd.service" ;;
-        2) path="$base/xdg/data/ableton-wine/ableton-linkctl" ;;
-        3) path="$base/external/victim" ;;
-    esac
-    printf '%s\n' "$path" > "$snap/asset-$label.path"
-done
-mkdir -p -- "$base/external"
-printf 'external snapshot victim\n' > "$base/external/victim"
-if run_isolated "$base" bash "$here/setup-link.sh" preflight-rollback "$txn" \
-    >"$base/out" 2>"$base/err"; then
-    fail "Link rollback accepted an external asset snapshot path"
-fi
-grep -qxF 'external snapshot victim' "$base/external/victim" \
-    || fail "Link snapshot refusal changed its external target"
-ok "Link rollback preflights the complete canonical asset snapshot set"
-
 run_link_transaction_action()
 {
     local base="$1" action="$2" txn="$3"
@@ -2797,74 +4582,86 @@ run_link_transaction_action()
 
 base="$(new_env link-valid-snapshot)"
 txn="$base/txn"
-mkdir -p -- "$txn" "$base/runtime" "$base/prefix" "$base/xdg/data/ableton-wine"
-printf 'owned asset bytes\n' > "$base/xdg/data/ableton-wine/setup-link.sh"
+data="$base/xdg/data/ableton-wine"
+state="$base/xdg/state/ableton-wine"
+mkdir -p -- "$txn" "$base/runtime" "$base/prefix" "$data" "$state" "$base/fakebin"
+# A manager that is unavailable both before and during rollback is exact state:
+# no service command can have changed it. This keeps this fixture focused on
+# policy-file ownership rather than service-manager behavior.
+printf '#!/bin/sh\nexit 1\n' > "$base/fakebin/systemctl"
+printf '#!/bin/sh\nexit 0\n' > "$base/fakebin/xdg-mime"
+chmod 755 "$base/fakebin/systemctl" "$base/fakebin/xdg-mime"
+printf 'format=1\nowner=ableton-linux\n' > "$state/.ableton-linux-state"
+printf 'configured\n' > "$data/link-configured"
+printf 'component asset before\n' > "$data/setup-link.sh"
+printf 'file\t%s\t%s\n' "$data/setup-link.sh" \
+    "$(sha256sum -- "$data/setup-link.sh" | awk '{print $1}')" \
+    > "$state/install-manifest.tsv"
 run_link_transaction_action "$base" snapshot "$txn" >"$base/snapshot.out" 2>"$base/snapshot.err" \
     || fail "valid Link snapshot fixture could not capture a complete snapshot"
 run_link_transaction_action "$base" preflight-rollback "$txn" >"$base/preflight.out" 2>"$base/preflight.err" \
     || fail "valid complete Link snapshot was rejected by preflight"
 find "$txn/link" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort > "$base/link.members"
-[ "$(wc -l < "$base/link.members")" -eq 20 ] \
+[ "$(wc -l < "$base/link.members")" -eq 10 ] \
     || fail "valid Link snapshot did not record the full inventory"
-printf '%s\n' "$base/external/other" > "$txn/link/asset-3.path"
-if run_link_transaction_action "$base" preflight-rollback "$txn" >"$base/path.out" 2>"$base/path.err"; then
-    fail "Link preflight accepted a valid snapshot after an external asset path was forged"
+! grep -Eq '^(asset-|manifest|prestate)' "$base/link.members" \
+    || fail "Link policy snapshot duplicated component transaction state"
+! grep -Eq '^link-configured([.]absent)?$' "$base/link.members" \
+    || fail "Link policy snapshot turned disposable legacy metadata into a rollback gate"
+# Component files may advance after the policy snapshot. Link preflight must not
+# reject or later restore those generic-transaction-owned objects.
+printf 'component asset after\n' > "$data/setup-link.sh"
+printf 'file\t%s\t%s\n' "$data/setup-link.sh" \
+    "$(sha256sum -- "$data/setup-link.sh" | awk '{print $1}')" \
+    > "$state/install-manifest.tsv"
+rm -f -- "$data/link-configured"
+run_link_transaction_action "$base" preflight-rollback "$txn" \
+    >"$base/changed-preflight.out" 2>"$base/changed-preflight.err" \
+    || fail "Link policy preflight inspected component-owned files"
+run_link_transaction_action "$base" rollback "$txn" >"$base/rollback.out" 2>"$base/rollback.err" \
+    || { sed -n '1,80p' "$base/rollback.err" >&2; fail "Link policy rollback failed"; }
+[ ! -e "$data/link-configured" ] && [ ! -L "$data/link-configured" ] \
+    || fail "Link rollback recreated disposable legacy policy metadata"
+grep -qxF 'component asset after' "$data/setup-link.sh" \
+    && grep -qF "$(sha256sum -- "$data/setup-link.sh" | awk '{print $1}')" \
+        "$state/install-manifest.tsv" \
+    || fail "Link rollback rewound generic component state"
+ok "Link snapshot owns external system state without gating on disposable legacy metadata"
+
+base="$(new_env link-snapshot-inventory-tamper)"
+txn="$base/txn"
+mkdir -p -- "$txn" "$base/runtime" "$base/prefix" "$base/fakebin"
+printf '#!/bin/sh\nexit 1\n' > "$base/fakebin/systemctl"
+printf '#!/bin/sh\nexit 0\n' > "$base/fakebin/xdg-mime"
+chmod 755 "$base/fakebin/systemctl" "$base/fakebin/xdg-mime"
+run_link_transaction_action "$base" snapshot "$txn" >"$base/snapshot.out" 2>"$base/snapshot.err" \
+    || fail "Link inventory-tamper fixture could not capture its snapshot"
+: > "$txn/link/asset-0.path"
+if run_link_transaction_action "$base" preflight-rollback "$txn" >"$base/out" 2>"$base/err"; then
+    fail "Link preflight accepted a component-asset member in its policy snapshot"
 fi
-grep -qF 'Link asset snapshot path is invalid' "$base/path.err" \
-    || fail "forged Link asset snapshot path refusal was not explicit"
-ok "valid Link snapshots pass preflight and still reject forged external asset paths"
+grep -qF 'Link transaction snapshot has an unknown member: asset-0.path' "$base/err" \
+    || fail "Link policy inventory tamper refusal was not explicit"
+ok "Link policy snapshot inventory rejects component-owned members"
 
-for kind in regular symlink directory; do
-    base="$(new_env "link-live-${kind}-changed")"
-    txn="$base/txn"
-    asset="$base/xdg/data/ableton-wine/setup-link.sh"
-    mkdir -p -- "$txn" "$base/runtime" "$base/prefix" "$(dirname "$asset")"
-    printf 'owned asset bytes\n' > "$asset"
-    run_link_transaction_action "$base" snapshot "$txn" >"$base/snapshot.out" 2>"$base/snapshot.err" \
-        || fail "Link live-$kind fixture could not capture its snapshot"
-    case "$kind" in
-        regular) printf 'user edit bytes\n' > "$asset" ;;
-        symlink)
-            printf 'external asset bytes\n' > "$base/external-asset"
-            rm -f -- "$asset"
-            ln -s -- "$base/external-asset" "$asset"
-            ;;
-        directory)
-            rm -f -- "$asset"
-            mkdir -p -- "$asset"
-            printf 'directory sentinel\n' > "$asset/sentinel"
-            ;;
-    esac
-    if run_link_transaction_action "$base" preflight-rollback "$txn" >"$base/out" 2>"$base/err"; then
-        fail "Link preflight accepted a $kind current asset change"
-    fi
-    case "$kind" in
-        directory)
-            grep -qF "Link rollback destination is unsafe: $asset" "$base/err" \
-                || fail "directory Link asset refusal was not explicit"
-            grep -qxF 'directory sentinel' "$asset/sentinel" \
-                || fail "directory Link asset refusal changed the live directory"
-            ;;
-        *)
-            grep -qF "Link asset changed while rollback was pending: $asset" "$base/err" \
-                || fail "$kind Link asset refusal was not explicit"
-            ;;
-    esac
-done
-ok "Link rollback preflight rejects regular, symlink, and directory asset changes after a valid snapshot"
-
-for corrupt_kind in symlink multiline; do
+for corrupt_kind in symlink multiline valid-unmarked; do
     base="$(new_env "link-firewall-${corrupt_kind}")"
     txn="$base/txn"
     mkdir -p -- "$txn" "$base/runtime" "$base/prefix" "$base/xdg/state/ableton-wine"
     case "$corrupt_kind" in
         symlink)
+            printf 'format=1\nowner=ableton-linux\n' \
+                > "$base/xdg/state/ableton-wine/.ableton-linux-state"
             printf 'external firewall sentinel\n' > "$base/external-firewall"
             ln -s -- "$base/external-firewall" "$base/xdg/state/ableton-wine/link-firewall"
             ;;
         multiline)
+            printf 'format=1\nowner=ableton-linux\n' \
+                > "$base/xdg/state/ableton-wine/.ableton-linux-state"
             printf 'ufw-added\nextra\n' > "$base/xdg/state/ableton-wine/link-firewall"
             ;;
+        valid-unmarked)
+            printf 'ufw-added\n' > "$base/xdg/state/ableton-wine/link-firewall" ;;
     esac
     if run_link_transaction_action "$base" snapshot "$txn" >"$base/out" 2>"$base/err"; then
         fail "Link snapshot accepted a $corrupt_kind firewall state record"
@@ -2879,14 +4676,54 @@ unit_file="$base/xdg/config/systemd/user/ableton-linkd.service"
 mkdir -p -- "$txn" "$base/runtime" "$base/prefix" "$(dirname "$unit_file")"
 printf 'external unit sentinel\n' > "$base/external-unit"
 ln -s -- "$base/external-unit" "$unit_file"
-if run_link_transaction_action "$base" snapshot "$txn" >"$base/out" 2>"$base/err"; then
-    fail "Link snapshot accepted a symlinked unit file"
-fi
-grep -qF "unsafe or foreign Link unit cannot be snapshotted: $unit_file" "$base/err" \
-    || fail "unit symlink snapshot refusal was not explicit"
+run_link_transaction_action "$base" snapshot "$txn" >"$base/out" 2>"$base/err" \
+    || fail "a generated user-service collision became a Link snapshot gate"
 grep -qxF 'external unit sentinel' "$base/external-unit" \
-    || fail "unit symlink snapshot refusal changed the foreign referent"
-ok "Link snapshot rejects unsafe firewall records and foreign unit symlinks"
+    || fail "Link snapshot followed or changed a generated-path symlink"
+ok "Link snapshot rejects unsafe firewall authority without gating on generated unit files"
+
+base="$(new_env mime-postpublish-query-not-used)"
+install_fake_host_tools "$base"
+make_runtime "$base/runtime" "$base/BUILD-INFO.txt" built
+printf 'format=1\nname=wine-d2d1-nspa-11.13\n' > "$base/runtime/.ableton-linux-runtime"
+mkdir -p -- "$base/xdg/config"
+printf '[Default Applications]\nx-scheme-handler/ableton=foreign.desktop\napplication/x-unrelated=foreign-other.desktop\n' \
+    > "$base/xdg/config/mimeapps.list"
+cat > "$base/fakebin/xdg-mime" <<'EOF'
+#!/bin/sh
+set -eu
+state="${XDG_CONFIG_HOME:?}/mimeapps.list"
+case "${1:-}" in
+    query) : > "$state.query-called"; exit 91 ;;
+    default)
+        [ "$#" -ge 3 ]
+        application="$2"
+        shift 2
+        mkdir -p -- "$(dirname "$state")"
+        touch "$state"
+        for type in "$@"; do
+            awk -F '=' -v type="$type" '$1 != type' "$state" > "$state.tmp"
+            printf '%s=%s\n' "$type" "$application" >> "$state.tmp"
+            mv -- "$state.tmp" "$state"
+        done ;;
+    *) exit 2 ;;
+esac
+EOF
+chmod 755 "$base/fakebin/xdg-mime"
+run_component_install "$base" "$base/runtime" --integration-only \
+    >"$base/out" 2>"$base/err" \
+    || fail "MIME default publication aborted generated integration"
+[ ! -e "$base/xdg/config/mimeapps.list.query-called" ] \
+    || fail "MIME defaults were redundantly queried after publication"
+[ -x "$base/home/.local/bin/ableton-live" ] \
+    || fail "MIME default publication did not keep the generated launcher"
+grep -qxF 'application/x-unrelated=foreign-other.desktop' \
+    "$base/xdg/config/mimeapps.list" \
+    || fail "MIME default publication corrupted an unrelated live default"
+grep -qxF 'x-scheme-handler/ableton=io.github.shibco.ableton-linux.protocol.desktop' \
+    "$base/xdg/config/mimeapps.list" \
+    || fail "MIME default publication discarded the staged Ableton default"
+ok "MIME defaults are published once without a redundant live query"
 
 base="$(new_env mime-stage-partial-failure)"
 install_fake_host_tools "$base"
@@ -2912,14 +4749,110 @@ case "${1:-}" in
 esac
 EOF
 chmod 755 "$base/fakebin/xdg-mime"
-if run_component_install "$base" "$base/runtime" --integration-only >"$base/out" 2>"$base/err"; then
-    fail "integration succeeded after staged MIME mutation failed"
-fi
-grep -qF 'MIME association staging failed; existing associations were unchanged' "$base/err" \
-    || fail "staged MIME failure was not explicit"
+run_component_install "$base" "$base/runtime" --integration-only >"$base/out" 2>"$base/err" \
+    || fail "staged MIME failure aborted generated integration"
+grep -qF 'Could not set Ableton as the default app for Live files. Ableton itself can still be used normally.' \
+    "$base/err" || fail "staged MIME failure did not produce its plain warning"
 cmp -s -- "$base/xdg/config/mimeapps.list" <(printf '[Default Applications]\nx-scheme-handler/ableton=foreign.desktop\n') \
     || fail "staged MIME failure mutated the live mimeapps file"
-ok "MIME staging can mutate its temp copy and still leaves live associations unchanged on failure"
+[ -x "$base/home/.local/bin/ableton-live" ] \
+    || fail "staged MIME failure rolled back the generated launcher"
+ok "MIME staging failure warns, preserves live associations, and keeps generated integration"
+
+# Model an xdg-mime backend with process-external side effects: every default
+# command consumes a global serial and records it in the selected mimeapps
+# file. Defaults are prepared against one temporary copy and published once as
+# optional live state, outside the generated-file transaction journal.
+base="$(new_env mime-single-publication)"
+install_fake_host_tools "$base"
+make_runtime "$base/runtime" "$base/BUILD-INFO.txt" built
+printf 'format=1\nname=wine-d2d1-nspa-11.13\n' > "$base/runtime/.ableton-linux-runtime"
+mkdir -p -- "$base/xdg/config"
+printf '[Default Applications]\nx-scheme-handler/ableton=foreign.desktop\napplication/x-unrelated=foreign-other.desktop\n' \
+    > "$base/xdg/config/mimeapps.list"
+cp -- "$base/xdg/config/mimeapps.list" "$base/mimeapps.before"
+printf '0\n' > "$base/mime-backend-count"
+: > "$base/mime-call-log"
+cat > "$base/fakebin/xdg-mime" <<'EOF'
+#!/bin/sh
+set -eu
+state="${XDG_CONFIG_HOME:?}/mimeapps.list"
+global="${MIME_GLOBAL_STATE:?}"
+log="${MIME_CALL_LOG:?}"
+case "${1:-}" in
+    query)
+        [ "${2:-}" = default ] && [ "$#" -eq 3 ]
+        printf 'query\t%s\t%s\n' "$XDG_CONFIG_HOME" "$3" >> "$log"
+        awk -F '=' -v type="$3" '$1 == type { value=$2 } END { print value }' \
+            "$state" 2>/dev/null || true
+        ;;
+    default)
+        [ "$#" -ge 3 ]
+        application="$2"
+        shift 2
+        serial="$(cat "$global")"
+        serial=$((serial + 1))
+        printf '%s\n' "$serial" > "$global"
+        printf 'default\t%s\t%s\n' "$XDG_CONFIG_HOME" "$application" >> "$log"
+        mkdir -p -- "$(dirname "$state")"
+        touch "$state"
+        awk '$0 !~ /^# backend-serial=/' "$state" > "$state.clean"
+        mv -- "$state.clean" "$state"
+        for type in "$@"; do
+            awk -F '=' -v type="$type" '$1 != type' "$state" > "$state.tmp"
+            printf '%s=%s\n' "$type" "$application" >> "$state.tmp"
+            mv -- "$state.tmp" "$state"
+        done
+        printf '# backend-serial=%s\n' "$serial" >> "$state"
+        ;;
+    *) exit 2 ;;
+esac
+EOF
+chmod 755 "$base/fakebin/xdg-mime"
+txn="$base/mime-transaction"
+mkdir -p -- "$txn"
+export MIME_GLOBAL_STATE="$base/mime-backend-count"
+export MIME_CALL_LOG="$base/mime-call-log"
+run_component_install "$base" "$base/runtime" --integration-only \
+    --transaction-dir "$txn" >"$base/install.out" 2>"$base/install.err" \
+    || fail "transactional MIME integration failed with a serializing backend"
+unset MIME_GLOBAL_STATE MIME_CALL_LOG
+[ "$(cat "$base/mime-backend-count")" -eq 3 ] \
+    || fail "MIME integration replayed default mutations after staged publication"
+[ "$(awk -F '\t' '$1=="default" { n++ } END { print n+0 }' "$base/mime-call-log")" -eq 3 ] \
+    || fail "MIME backend saw an unexpected number of default mutations"
+awk -F '\t' -v prefix="$base/tmp/ableton-mimeapps." '
+    $1=="default" && index($2, prefix) != 1 { bad=1 }
+    END { exit bad }
+' "$base/mime-call-log" \
+    || fail "a MIME default mutation targeted the live configuration home"
+grep -qxF '# backend-serial=3' "$base/xdg/config/mimeapps.list" \
+    || fail "the staged MIME generation was not the single published live object"
+! awk -F '\t' -v p="$base/xdg/config/mimeapps.list" \
+    '$2==p { found=1 } END { exit !found }' "$txn/files.tsv" \
+    || fail "optional MIME defaults were recorded in the generated-file journal"
+run_component_install "$base" "$base/runtime" --preflight-commit "$txn" \
+    >"$base/commit-preflight.out" 2>"$base/commit-preflight.err" \
+    || fail "MIME integration rejected its own final generation at commit preflight"
+run_component_install "$base" "$base/runtime" --preflight-rollback "$txn" \
+    >"$base/rollback-preflight.out" 2>"$base/rollback-preflight.err" \
+    || fail "MIME integration rejected its own final generation at rollback preflight"
+run_component_install "$base" "$base/runtime" --rollback "$txn" \
+    >"$base/rollback.out" 2>"$base/rollback.err" \
+    || fail "generated integration could not roll back with optional MIME state present"
+grep -qxF 'application/x-unrelated=foreign-other.desktop' \
+    "$base/xdg/config/mimeapps.list" \
+    || fail "optional MIME publication or generated-file rollback corrupted an unrelated default"
+grep -qxF 'x-scheme-handler/ableton=io.github.shibco.ableton-linux.protocol.desktop' \
+    "$base/xdg/config/mimeapps.list" \
+    || fail "generated-file rollback rewound the independently published Ableton default"
+grep -qxF '# backend-serial=3' "$base/xdg/config/mimeapps.list" \
+    || fail "generated-file rollback changed the optional MIME generation"
+[ -x "$base/home/.local/bin/ableton-live" ] \
+    || fail "component rollback removed an independently completed launcher repair"
+[ -f "$txn/active" ] \
+    || fail "MIME component rollback retired its coordinator-owned active marker"
+ok "MIME defaults and completed generated files stay published across later component recovery"
 
 write_valid_managed_config()
 {
@@ -2960,6 +4893,44 @@ fi
 grep -qF 'installation configuration changed; retry the command' "$base/err" \
     || fail "configuration race refusal was not explicit"
 ok "config lock revalidates the captured configuration token before mutating anything"
+
+base="$(new_env config-mid-read-race)"
+config_path="$base/xdg/config/ableton-wine/config"
+replacement="$base/config.replacement"
+write_valid_managed_config "$config_path" "$base/runtime-a" "$base/prefix-a" \
+    "$base/xdg/data/ableton-wine/linkd-a"
+write_valid_managed_config "$replacement" "$base/runtime-b" "$base/prefix-b" \
+    "$base/xdg/data/ableton-wine/linkd-b"
+if run_isolated "$base" env \
+    ABLETON_TEST_CONFIG_TARGET="$config_path" \
+    ABLETON_TEST_CONFIG_REPLACEMENT="$replacement" \
+    ABLETON_TEST_CONFIG_TRIGGER="$base/config-replaced" \
+    bash -c '
+        set -euo pipefail
+        . "$1/lib/config.sh"
+        original_definition="$(declare -f ableton_config_file_value)"
+        eval "${original_definition/ableton_config_file_value/ableton_config_file_value_original}"
+        ableton_config_file_value()
+        {
+            local wanted="$1" value status=0
+            value="$(ableton_config_file_value_original "$wanted")" || status=$?
+            if [ "$wanted" = runtime_root ] && [ ! -e "${ABLETON_TEST_CONFIG_TRIGGER:?}" ]; then
+                mv -T -- "${ABLETON_TEST_CONFIG_REPLACEMENT:?}" \
+                    "${ABLETON_TEST_CONFIG_TARGET:?}"
+                : > "${ABLETON_TEST_CONFIG_TRIGGER:?}"
+            fi
+            printf "%s\n" "$value"
+            return "$status"
+        }
+        ableton_config_init
+    ' _ "$here" >"$base/out" 2>"$base/err"; then
+    fail "config init accepted values mixed across two atomic file generations"
+fi
+[ -e "$base/config-replaced" ] \
+    || fail "mid-read configuration replacement fixture did not fire"
+grep -qF 'installation configuration changed while it was being read; retry the command' \
+    "$base/err" || fail "mid-read configuration race refusal was not explicit"
+ok "config parsing binds every resolved field to one file generation"
 
 for corrupt_kind in truncated duplicate symlink; do
     base="$(new_env "config-${corrupt_kind}")"
@@ -3011,6 +4982,59 @@ EOF
 done
 ok "strict managed-config validation rejects truncated, duplicate, and symlinked configs"
 
+base="$(new_env link-defaultable-config-repair)"
+install_fake_host_tools "$base"
+config_path="$base/xdg/config/ableton-wine/config"
+mkdir -p -- "$(dirname "$config_path")"
+cat > "$config_path" <<EOF
+# ableton-linux installer configuration; managed by the installer
+format=1
+runtime_root=$base/runtime
+prefix=$base/prefix
+link_mode=session
+EOF
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    bash "$here/setup-link.sh" disable >"$base/out" 2>"$base/err" \
+    || fail "missing defaultable installer settings blocked Link disable"
+run_isolated "$base" bash -c '
+    set -euo pipefail
+    . "$1/lib/config.sh"
+    ableton_config_init strict
+    ableton_managed_config_valid "$ABLETON_CONFIG_FILE"
+' _ "$here" || fail "Link disable did not rebuild a valid installer configuration"
+grep -qxF 'link_mode=off' "$config_path" \
+    && grep -qxF "linkd=$base/xdg/data/ableton-wine/ableton-linkd" "$config_path" \
+    || fail "Link disable did not default and save the missing installer settings"
+ok "missing defaultable settings cannot gate a direct Link change"
+
+base="$(new_env prefix-defaultable-config-repair)"
+config_path="$base/xdg/config/ableton-wine/config"
+mkdir -p -- "$(dirname "$config_path")" "$base/prefix"
+cat > "$config_path" <<EOF
+# ableton-linux installer configuration; managed by the installer
+format=1
+runtime_root=$base/runtime
+prefix=$base/prefix
+link_mode=off
+EOF
+printf 'WINE REGISTRY Version 2\n' > "$base/prefix/system.reg"
+cat > "$base/hide-cabextract.bash" <<'EOF'
+command()
+{
+    if [ "${1:-}" = -v ] && [ "${2:-}" = cabextract ]; then return 1; fi
+    builtin command "$@"
+}
+EOF
+run_isolated "$base" env BASH_ENV="$base/hide-cabextract.bash" \
+    ABLETON_RUNTIME_PENDING=1 \
+    bash "$here/setup-prefix.sh" --refresh --validate >"$base/out" 2>"$base/err" \
+    || fail "unused cabextract or missing default settings blocked prefix refresh validation"
+grep -qF -- '-- Wine prefix settings are valid' "$base/out" \
+    || fail "direct prefix validation did not reach its successful result"
+grep -qxF "runtime_root=$base/runtime" "$config_path" \
+    || fail "prefix validation changed the project settings it only needed to read"
+ok "unused cabextract and missing default settings cannot gate prefix refresh validation"
+
 base="$(new_env legacy-shortcut-state)"
 state="$base/xdg/state/ableton-wine"
 mkdir -p -- "$state"
@@ -3043,7 +5067,7 @@ run_isolated "$base" env PATH="$base/fakebin:$PATH" \
     bash "$base/kit/scripts/installer.sh" plan runtime install \
     --runtime-root "$base/runtime" --yes >"$base/out" 2>"$base/err" \
     || fail "public runtime plan failed"
-[ "$(grep -c '^== validate runtime payload:' "$base/out")" -eq 1 ] \
+[ "$(grep -c '^== Check the Wine package:' "$base/out")" -eq 1 ] \
     || fail "public runtime plan validates and extracts its payload more than once"
 if find "$base/tmp" -mindepth 1 -maxdepth 1 \
     \( -name 'ableton-install-plan.*' -o -name 'ableton-runtime-validate.*' \) \
@@ -3053,6 +5077,79 @@ fi
 [ ! -e "$base/xdg/state" ] \
     || fail "public runtime plan created persistent installer state"
 ok "public runtime plans retire validation transactions and extracted payloads"
+
+base="$(new_env plan-temp-cleanup-warning)"
+make_runtime_only_kit "$base"
+cat > "$base/refuse-preview-cleanup.bash" <<'EOF'
+rm()
+{
+    local argument
+    for argument in "$@"; do
+        case "$argument" in
+            */ableton-install-plan.*|*/ableton-runtime-validate.*) return 73 ;;
+        esac
+    done
+    command rm "$@"
+}
+EOF
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    BASH_ENV="$base/refuse-preview-cleanup.bash" \
+    PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+    bash "$base/kit/scripts/installer.sh" plan runtime install \
+        --runtime-root "$base/runtime" --yes >"$base/out" 2>"$base/err" \
+    || fail "private scratch cleanup failure changed a successful runtime plan"
+grep -qF 'Checks finished, but temporary files remain at' "$base/err" \
+    || fail "runtime plan scratch residue was not reported"
+if ! find "$base/tmp" -mindepth 1 -maxdepth 1 \
+    \( -name 'ableton-install-plan.*' -o -name 'ableton-runtime-validate.*' \) \
+    -print -quit | grep -q .; then
+    fail "runtime plan cleanup failure fixture did not retain its injected scratch path"
+fi
+ok "runtime plan success is independent of private scratch cleanup"
+
+# A failed check is still only a check: it has no installed files to restore
+# and must not manufacture a recovery record or rollback report.
+for preview_kind in public-plan direct-validate; do
+    base="$(new_env "failed-preview-${preview_kind}")"
+    make_runtime_only_kit "$base"
+    cat > "$base/fakebin/readelf" <<'EOF'
+#!/bin/sh
+cat <<'OUT'
+  Shared library: [libusb-1.0.so.0]
+  Shared library: [libpipewire-0.3.so.0]
+  Shared library: [libgstreamer-1.0.so.0]
+OUT
+exit 93
+EOF
+    chmod 755 "$base/fakebin/readelf"
+    if [ "$preview_kind" = public-plan ]; then
+        preview_command=(bash "$base/kit/scripts/installer.sh" plan runtime install
+            --runtime-root "$base/runtime" --yes)
+    else
+        preview_command=(bash "$base/kit/scripts/install.sh" --runtime-only --validate)
+    fi
+    if run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+        ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
+        PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+        "${preview_command[@]}" > "$base/out" 2> "$base/err"; then
+        fail "$preview_kind ignored a failed runtime check"
+    fi
+    grep -qF 'runtime Push bridge dependency validation failed' "$base/err" \
+        || fail "$preview_kind replaced the failed check's original cause"
+    if grep -qF 'Earlier files were restored' "$base/err" \
+       || grep -qF 'Restoring the files from before this attempt' "$base/err"; then
+        fail "$preview_kind reported rollback for a check that changed no installed files"
+    fi
+    if find "$base" -name FAILURE -print -quit | grep -q .; then
+        fail "$preview_kind wrote an installation failure record for a check"
+    fi
+    if find "$base/tmp" -mindepth 1 -maxdepth 1 \
+        \( -name 'ableton-install-plan.*' -o -name 'ableton-runtime-validate.*' \) \
+        -print -quit | grep -q .; then
+        fail "$preview_kind leaked its failed-check scratch files"
+    fi
+done
+ok "failed runtime checks preserve their cause without fake rollback or recovery state"
 
 base="$(new_env rollback-literal-pipeasio-symlink)"
 make_rollback_fixture "$base"
@@ -3128,6 +5225,43 @@ for race_kind in public-runtime direct-link; do
 done
 ok "public and direct mutators refuse a configuration changed before lock acquisition"
 
+base="$(new_env config-repair-race)"
+config_path="$base/xdg/config/ableton-wine/config"
+mkdir -p -- "$(dirname "$config_path")"
+cat > "$config_path" <<EOF
+# ableton-linux installer configuration; managed by the installer
+format=1
+runtime_root=$base/old-runtime
+prefix=$base/custom-prefix
+obsolete=first-generation
+EOF
+replacement="$base/config.replacement"
+cat > "$replacement" <<EOF
+# ableton-linux installer configuration; managed by the installer
+format=1
+runtime_root=$base/replaced-runtime
+prefix=$base/replaced-prefix
+obsolete=second-generation
+EOF
+install_config_race_flock "$base"
+make_runtime_only_kit "$base"
+if run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    PROBE_CLIENT=1.4.2 PROBE_DAEMON=1.4.2 \
+    ABLETON_TEST_FLOCK_MUTATED="$base/flock-mutated" \
+    ABLETON_TEST_CONFIG_REPLACEMENT="$replacement" \
+    ABLETON_TEST_CONFIG_TARGET="$config_path" \
+    bash "$base/kit/scripts/installer.sh" runtime install \
+        --runtime-root "$base/runtime" --yes >"$base/out" 2>"$base/err"; then
+    fail "repair mode accepted a malformed config replaced before lock acquisition"
+fi
+[ -e "$base/flock-mutated" ] \
+    || fail "malformed-config lock-race fixture did not replace its generation"
+grep -qF 'installation configuration changed; retry the command' "$base/err" \
+    || fail "malformed-config generation race did not report an exact retry"
+[ ! -e "$base/runtime" ] \
+    || fail "malformed-config generation race reached runtime promotion"
+ok "repair mode binds salvaged values to one generation before any core mutation"
+
 base="$(new_env inherited-lock-daemon)"
 linkd="$base/xdg/data/ableton-wine/ableton-linkd"
 mkdir -p -- "$(dirname "$linkd")"
@@ -3199,6 +5333,16 @@ case "${1:-}" in
         : > "$2/component-backup"
         : > "$2/prefix-backup"
         ;;
+    enable)
+        if [ "${ABLETON_TEST_WRITE_LINK_CONFIG:-0}" -eq 1 ]; then
+            mkdir -p -- "$(dirname "${ABLETON_CONFIG_FILE:?}")"
+            printf '# ableton-linux installer configuration; managed by the installer\nformat=1\nruntime_root=%s\nprefix=%s\nlive_major=%s\nlink_mode=%s\nlinkd=%s\n' \
+                "${ABLETON_WINE_ROOT:?}" "${ABLETON_WINEPREFIX:?}" \
+                "${ABLETON_LIVE_VERSION:-}" "${ABLETON_LINK_MODE:?}" \
+                "${ABLETON_LINKD:?}" > "$ABLETON_CONFIG_FILE"
+            : > "${ABLETON_TEST_CONFIG_RECHECK_MARKER:?}"
+        fi
+        ;;
     preflight-commit)
         if [ "${ABLETON_TEST_FAIL_COMMIT_DOMAIN:-}" = link ]; then
             echo '!! injected Link commit preflight failure' >&2
@@ -3242,11 +5386,59 @@ for fail_domain in prefix link; do
 done
 ok "outer commit preflights every domain before retiring any rollback material"
 
+# The Link helper owns the write and postcondition for its saved setting. The
+# parent must not add another checksum/read gate after the requested Link action
+# has already succeeded.
+base="$(new_env link-parent-config-recheck)"
+make_commit_preflight_kit "$base"
+call_log="$base/calls.log"
+: > "$call_log"
+mkdir -p -- "$base/fakebin"
+real_sha256sum="$(command -v sha256sum)"
+cat > "$base/fakebin/sha256sum" <<EOF
+#!/bin/sh
+if [ -e "\${ABLETON_TEST_CONFIG_RECHECK_MARKER:-}" ]; then
+    case "\${1:-}" in
+        --) checked="\${2:-}" ;;
+        *) checked="\${1:-}" ;;
+    esac
+    if [ "\$checked" = "\${ABLETON_CONFIG_FILE:-}" ]; then
+        /bin/rm -f -- "\$ABLETON_TEST_CONFIG_RECHECK_MARKER"
+        exit 73
+    fi
+fi
+exec "$real_sha256sum" "\$@"
+EOF
+chmod 755 "$base/fakebin/sha256sum"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_TEST_CALL_LOG="$call_log" \
+    ABLETON_TEST_WRITE_LINK_CONFIG=1 \
+    ABLETON_TEST_CONFIG_RECHECK_MARKER="$base/recheck-ready" \
+    bash "$base/commit-kit/scripts/installer.sh" link enable --mode=session \
+    > "$base/out" 2> "$base/err" \
+    || fail "parent settings handling invented a failure after Link succeeded"
+grep -qxF 'link_mode=session' "$base/xdg/config/ableton-wine/config" \
+    || fail "Link helper did not publish the selected saved setting"
+[ -e "$base/recheck-ready" ] \
+    || fail "parent redundantly re-read the Link helper's generated setting"
+! grep -qF 'saved setting could not be rechecked' "$base/err" \
+    || fail "parent printed a redundant saved-setting diagnostic"
+grep -qxF 'OK: Ableton Link is enabled (session)' "$base/out" \
+    || fail "parent settings handling hid the successful Link outcome"
+if grep -Eq -- '--rollback |^link rollback ' "$call_log"; then
+    fail "parent settings handling rolled back a successful Link action"
+fi
+ok "the parent adds no generated-setting gate after successful Link setup"
+
 make_pr182_custom_link_fixture()
 {
     local base="$1" mode="$2" data state config custom digest id backup
     make_runtime_only_kit "$base"
     install_fake_host_tools "$base"
+    # Model an unavailable user manager; Link disable must still complete from
+    # its file/config state.
+    printf '#!/bin/sh\nexit 1\n' > "$base/fakebin/systemctl"
+    chmod 755 "$base/fakebin/systemctl"
     cp -- "$here/setup-link.sh" "$here/ableton-linkctl" \
         "$here/ableton-linkd.service" "$base/kit/scripts/"
     cat > "$base/kit/bin/ableton-linkd" <<'EOF'
@@ -3289,6 +5481,16 @@ EOF
             printf 'present\t%s\t%s\n' "$custom" "$backup" \
                 > "$state/install-prestate.tsv"
             ;;
+        owned-stale-prestate)
+            # Recognition is still backed by the exact PR182 release evidence,
+            # but the old restoration journal is deliberately unusable. The
+            # helper must stay live while canonical Link support is repaired.
+            printf 'file\t%s\t%s\n' "$custom" "$digest" > "$state/install-manifest.tsv"
+            mkdir -p -- "$state/install-prestate"
+            printf 'stale recovery sentinel\n' > "$state/install-prestate/not-a-valid-slot"
+            printf 'present\t%s\t/tmp/untrusted-pr182-backup\n' "$custom" \
+                > "$state/install-prestate.tsv"
+            ;;
         modified)
             printf 'file\t%s\t%s\n' "$custom" "$digest" > "$state/install-manifest.tsv"
             printf 'user modified former PR182 Link binary\n' > "$custom"
@@ -3309,7 +5511,78 @@ EOF
     PR182_CONFIG="$config"
 }
 
-for migration_mode in owned-prestate modified unowned-off; do
+# Publishing generated Link support files does not need to stop or restart a
+# running daemon. The following controller deliberately fails if invoked: the
+# file update must still succeed, leaving lifecycle changes to setup-link.sh.
+base="$(new_env link-assets-ignore-running-state)"
+make_pr182_custom_link_fixture "$base" unowned-off
+canonical="$base/xdg/data/ableton-wine/ableton-linkd"
+cp -- "$base/kit/bin/ableton-linkd" "$canonical"
+chmod 755 "$canonical"
+cat > "$base/kit/scripts/ableton-linkctl" <<'EOF'
+#!/bin/sh
+: > "${ABLETON_TEST_LINKCTL_CALLED:?}"
+exit 73
+EOF
+chmod 755 "$base/kit/scripts/ableton-linkctl"
+txn="$base/link-assets-transaction"
+mkdir -p -- "$txn"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_LINKD="$canonical" \
+    ABLETON_TEST_LINKCTL_CALLED="$base/link-controller-called" \
+    bash "$base/kit/scripts/install.sh" --link-assets-only \
+        --transaction-dir "$txn" >"$base/out" 2>"$base/err" \
+    || fail "running Link state became a generated-file update gate"
+[ ! -e "$base/link-controller-called" ] \
+    || fail "Link asset publication invoked the lifecycle controller"
+[ -x "$canonical" ] \
+    && [ -x "$base/xdg/data/ableton-wine/ableton-linkctl" ] \
+    && [ -x "$base/xdg/data/ableton-wine/setup-link.sh" ] \
+    && [ -f "$base/xdg/data/ableton-wine/ableton-linkd.service" ] \
+    || fail "Link asset publication did not replace its generated files"
+ok "Link support files are replaced without a lifecycle failure gate"
+
+# A repair that still needs Link support enters install.sh with the narrowly
+# proven historical custom path already canonicalized by the coordinator. Bad
+# legacy restoration data may prevent retirement, but must not block canonical
+# support or mutate the custom helper.
+base="$(new_env pr182-custom-link-stale-repair)"
+make_pr182_custom_link_fixture "$base" owned-stale-prestate
+custom="$PR182_CUSTOM_LINK"
+canonical="$base/xdg/data/ableton-wine/ableton-linkd"
+txn="$base/link-repair-transaction"
+mkdir -p -- "$txn"
+run_isolated "$base" env PATH="$base/fakebin:$PATH" \
+    ABLETON_PR182_CUSTOM_LINKD="$custom" ABLETON_LINKD="$canonical" \
+    bash "$base/kit/scripts/install.sh" --link-assets-only \
+        --transaction-dir "$txn" >"$base/out" 2>"$base/err" \
+    || fail "stale PR182 recovery data aborted canonical Link repair"
+grep -qxF 'historical PR182 Link binary' "$custom" \
+    || fail "stale PR182 recovery data changed the custom helper"
+grep -qF 'Kept the older custom Link helper because its saved recovery data could not be used safely.' \
+    "$base/err" || fail "stale PR182 recovery data did not produce its plain warning"
+grep -qxF 'stale recovery sentinel' \
+    "$(dirname "$PR182_PRESTATE_INDEX")/install-prestate/not-a-valid-slot" \
+    || fail "PR182 repair consumed an unverifiable recovery object"
+[ -x "$canonical" ] \
+    && [ -x "$base/xdg/data/ableton-wine/ableton-linkctl" ] \
+    && [ -x "$base/xdg/data/ableton-wine/setup-link.sh" ] \
+    && [ -f "$base/xdg/data/ableton-wine/ableton-linkd.service" ] \
+    || fail "stale PR182 recovery data prevented canonical Link support repair"
+if awk -F '\t' -v p="$custom" '$2==p { found=1 } END { exit !found }' \
+    "$PR182_MANIFEST"; then
+    fail "stale PR182 helper retained an obsolete ownership row after repair"
+fi
+run_component_install "$base" "$base/runtime" --preflight-commit "$txn" \
+    >"$base/preflight.out" 2>"$base/preflight.err" \
+    || fail "stale PR182 recovery data poisoned canonical Link commit preflight"
+ok "stale PR182 recovery data keeps the custom helper while canonical Link support is repaired"
+
+# Disabling Link no longer stages support files just to delete them. It keeps
+# every external custom helper and its historical recovery object untouched,
+# while pruning obsolete ownership rows and saving the canonical disabled
+# configuration for a proven PR182 release.
+for migration_mode in owned-prestate owned-stale-prestate modified unowned-off; do
     base="$(new_env "pr182-custom-link-${migration_mode}")"
     make_pr182_custom_link_fixture "$base" "$migration_mode"
     custom="$PR182_CUSTOM_LINK"
@@ -3322,21 +5595,22 @@ for migration_mode in owned-prestate modified unowned-off; do
     fi
     case "$migration_mode" in
         owned-prestate)
-            grep -qxF 'foreign pre-PR182 Link binary' "$custom" \
-                || fail "PR182 custom-Link migration did not restore the foreign prestate"
-            if [ -e "$PR182_PRESTATE_INDEX" ] \
-               && awk -F '\t' -v p="$custom" '$2==p { found=1 } END { exit !found }' \
-                    "$PR182_PRESTATE_INDEX"; then
-                fail "PR182 custom-Link migration retained consumed prestate authority"
-            fi
-            grep -qF 'retired the PR #182 custom Link binary ownership' "$base/out" \
-                || fail "owned PR182 custom-Link path did not use the verified retirement path"
+            grep -qxF 'historical PR182 Link binary' "$custom" \
+                || fail "Link disable changed the historical custom helper"
+            awk -F '\t' -v p="$custom" '$2==p { found=1 } END { exit !found }' \
+                "$PR182_PRESTATE_INDEX" \
+                || fail "Link disable consumed the custom helper's historical recovery row"
+            ;;
+        owned-stale-prestate)
+            grep -qxF 'historical PR182 Link binary' "$custom" \
+                || fail "Link disable changed the helper with stale PR182 recovery data"
+            grep -qxF 'stale recovery sentinel' \
+                "$(dirname "$PR182_PRESTATE_INDEX")/install-prestate/not-a-valid-slot" \
+                || fail "Link disable consumed an unverifiable custom recovery object"
             ;;
         modified)
             grep -qxF 'user modified former PR182 Link binary' "$custom" \
-                || fail "PR182 custom-Link migration overwrote a user-modified object"
-            grep -qF 'kept and de-owned the modified former PR #182 Link binary' "$base/out" \
-                || fail "modified PR182 custom-Link path did not use the de-ownership path"
+                || fail "Link disable overwrote a user-modified PR182 helper"
             ;;
         unowned-off)
             grep -qxF 'external Link sentinel from --link=off' "$custom" \
@@ -3351,11 +5625,16 @@ for migration_mode in owned-prestate modified unowned-off; do
     fi
     grep -qxF 'link_mode=off' "$PR182_CONFIG" \
         || fail "PR182 custom-Link mode $migration_mode did not finish disabled"
+    for generated_link_file in ableton-linkd ableton-linkctl setup-link.sh ableton-linkd.service; do
+        [ ! -e "$base/xdg/data/ableton-wine/$generated_link_file" ] \
+            && [ ! -L "$base/xdg/data/ableton-wine/$generated_link_file" ] \
+            || fail "Link disable retained canonical support file $generated_link_file"
+    done
     if [ "$migration_mode" != unowned-off ]; then
         grep -qxF "linkd=$base/xdg/data/ableton-wine/ableton-linkd" "$PR182_CONFIG" \
             || fail "verified PR182 custom-Link ownership was not migrated to the canonical path"
     fi
 done
-ok "PR182 custom-Link migration restores owned prestate, de-owns edits, and preserves --link=off paths"
+ok "Link disable preserves PR182 custom helpers while removing canonical support and stale ownership rows"
 
 printf 'PASS: %s focused PipeASIO installer checks\n' "$pass"

--- a/scripts/test-release-policy.sh
+++ b/scripts/test-release-policy.sh
@@ -37,6 +37,47 @@ rejects()
     fi
 }
 
+set +e
+(
+    set +o pipefail
+    config_lib="$root/scripts/lib/config.sh"
+    # shellcheck disable=SC1090
+    . "$config_lib"
+    export ABLETON_CONFIG_FILE="$tmp/missing-config" \
+        ABLETON_WINE_ROOT="$tmp/runtime-root" ABLETON_WINEPREFIX="$tmp/prefix" \
+        ABLETON_LINKD="$tmp/linkd" ABLETON_LINK_MODE=off \
+        ABLETON_DATA_HOME="$tmp/data" ABLETON_CONFIG_HOME="$tmp/config" \
+        ABLETON_STATE_HOME="$tmp/state" ABLETON_CACHE_HOME="$tmp/cache" \
+        ABLETON_BIN_HOME="$tmp/bin"
+    sha256sum() { return 91; }
+    ableton_config_snapshot_capture absent
+)
+snapshot_rc=$?
+set -e
+[ "$snapshot_rc" -eq 1 ] \
+    || fail "configuration snapshot capture returned $snapshot_rc for a value-hash failure without pipefail"
+set +e
+(
+    set +o pipefail
+    config_lib="$root/scripts/lib/config.sh"
+    # shellcheck disable=SC1090
+    . "$config_lib"
+    export ABLETON_CONFIG_FILE="$tmp/missing-config" \
+        ABLETON_WINE_ROOT="$tmp/runtime-root" ABLETON_WINEPREFIX="$tmp/prefix" \
+        ABLETON_LINKD="$tmp/linkd" ABLETON_LINK_MODE=off \
+        ABLETON_DATA_HOME="$tmp/data" ABLETON_CONFIG_HOME="$tmp/config" \
+        ABLETON_STATE_HOME="$tmp/state" ABLETON_CACHE_HOME="$tmp/cache" \
+        ABLETON_BIN_HOME="$tmp/bin"
+    ableton_config_snapshot_capture absent || exit 90
+    sha256sum() { return 91; }
+    ableton_config_snapshot_verify
+)
+snapshot_rc=$?
+set -e
+[ "$snapshot_rc" -eq 1 ] \
+    || fail "configuration snapshot verification returned $snapshot_rc for a value-hash failure without pipefail"
+printf 'ok - configuration snapshot hash failures propagate without caller pipefail\n'
+
 printf 'dist-version: 2026.08.12.1\nsource-tree: %s\ncabextract-static: %s\nableton-linkd: %s\n%s\n' \
     "$source_sha" "$cab_hash" "$link_hash" "$official" > "$tmp/official"
 accepts "$tmp/official" || fail 'exact official sanitizer record was rejected'
@@ -117,6 +158,52 @@ seal_kit()
     cat "$payload" >> "$wrapper"
     chmod +x "$wrapper"
 }
+
+cleanup_kit="$tmp/cleanup-kit"
+mkdir -p -- "$cleanup_kit/scripts" "$tmp/failing-rm" "$tmp/wrapper-tmp"
+cat > "$cleanup_kit/scripts/installer.sh" <<'EOF'
+#!/usr/bin/env bash
+printf 'installer child reached status %s\n' "${WRAPPER_TEST_STATUS:-0}"
+exit "${WRAPPER_TEST_STATUS:-0}"
+EOF
+chmod +x "$cleanup_kit/scripts/installer.sh"
+seal_kit "$cleanup_kit" "$tmp/cleanup-status.run"
+cat > "$tmp/failing-rm/rm" <<'EOF'
+#!/usr/bin/env bash
+target=""
+for target in "$@"; do :; done
+case "$target" in
+    "$WRAPPER_TEST_TMP"/ableton-installer.*) exit 91 ;;
+esac
+exec /bin/rm "$@"
+EOF
+chmod +x "$tmp/failing-rm/rm"
+
+set +e
+PATH="$tmp/failing-rm:$PATH" TMPDIR="$tmp/wrapper-tmp" \
+    WRAPPER_TEST_TMP="$tmp/wrapper-tmp" WRAPPER_TEST_STATUS=0 \
+    bash "$tmp/cleanup-status.run" > "$tmp/cleanup-zero.out" 2>&1
+cleanup_rc=$?
+set -e
+[ "$cleanup_rc" -eq 0 ] \
+    || fail "installer wrapper changed child status 0 to $cleanup_rc after scratch cleanup failed"
+grep -qF 'installer child reached status 0' "$tmp/cleanup-zero.out" \
+    || fail 'installer wrapper did not reach its child after early scratch cleanup failed'
+grep -qF '!! The installer finished, but temporary files remain at' "$tmp/cleanup-zero.out" \
+    || fail 'installer wrapper did not name retained scratch after cleanup failed'
+
+set +e
+PATH="$tmp/failing-rm:$PATH" TMPDIR="$tmp/wrapper-tmp" \
+    WRAPPER_TEST_TMP="$tmp/wrapper-tmp" WRAPPER_TEST_STATUS=37 \
+    bash "$tmp/cleanup-status.run" > "$tmp/cleanup-nonzero.out" 2>&1
+cleanup_rc=$?
+set -e
+[ "$cleanup_rc" -eq 37 ] \
+    || fail "installer wrapper changed child status 37 to $cleanup_rc after scratch cleanup failed"
+grep -qF 'installer child reached status 37' "$tmp/cleanup-nonzero.out" \
+    || fail 'installer wrapper did not preserve the failing child execution path'
+printf 'ok - installer wrapper scratch cleanup is warning-only and preserves child status\n'
+
 tar --sort=name --owner=0 --group=0 --numeric-owner \
     -cf "$tmp/payload.tar" -C "$tmp/kit" .
 payload_sha="$(sha256sum "$tmp/payload.tar" | awk '{print $1}')"

--- a/scripts/test-shortcut-hold.sh
+++ b/scripts/test-shortcut-hold.sh
@@ -141,9 +141,23 @@ values[$down]="['<Primary><Alt>Down']"
 ableton_shortcuts_prepare 'Ableton Live 12 Suite.exe'
 rm -f -- "$ableton_shortcuts_state_dir"/lease.*
 export ABLETON_SHORTCUTS_POLL_SECONDS=0.01
+install_lock_attempts=0
+install_lock_releases=0
+ableton_install_lock_acquire()
+{
+    install_lock_attempts=$((install_lock_attempts + 1))
+    [ "$install_lock_attempts" -ge 3 ]
+}
+ableton_install_lock_release()
+{
+    install_lock_releases=$((install_lock_releases + 1))
+}
 ableton_shortcuts_watch_loop
+check "watcher retries while installer owns the global lock" "$install_lock_attempts" "3"
+check "watcher releases the global lock after restoration" "$install_lock_releases" "1"
 check "watcher restores after last lease exits" "${values[$up]}" "['<Control><Alt>Up']"
 check "watcher removes completed recovery state" "$([ ! -e "$ableton_shortcuts_state" ]; echo $?)" "0"
+unset -f ableton_install_lock_acquire ableton_install_lock_release
 
 # Recovery still runs when discovery did not find a Live executable. It must
 # not start a new hold in this path, even when the opt-in variable is present.

--- a/scripts/test-uninstall-boundary.sh
+++ b/scripts/test-uninstall-boundary.sh
@@ -1,0 +1,1078 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+ABLETON_PROTOCOL_DESKTOP_ID=io.github.shibco.ableton-linux.protocol.desktop
+ABLETON_AUZ_DESKTOP_ID=io.github.shibco.ableton-linux.auz.desktop
+work="$(mktemp -d "${TMPDIR:-/tmp}/ableton-uninstall-boundary-test.XXXXXX")"
+cleanup()
+{
+    case "${work:-}" in
+        "${TMPDIR:-/tmp}"/ableton-uninstall-boundary-test.*) rm -rf -- "$work" ;;
+    esac
+}
+trap cleanup EXIT
+
+fail()
+{
+    printf 'not ok - %s\n' "$1" >&2
+    exit 1
+}
+
+pass=0
+ok()
+{
+    pass=$((pass + 1))
+    printf 'ok - %s\n' "$1"
+}
+
+kit="$work/kit/scripts"
+mkdir -p -- "$kit/lib"
+cp -- "$here/installer.sh" "$here/uninstall.sh" "$kit/"
+cp -- "$here/detect-scale.sh" "$here/detect-theme.sh" \
+    "$here/shortcut-hold.sh" "$here/check-ntsync.sh" \
+    "$here/ableton-linkctl" "$here/ableton-linkd.service" "$kit/"
+mkdir -p -- "$kit/../tools"
+cp -- "$here/../tools/setsyscolors.exe" "$here/../tools/learnheal.exe" \
+    "$kit/../tools/"
+cp -- "$here/lib/config.sh" "$here/lib/lifecycle.sh" \
+    "$here/lib/manifest.sh" "$here/lib/pipeasio.sh" "$kit/lib/"
+cat > "$kit/setup-link.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+    plan-disable) exit "${TEST_LINK_PLAN_RC:-0}" ;;
+    disable) exit "${TEST_LINK_DISABLE_RC:-0}" ;;
+    *) exit 2 ;;
+esac
+EOF
+cat > "$kit/install.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod 755 "$kit/setup-link.sh" "$kit/install.sh"
+
+new_fixture()
+{
+    local base="$work/$1"
+    mkdir -p -- "$base/home" "$base/tmp" "$base/xdg/config" \
+        "$base/xdg/data" "$base/xdg/state/ableton-wine" \
+        "$base/xdg/cache" "$base/xdg/run" "$base/runtime" "$base/fakebin"
+    printf 'format=1\nname=wine-d2d1-nspa-11.13\n' \
+        > "$base/runtime/.ableton-linux-runtime"
+    printf 'format=1\nowner=ableton-linux\n' \
+        > "$base/xdg/state/ableton-wine/.ableton-linux-state"
+    cat > "$base/fakebin/rm" <<'EOF'
+#!/usr/bin/env bash
+set -u
+for argument in "$@"; do
+    if [ "${FAIL_ADOPTION_CLEANUP:-0}" -eq 1 ]; then
+        case "$argument" in
+            */transactions/uninstall-adopt.*) exit 75 ;;
+        esac
+    fi
+    if [ -n "${CORRUPT_STATE_AFTER_TARGET:-}" ] \
+       && [ "$argument" = "$CORRUPT_STATE_AFTER_TARGET" ]; then
+        /bin/rm "$@" || exit $?
+        printf 'changed during uninstall\n' > "${CORRUPT_STATE_FILE:?}"
+        exit 0
+    fi
+    if [ -n "${FAIL_RM_TARGET:-}" ] && [ "$argument" = "$FAIL_RM_TARGET" ]; then
+        if [ "${FAIL_RM_REMOVE_FIRST:-0}" -eq 1 ]; then
+            /bin/rm "$@" || exit $?
+        fi
+        exit "${FAIL_RM_RC:-73}"
+    fi
+done
+exec /bin/rm "$@"
+EOF
+    cat > "$base/fakebin/find" <<'EOF'
+#!/usr/bin/env bash
+set -u
+for argument in "$@"; do
+    if [ -n "${FAIL_FIND_TARGET:-}" ] && [ "$argument" = "$FAIL_FIND_TARGET" ]; then
+        exit "${FAIL_FIND_RC:-74}"
+    fi
+done
+exec /usr/bin/find "$@"
+EOF
+    cat > "$base/fakebin/xdg-mime" <<'EOF'
+#!/usr/bin/env bash
+set -u
+if [ "${1:-}" = query ] && [ "${2:-}" = default ]; then
+    rc="${TEST_XDG_QUERY_RC:-0}"
+    [ "$rc" -eq 0 ] || exit "$rc"
+    printf '%s\n' "${TEST_XDG_DEFAULT:-foreign.desktop}"
+    exit 0
+fi
+if [ "${1:-}" = default ]; then
+    exit "${TEST_XDG_SET_RC:-0}"
+fi
+exit 2
+EOF
+    cat > "$base/fakebin/update-mime-database" <<'EOF'
+#!/usr/bin/env bash
+exit "${TEST_MIME_CACHE_RC:-0}"
+EOF
+    cat > "$base/fakebin/update-desktop-database" <<'EOF'
+#!/usr/bin/env bash
+exit "${TEST_DESKTOP_CACHE_RC:-0}"
+EOF
+    cat > "$base/fakebin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod 755 "$base/fakebin/"*
+    printf '%s\n' "$base"
+}
+
+run_uninstall()
+{
+    local base="$1" mode="$2"
+    shift 2
+    env HOME="$base/home" \
+        XDG_CONFIG_HOME="$base/xdg/config" \
+        XDG_DATA_HOME="$base/xdg/data" \
+        XDG_STATE_HOME="$base/xdg/state" \
+        XDG_CACHE_HOME="$base/xdg/cache" \
+        XDG_RUNTIME_DIR="$base/xdg/run" \
+        TMPDIR="$base/tmp" \
+        PATH="$base/fakebin:$PATH" \
+        ABLETON_WINE_ROOT="$base/runtime" \
+        ABLETON_WINEPREFIX="$base/prefix" \
+        ABLETON_LINK_MODE=off \
+        ABLETON_SHORTCUTS=preserve \
+        "$@" bash "$kit/uninstall.sh" "$mode" --yes
+}
+
+run_integration_install()
+{
+    local base="$1"
+    env HOME="$base/home" \
+        XDG_CONFIG_HOME="$base/xdg/config" \
+        XDG_DATA_HOME="$base/xdg/data" \
+        XDG_STATE_HOME="$base/xdg/state" \
+        XDG_CACHE_HOME="$base/xdg/cache" \
+        XDG_RUNTIME_DIR="$base/xdg/run" \
+        TMPDIR="$base/tmp" \
+        PATH="$base/fakebin:$PATH" \
+        ABLETON_WINE_ROOT="$base/runtime" \
+        ABLETON_WINEPREFIX="$base/prefix" \
+        ABLETON_LINK_MODE=off \
+        ABLETON_SHORTCUTS=preserve \
+        bash "$here/install.sh" --integration-only
+}
+
+assert_warning_contract()
+{
+    local error_file="$1" retry_expected="${2:-yes}" retry_count
+    grep -q '^!! warning:' "$error_file" \
+        || fail "optional failure did not produce a warning"
+    retry_count="$(grep -c '^   Retry:' "$error_file" || true)"
+    if [ "$retry_expected" = yes ]; then
+        [ "$retry_count" -eq 1 ] \
+            || fail "retained retry support did not print exactly one final retry command"
+    elif [ "$retry_count" -ne 0 ]; then
+        fail "advisory cleanup warning printed a retry command without retained support"
+    fi
+    if grep -Eiw 'gate|journal|generation|CAS' "$error_file" >/dev/null; then
+        fail "warning exposed internal lifecycle terminology"
+    fi
+}
+
+run_public_uninstall()
+{
+    local base="$1"
+    env HOME="$base/home" \
+        XDG_CONFIG_HOME="$base/xdg/config" \
+        XDG_DATA_HOME="$base/xdg/data" \
+        XDG_STATE_HOME="$base/xdg/state" \
+        XDG_CACHE_HOME="$base/xdg/cache" \
+        XDG_RUNTIME_DIR="$base/xdg/run" \
+        TMPDIR="$base/tmp" \
+        PATH="$base/fakebin:$PATH" \
+        ABLETON_LINK_MODE=off ABLETON_SHORTCUTS=preserve \
+        bash "$kit/installer.sh" uninstall \
+            --runtime-root "$base/runtime" --prefix "$base/prefix" \
+            --keep-prefix --yes
+}
+
+state_path()
+{
+    printf '%s/xdg/state/ableton-wine\n' "$1"
+}
+
+make_legacy_runtime_without_state()
+{
+    local base="$1" runtime pe_hash unix_hash
+    runtime="$base/home/.local/opt/wine-d2d1-nspa-11.13"
+    rm -f -- "$base/xdg/state/ableton-wine/.ableton-linux-state"
+    rmdir -- "$base/xdg/state/ableton-wine"
+    mkdir -p -- "$base/home/.local/share/ableton-wine" \
+        "$base/home/.local/bin" "$runtime/bin" \
+        "$runtime/lib/wine/x86_64-windows" \
+        "$runtime/lib/wine/x86_64-unix"
+    printf '2025.01.01.1\n' > "$base/home/.local/share/ableton-wine/VERSION"
+    printf '#!/bin/sh\n# Ableton Live launcher for the patched Wine stack\n' \
+        > "$base/home/.local/bin/ableton-live"
+    printf '#!/bin/sh\nexit 0\n' > "$runtime/bin/wine"
+    printf '#!/bin/sh\nexit 0\n' > "$runtime/bin/wineserver"
+    chmod 755 "$base/home/.local/bin/ableton-live" \
+        "$runtime/bin/wine" "$runtime/bin/wineserver"
+    printf 'legacy PE fixture\n' \
+        > "$runtime/lib/wine/x86_64-windows/pipeasio64.dll"
+    printf 'legacy Unix fixture\n' \
+        > "$runtime/lib/wine/x86_64-unix/pipeasio64.dll.so"
+    pe_hash="$(sha256sum -- "$runtime/lib/wine/x86_64-windows/pipeasio64.dll")"
+    pe_hash="${pe_hash%% *}"
+    unix_hash="$(sha256sum -- "$runtime/lib/wine/x86_64-unix/pipeasio64.dll.so")"
+    unix_hash="${unix_hash%% *}"
+    printf 'dist-version: 2025.01.01.1\npipeasio-pe: %s\npipeasio-unix: %s\n' \
+        "$pe_hash" "$unix_hash" > "$runtime/ABLETON-WINE-BUILD-INFO.txt"
+    printf '%s\n' "$runtime"
+}
+
+prepare_optional_inventory_fixture()
+{
+    local base="$1" digest state
+    state="$(state_path "$base")"
+    TEST_INVENTORY_DESKTOP="$base/xdg/data/applications/ableton-live.desktop"
+    TEST_EXTRA_RUNTIME="$base/older-recorded-runtime"
+    mkdir -p -- "$(dirname "$TEST_INVENTORY_DESKTOP")" "$TEST_EXTRA_RUNTIME" \
+        "$base/xdg/config"
+    printf 'generated desktop fixture\n' > "$TEST_INVENTORY_DESKTOP"
+    printf '[Default Applications]\nx-scheme-handler/ableton=%s\n' \
+        "$ABLETON_PROTOCOL_DESKTOP_ID" > "$base/xdg/config/mimeapps.list"
+    printf 'format=1\nname=wine-d2d1-nspa-11.13\n' \
+        > "$TEST_EXTRA_RUNTIME/.ableton-linux-runtime"
+    digest="$(sha256sum -- "$TEST_INVENTORY_DESKTOP")"
+    digest="${digest%% *}"
+    printf 'file\t%s\t%s\nruntime\t%s\twine-d2d1-nspa-11.13\n' \
+        "$TEST_INVENTORY_DESKTOP" "$digest" "$TEST_EXTRA_RUNTIME" \
+        > "$state/install-manifest.tsv"
+}
+
+# Optional installer settings cannot veto removal when the public dispatcher
+# has already supplied exact runtime/prefix paths. Runtime ownership remains
+# the deletion authority; the malformed settings are preserved for inspection.
+base="$(new_fixture malformed-installer-settings)"
+config="$base/xdg/config/ableton-wine/config"
+mkdir -p -- "$(dirname "$config")"
+printf '# ableton-linux installer configuration; managed by the installer\nformat=1\nobsolete_key=value\n' \
+    > "$config"
+cp -- "$config" "$base/config.before"
+run_public_uninstall "$base" > "$base/out" 2> "$base/err" \
+    || fail "malformed optional settings blocked public uninstall with exact targets"
+[ ! -e "$base/runtime" ] \
+    && cmp -s -- "$config" "$base/config.before" \
+    && [ -f "$(state_path "$base")/.ableton-linux-state" ] \
+    || fail "public uninstall changed malformed settings or retained the exact runtime"
+grep -qF "installer settings at $config" "$base/err" \
+    || fail "preserved malformed installer settings were not reported"
+assert_warning_contract "$base/err"
+ok "malformed optional settings cannot veto public uninstall with exact core targets"
+
+# Cache cleanup is best effort and is not used by runtime installation. A
+# non-directory cache object must therefore survive without blocking even a
+# public runtime plan.
+base="$(new_fixture cache-object-runtime-plan)"
+printf 'foreign cache object\n' > "$base/xdg/cache/ableton-wine"
+env HOME="$base/home" \
+    XDG_CONFIG_HOME="$base/xdg/config" \
+    XDG_DATA_HOME="$base/xdg/data" \
+    XDG_STATE_HOME="$base/xdg/state" \
+    XDG_CACHE_HOME="$base/xdg/cache" \
+    XDG_RUNTIME_DIR="$base/xdg/run" \
+    TMPDIR="$base/tmp" PATH="$base/fakebin:$PATH" \
+    ABLETON_WINEPREFIX="$base/prefix" ABLETON_LINK_MODE=off \
+    ABLETON_SHORTCUTS=preserve \
+    bash "$kit/installer.sh" runtime install \
+        --runtime-root "$base/runtime" --yes --dry-run \
+        > "$base/out" 2> "$base/err" \
+    || fail "foreign cache object blocked a public runtime plan"
+grep -qxF 'foreign cache object' "$base/xdg/cache/ableton-wine" \
+    || fail "public runtime plan changed the unrelated cache object"
+ok "unrelated cache objects cannot gate public runtime work"
+
+# Current installs no longer save the desktop default they replaced. Their
+# dry-run must say that only Ableton Linux defaults will be cleared, rather
+# than claiming every file-opening default will be left unchanged.
+base="$(new_fixture snapshot-free-mime-plan)"
+printf 'runtime\t%s\twine-d2d1-nspa-11.13\n' "$base/runtime" \
+    > "$(state_path "$base")/install-manifest.tsv"
+env HOME="$base/home" \
+    XDG_CONFIG_HOME="$base/xdg/config" \
+    XDG_DATA_HOME="$base/xdg/data" \
+    XDG_STATE_HOME="$base/xdg/state" \
+    XDG_CACHE_HOME="$base/xdg/cache" \
+    XDG_RUNTIME_DIR="$base/xdg/run" \
+    TMPDIR="$base/tmp" PATH="$base/fakebin:$PATH" \
+    ABLETON_WINE_ROOT="$base/runtime" ABLETON_WINEPREFIX="$base/prefix" \
+    ABLETON_LINK_MODE=off ABLETON_SHORTCUTS=preserve \
+    bash "$kit/uninstall.sh" --keep-prefix --yes --dry-run \
+    > "$base/out" 2> "$base/err" \
+    || fail "snapshot-free current uninstall plan failed"
+grep -qxF '  clear only file-opening defaults that name Ableton Linux' "$base/out" \
+    || fail "snapshot-free current uninstall plan misdescribed MIME cleanup"
+if grep -qxF '  leave file-opening defaults unchanged' "$base/out"; then
+    fail "snapshot-free current uninstall plan claimed its own defaults were untouched"
+fi
+ok "snapshot-free current uninstall plans describe their narrow MIME cleanup truthfully"
+
+# Exercise the real integration manifest so an ordinary clean uninstall does
+# not acquire a warning merely because a generated support path is present.
+base="$(new_fixture clean-integration)"
+run_integration_install "$base" > "$base/install.out" 2> "$base/install.err" \
+    || fail "could not create a full integration fixture"
+run_uninstall "$base" --keep-prefix > "$base/out" 2> "$base/err" \
+    || fail "clean full integration uninstall failed"
+[ ! -e "$base/runtime" ] \
+    && [ ! -e "$(state_path "$base")" ] \
+    && [ ! -e "$base/xdg/config/ableton-wine/config" ] \
+    || fail "clean full integration uninstall retained managed state"
+if grep -q '^!! warning:' "$base/err"; then
+    fail "clean full integration uninstall emitted an optional-failure warning"
+fi
+grep -qxF 'OK: uninstall complete' "$base/out" \
+    || fail "clean full integration uninstall did not report complete success"
+ok "clean full integration uninstall removes all managed state without warnings"
+
+# Legacy marker adoption creates a short-lived transaction under state. The
+# uninstall must mark that directory before using it, so its own transaction
+# cannot later be mistaken for foreign state after core removal succeeds.
+base="$(new_fixture legacy-adoption-state)"
+legacy_runtime="$(make_legacy_runtime_without_state "$base")"
+run_uninstall "$base" --keep-prefix "ABLETON_WINE_ROOT=$legacy_runtime" \
+    > "$base/out" 2> "$base/err" \
+    || fail "legacy adoption's own support state made uninstall fail"
+[ ! -e "$legacy_runtime" ] \
+    || fail "legacy adoption support-state handling retained the runtime"
+legacy_state="$(state_path "$base")"
+if [ -e "$legacy_state" ] || [ -L "$legacy_state" ]; then
+    if [ ! -d "$legacy_state" ] || [ -L "$legacy_state" ]; then
+        fail "legacy adoption retained unsafe support state"
+    fi
+    grep -qxF 'owner=ableton-linux' "$legacy_state/.ableton-linux-state" \
+        || fail "legacy adoption retained unmarked support state"
+fi
+ok "legacy adoption never rejects support state created by the uninstall itself"
+
+# Pre-manifest installers left their generated support bundle at the historical
+# HOME path, independent of XDG_DATA_HOME. Exact packaged copies and the
+# VERSION record corroborated by the legacy launcher are safe to retire.
+base="$(new_fixture clean-legacy-support)"
+legacy_runtime="$(make_legacy_runtime_without_state "$base")"
+legacy_data="$base/home/.local/share/ableton-wine"
+for legacy_helper in \
+    detect-scale.sh detect-theme.sh shortcut-hold.sh check-ntsync.sh \
+    setup-link.sh ableton-linkctl ableton-linkd.service; do
+    cp -- "$kit/$legacy_helper" "$legacy_data/$legacy_helper"
+done
+cp -- "$kit/../tools/setsyscolors.exe" "$legacy_data/setsyscolors.exe"
+cp -- "$kit/../tools/learnheal.exe" "$legacy_data/learnheal.exe"
+cat > "$legacy_data/wine-protocol-ableton.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Exec=$base/home/.local/bin/ableton-live %u
+MimeType=x-scheme-handler/ableton;
+NoDisplay=true
+EOF
+run_uninstall "$base" --keep-prefix "ABLETON_WINE_ROOT=$legacy_runtime" \
+    > "$base/out" 2> "$base/err" \
+    || fail "clean legacy support-file removal failed"
+[ ! -e "$legacy_runtime" ] && [ ! -L "$legacy_runtime" ] \
+    && [ ! -e "$legacy_data" ] && [ ! -L "$legacy_data" ] \
+    && [ ! -e "$base/home/.local/bin/ableton-live" ] \
+    || fail "clean legacy uninstall retained recognised project support files"
+if grep -q '^!! warning:' "$base/err"; then
+    fail "clean legacy support-file removal emitted a warning"
+fi
+grep -qxF 'OK: uninstall complete' "$base/out" \
+    || fail "clean legacy support-file removal did not report complete success"
+ok "clean legacy uninstall retires exactly recognised historical support files"
+
+# A same-path helper that differs from the packaged generation may contain
+# local work. Legacy evidence authorises inspection, never deletion by name.
+base="$(new_fixture modified-legacy-support)"
+legacy_runtime="$(make_legacy_runtime_without_state "$base")"
+legacy_data="$base/home/.local/share/ableton-wine"
+cp -- "$kit/detect-scale.sh" "$legacy_data/detect-scale.sh"
+printf '\n# local modification\n' >> "$legacy_data/detect-scale.sh"
+cp -- "$legacy_data/detect-scale.sh" "$base/modified-helper.before"
+run_uninstall "$base" --keep-prefix "ABLETON_WINE_ROOT=$legacy_runtime" \
+    > "$base/out" 2> "$base/err" \
+    || fail "modified legacy support file made core uninstall fail"
+cmp -s -- "$base/modified-helper.before" "$legacy_data/detect-scale.sh" \
+    || fail "legacy uninstall deleted or changed a modified support file"
+[ ! -e "$legacy_runtime" ] \
+    || fail "modified legacy support file retained the recognised runtime"
+grep -qF "kept a modified or unrecognised older support file at $legacy_data/detect-scale.sh" \
+    "$base/err" || fail "modified legacy support-file preservation was not reported"
+assert_warning_contract "$base/err"
+ok "legacy uninstall preserves modified historical support files"
+
+# Publishing the adopted ownership marker is the legacy migration commit. If
+# its disposable transaction directory cannot be removed afterward, the exact
+# core-complete record must make the residue non-blocking on the next run.
+base="$(new_fixture legacy-adoption-cleanup-retry)"
+legacy_runtime="$(make_legacy_runtime_without_state "$base")"
+legacy_foreign_desktop="$base/xdg/data/applications/ableton-live.desktop"
+mkdir -p -- "$(dirname "$legacy_foreign_desktop")"
+printf 'foreign desktop fixture\n' > "$legacy_foreign_desktop"
+run_uninstall "$base" --keep-prefix \
+    "ABLETON_WINE_ROOT=$legacy_runtime" FAIL_ADOPTION_CLEANUP=1 \
+    > "$base/first.out" 2> "$base/first.err" \
+    || fail "legacy adoption cleanup residue made completed runtime removal fail"
+[ ! -e "$legacy_runtime" ] \
+    || fail "legacy adoption cleanup residue retained the adopted runtime"
+legacy_state="$(state_path "$base")"
+legacy_adoption_txn="$(find "$legacy_state/transactions" -mindepth 1 -maxdepth 1 \
+    -type d -name 'uninstall-adopt.*' -print -quit)"
+[ -n "$legacy_adoption_txn" ] \
+    && [ -f "$legacy_adoption_txn/active" ] \
+    && cmp -s -- "$legacy_adoption_txn/core-complete" \
+        <(printf 'format=1\ncore=complete\n') \
+    || fail "legacy adoption cleanup residue lacked its completed-core proof"
+/bin/rm -f -- "$legacy_foreign_desktop"
+run_uninstall "$base" --keep-prefix "ABLETON_WINE_ROOT=$legacy_runtime" \
+    > "$base/retry.out" 2> "$base/retry.err" \
+    || fail "completed legacy adoption cleanup residue blocked a direct retry"
+[ ! -e "$legacy_state" ] && [ ! -L "$legacy_state" ] \
+    || fail "legacy adoption retry retained disposable support state"
+ok "completed legacy adoption cleanup residue cannot block a direct retry"
+
+# Installed-file lists authorize only optional cleanup. Malformed text and
+# binary/unreadable content must preserve every listed object while independently
+# validated configured runtime/prefix removal continues.
+for inventory_case in \
+    manifest-malformed manifest-binary manifest-unreadable \
+    manifest-unmarked-extra \
+    prestate-malformed prestate-binary prestate-unreadable; do
+    base="$(new_fixture "optional-$inventory_case")"
+    state="$(state_path "$base")"
+    prepare_optional_inventory_fixture "$base"
+    mode=--keep-prefix
+    case "$inventory_case" in
+        manifest-malformed)
+            printf 'file\t/\t%064d\n' 0 >> "$state/install-manifest.tsv"
+            mkdir -p -- "$base/prefix"
+            printf 'format=1\nprefix=%s\n' "$base/prefix" \
+                > "$base/prefix/.ableton-linux-prefix"
+            printf 'registry fixture\n' > "$base/prefix/system.reg"
+            mode=--delete-prefix
+            ;;
+        manifest-binary)
+            printf '\0binary installed-file data\n' >> "$state/install-manifest.tsv"
+            ;;
+        manifest-unreadable)
+            rm -f -- "$state/install-manifest.tsv"
+            ln -s -- /dev/null "$state/install-manifest.tsv"
+            ;;
+        manifest-unmarked-extra)
+            rm -f -- "$TEST_EXTRA_RUNTIME/.ableton-linux-runtime"
+            printf 'foreign runtime bytes\n' > "$TEST_EXTRA_RUNTIME/sentinel"
+            ;;
+        prestate-malformed)
+            printf 'present\t%s\t%s/not-a-saved-copy\n' \
+                "$TEST_INVENTORY_DESKTOP" "$state" > "$state/install-prestate.tsv"
+            ;;
+        prestate-binary)
+            printf '\0binary saved-file data\n' > "$state/install-prestate.tsv"
+            ;;
+        prestate-unreadable)
+            ln -s -- /dev/null "$state/install-prestate.tsv"
+            ;;
+    esac
+    run_uninstall "$base" "$mode" TEST_LINK_DISABLE_RC=73 \
+        > "$base/out" 2> "$base/err" \
+        || fail "$inventory_case vetoed independently validated core removal"
+    [ ! -e "$base/runtime" ] \
+        || fail "$inventory_case retained the configured runtime"
+    if [ "$mode" = --delete-prefix ] && [ -e "$base/prefix" ]; then
+        fail "$inventory_case retained the requested validated prefix"
+    fi
+    [ -e "$TEST_INVENTORY_DESKTOP" ] && [ -e "$TEST_EXTRA_RUNTIME" ] \
+        || fail "$inventory_case removed an object from untrusted optional information"
+    grep -qxF "x-scheme-handler/ableton=$ABLETON_PROTOCOL_DESKTOP_ID" \
+        "$base/xdg/config/mimeapps.list" \
+        || fail "$inventory_case changed a desktop default from untrusted optional information"
+    grep -q "installer's file list could not be trusted" "$base/err" \
+        || fail "$inventory_case warning did not identify why optional files remain"
+    if grep -q 'Link integration may still be enabled' "$base/err"; then
+        fail "$inventory_case attempted Link cleanup from untrusted optional information"
+    fi
+    assert_warning_contract "$base/err"
+done
+ok "malformed optional file lists never veto configured runtime or requested-prefix removal"
+
+# An unfinished core operation remains a real stop condition.
+base="$(new_fixture active-core-recovery)"
+mkdir -p -- "$(state_path "$base")/transactions/install.active"
+: > "$(state_path "$base")/transactions/install.active/active"
+if run_uninstall "$base" --keep-prefix > "$base/out" 2> "$base/err"; then
+    fail "uninstall ignored unfinished installer recovery"
+fi
+[ -e "$base/runtime/.ableton-linux-runtime" ] \
+    || fail "active recovery refusal happened after runtime deletion"
+grep -q 'earlier installation stopped before recovery finished' "$base/err" \
+    || fail "active recovery refusal was not explicit"
+ok "unfinished core recovery remains fatal before removal"
+
+# Unrecognised optional support state cannot invalidate an exact runtime target.
+base="$(new_fixture malformed-support-state)"
+printf 'foreign support state\n' > "$(state_path "$base")/.ableton-linux-state"
+run_uninstall "$base" --keep-prefix > "$base/out" 2> "$base/err" \
+    || fail "unrecognised optional support state made core removal fail"
+[ ! -e "$base/runtime" ] || fail "unrecognised support state retained the runtime"
+[ -e "$(state_path "$base")/.ableton-linux-state" ] \
+    || fail "unrecognised support state was deleted"
+grep -q 'support files were left unchanged' "$base/err" \
+    || fail "unrecognised support state warning did not identify what remains"
+assert_warning_contract "$base/err"
+ok "unrecognised support state is warning-only"
+
+# The support path itself is optional cleanup. A regular file there is neither
+# owned directory state nor a reason to retain an independently proven runtime.
+base="$(new_fixture regular-support-state-root)"
+state="$(state_path "$base")"
+rm -rf -- "$state"
+printf 'foreign support-state root\n' > "$state"
+run_uninstall "$base" --keep-prefix > "$base/out" 2> "$base/err" \
+    || fail "regular optional support-state root made core removal fail"
+[ ! -e "$base/runtime" ] \
+    || fail "regular optional support-state root retained the runtime"
+grep -qxF 'foreign support-state root' "$state" \
+    || fail "regular optional support-state root was changed"
+grep -q 'support files were left unchanged' "$base/err" \
+    || fail "regular optional support-state root was not reported"
+assert_warning_contract "$base/err"
+ok "a non-directory optional support path cannot veto runtime removal"
+
+# A configured support root may overlap a kept core tree after manual settings
+# edits. Do not inspect its transaction-looking children as installer recovery,
+# and never recursively clean the overlapping tree as optional state.
+base="$(new_fixture overlapping-support-prefix)"
+mkdir -p -- "$base/prefix/transactions/foreign-run"
+printf 'format=1\nowner=ableton-linux\n' \
+    > "$base/prefix/.ableton-linux-state"
+printf 'kept prefix sentinel\n' > "$base/prefix/user-data"
+: > "$base/prefix/transactions/foreign-run/active"
+run_uninstall "$base" --keep-prefix "ABLETON_STATE_HOME=$base/prefix" \
+    > "$base/out" 2> "$base/err" \
+    || fail "overlapping optional support state made runtime removal fail"
+[ ! -e "$base/runtime" ] \
+    || fail "overlapping optional support state retained the runtime"
+grep -qxF 'kept prefix sentinel' "$base/prefix/user-data" \
+    && [ -e "$base/prefix/transactions/foreign-run/active" ] \
+    || fail "optional state cleanup changed the overlapping kept prefix"
+grep -q 'path overlaps the Wine runtime or prefix' "$base/err" \
+    || fail "overlapping optional support state was not reported"
+assert_warning_contract "$base/err"
+ok "overlapping optional support state is skipped without gating core removal"
+
+# Current installs do not retain the default an authoritative project ID
+# replaced. Uninstall still removes only those exact IDs and preserves every
+# unrelated mimeapps.list entry.
+base="$(new_fixture snapshot-free-mime)"
+rm -f -- "$base/fakebin/xdg-mime" "$base/fakebin/update-mime-database" \
+    "$base/fakebin/update-desktop-database"
+mkdir -p -- "$base/xdg/data/applications" "$base/xdg/config"
+cat > "$base/xdg/data/applications/third-party.desktop" <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=Third Party
+Exec=/usr/bin/true %f
+EOF
+cat > "$base/xdg/config/mimeapps.list" <<'EOF'
+[Default Applications]
+x-scheme-handler/ableton=third-party.desktop
+text/plain=third-party.desktop
+EOF
+run_integration_install "$base" > "$base/install.out" 2> "$base/install.err" \
+    || fail "could not create a snapshot-free MIME fixture"
+grep -qxF "x-scheme-handler/ableton=$ABLETON_PROTOCOL_DESKTOP_ID" \
+    "$base/xdg/config/mimeapps.list" \
+    || fail "integration fixture did not install its scheme-handler default"
+run_uninstall "$base" --keep-prefix > "$base/out" 2> "$base/err" \
+    || fail "snapshot-free MIME cleanup made uninstall fail"
+if grep -Eq "=($ABLETON_PROTOCOL_DESKTOP_ID|$ABLETON_AUZ_DESKTOP_ID|ableton-live[.]desktop|max9[.]desktop|wine-protocol-c74max[.]desktop)$" \
+    "$base/xdg/config/mimeapps.list"; then
+    fail "snapshot-free uninstall left a default naming a removed project entry"
+fi
+grep -qxF 'text/plain=third-party.desktop' "$base/xdg/config/mimeapps.list" \
+    || fail "snapshot-free MIME cleanup changed an unrelated default"
+! grep -q '^x-scheme-handler/ableton=third-party.desktop$' \
+    "$base/xdg/config/mimeapps.list" \
+    || fail "snapshot-free MIME cleanup invented restoration data it did not retain"
+ok "snapshot-free uninstall clears exact project defaults and preserves unrelated MIME entries"
+
+# Link shutdown is helpful cleanup, not authority to remove a proven runtime.
+base="$(new_fixture optional-link)"
+run_uninstall "$base" --keep-prefix TEST_LINK_DISABLE_RC=73 \
+    > "$base/out" 2> "$base/err" \
+    || fail "Link cleanup failure made uninstall fail"
+[ ! -e "$base/runtime" ] || fail "Link cleanup failure retained the runtime"
+[ -e "$(state_path "$base")" ] \
+    || fail "Link cleanup failure discarded the support files needed to retry"
+grep -q 'Ableton Link integration may still be enabled' "$base/err" \
+    || fail "Link cleanup warning did not identify what remains"
+assert_warning_contract "$base/err"
+ok "Link cleanup failure is warning-only and retains retry support"
+
+# Generated desktop helpers are optional. A readable helper with broken shell
+# syntax must be reported without letting a bare source command abort uninstall.
+base="$(new_fixture shortcut-helper-source)"
+mkdir -p -- "$base/xdg/data/ableton-wine"
+cat > "$base/xdg/data/ableton-wine/shortcut-hold.sh" <<'EOF'
+# GNOME shortcut hold
+if this helper is incomplete
+EOF
+: > "$(state_path "$base")/hold-v2"
+cat > "$base/fakebin/gsettings" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod 755 "$base/fakebin/gsettings"
+run_uninstall "$base" --keep-prefix > "$base/out" 2> "$base/err" \
+    || fail "broken optional shortcut helper made uninstall fail"
+[ ! -e "$base/runtime" ] || fail "broken shortcut helper retained the runtime"
+grep -q 'shortcut restoration was skipped' "$base/err" \
+    || fail "broken shortcut helper warning did not identify what remains"
+assert_warning_contract "$base/err"
+ok "broken generated shortcut helper is warning-only"
+
+# Failure to inspect a legacy panel shortcut is optional and must leave the
+# shortcut untouched while core removal proceeds.
+base="$(new_fixture panel-ownership-query)"
+state="$(state_path "$base")"
+panel="$base/home/.local/bin/pipeasio-settings"
+mkdir -p -- "$(dirname "$panel")" "$base/xdg/data/ableton-wine"
+ln -s -- "$base/runtime/bin/pipeasio-settings" "$panel"
+printf '2026.01.01.1\n' > "$base/xdg/data/ableton-wine/VERSION"
+printf 'runtime\t%s\twine-d2d1-nspa-11.13\n' "$base/runtime" \
+    > "$state/install-manifest.tsv"
+cat > "$base/fakebin/awk" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+    *'$2==p && ($1=="file" || $1=="config" || $1=="symlink")'*) exit 77 ;;
+esac
+exec /usr/bin/awk "$@"
+EOF
+chmod 755 "$base/fakebin/awk"
+run_uninstall "$base" --keep-prefix > "$base/out" 2> "$base/err" \
+    || fail "panel ownership-query failure made uninstall fail"
+[ ! -e "$base/runtime" ] || fail "panel ownership-query failure retained the runtime"
+[ -L "$panel" ] || fail "panel ownership-query failure removed its optional shortcut"
+grep -q 'PipeASIO Settings shortcuts were left unchanged' "$base/err" \
+    || fail "panel ownership-query warning did not identify what remains"
+assert_warning_contract "$base/err"
+ok "legacy panel ownership-query failure is warning-only"
+
+# A corrupt optional MIME snapshot cannot veto removal of the runtime.
+base="$(new_fixture invalid-mime-state)"
+printf 'application/x-not-owned\tforeign.desktop\n' \
+    > "$(state_path "$base")/mime-prestate.tsv"
+run_uninstall "$base" --keep-prefix > "$base/out" 2> "$base/err" \
+    || fail "invalid MIME state made uninstall fail"
+[ ! -e "$base/runtime" ] || fail "invalid MIME state retained the runtime"
+[ -e "$(state_path "$base")/mime-prestate.tsv" ] \
+    || fail "invalid MIME state was discarded before it could be reviewed"
+grep -q 'File-opening defaults were left unchanged because the saved settings' "$base/err" \
+    || fail "invalid MIME state warning was not explicit"
+assert_warning_contract "$base/err"
+ok "invalid MIME restoration state is warning-only"
+
+# Backend query failure is also optional and must retain the exact saved value.
+base="$(new_fixture mime-query)"
+printf 'application/x-ableton-live-set\tforeign.desktop\n' \
+    > "$(state_path "$base")/mime-prestate.tsv"
+run_uninstall "$base" --keep-prefix TEST_XDG_QUERY_RC=77 \
+    > "$base/out" 2> "$base/err" \
+    || fail "MIME query failure made uninstall fail"
+[ ! -e "$base/runtime" ] || fail "MIME query failure retained the runtime"
+grep -qx $'application/x-ableton-live-set\tforeign.desktop' \
+    "$(state_path "$base")/mime-prestate.tsv" \
+    || fail "MIME query failure discarded the saved default"
+grep -q 'could not be checked' "$base/err" \
+    || fail "MIME query warning did not identify the failed operation"
+assert_warning_contract "$base/err"
+ok "MIME backend failure is warning-only"
+
+# A recognisable project file is removed authoritatively; an opaque changed
+# file at another managed path is preserved without blocking core removal.
+base="$(new_fixture authoritative-and-foreign)"
+desktop="$base/xdg/data/applications/ableton-live.desktop"
+opaque="$base/xdg/data/ableton-wine/ntsyncprobe.exe"
+mkdir -p -- "$(dirname "$desktop")" "$(dirname "$opaque")"
+cat > "$desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=Locally renamed Ableton Live
+Comment=Music production and performance
+Exec=$base/home/.local/bin/ableton-live %f
+MimeType=application/x-ableton-live-set;application/x-ableton-live-clip;application/x-ableton-live-pack;
+EOF
+printf 'foreign opaque bytes\n' > "$opaque"
+zero_digest="$(printf '%064d' 0)"
+printf 'file\t%s\t%s\nfile\t%s\t%s\n' \
+    "$desktop" "$zero_digest" "$opaque" "$zero_digest" \
+    > "$(state_path "$base")/install-manifest.tsv"
+run_uninstall "$base" --keep-prefix > "$base/out" 2> "$base/err" \
+    || fail "preserved foreign integration file made uninstall fail"
+[ ! -e "$desktop" ] \
+    || fail "recognisable project desktop file was not removed authoritatively"
+grep -qxF 'foreign opaque bytes' "$opaque" \
+    || fail "unrecognised opaque file was removed"
+[ ! -e "$base/runtime" ] \
+    || fail "preserved foreign integration file retained the runtime"
+grep -qF "kept an unrecognised or user-modified file at $opaque" "$base/err" \
+    || fail "preserved foreign integration file was not reported"
+assert_warning_contract "$base/err"
+ok "recognisable project files are removed while foreign data is preserved"
+
+# Snapshot-free launcher replacement has one two-path ownership relation: the
+# canonical path is generated, while its adjacent .bak contains the displaced
+# user object. A failed cleanup must remain retryable without deleting either
+# copy, and the retry must recognise an already-restored launcher.
+base="$(new_fixture adjacent-launcher-retry)"
+state="$(state_path "$base")"
+panel_command="$base/home/.local/bin/pipeasio-settings"
+panel_desktop="$base/xdg/data/applications/pipeasio-settings.desktop"
+mkdir -p -- "$base/runtime/bin" "$(dirname "$panel_command")" \
+    "$(dirname "$panel_desktop")"
+printf '#!/bin/sh\nexit 0\n' > "$base/runtime/bin/pipeasio-settings"
+chmod 755 "$base/runtime/bin/pipeasio-settings"
+ln -s -- "$base/runtime/bin/pipeasio-settings" "$panel_command"
+printf '[Desktop Entry]\nName=PipeASIO Settings\n' > "$panel_desktop"
+printf '#!/bin/sh\necho displaced-user-command\n' > "${panel_command}.bak"
+chmod 755 "${panel_command}.bak"
+printf '[Desktop Entry]\nName=Displaced user desktop\n' > "${panel_desktop}.bak"
+cp -- "${panel_command}.bak" "$base/command.before"
+cp -- "${panel_desktop}.bak" "$base/desktop.before"
+command_digest="$({ printf 'symlink\0'; readlink -n -- "$panel_command"; } \
+    | sha256sum | awk '{print $1}')"
+desktop_digest="$(sha256sum -- "$panel_desktop")"
+desktop_digest="${desktop_digest%% *}"
+command_backup_digest="$(sha256sum -- "${panel_command}.bak")"
+command_backup_digest="${command_backup_digest%% *}"
+desktop_backup_digest="$(sha256sum -- "${panel_desktop}.bak")"
+desktop_backup_digest="${desktop_backup_digest%% *}"
+# Put each backup row first to prove record order cannot delete the recovery
+# copy before the canonical launcher is considered.
+printf 'file\t%s\t%s\nsymlink\t%s\t%s\nfile\t%s\t%s\nfile\t%s\t%s\nruntime\t%s\twine-d2d1-nspa-11.13\n' \
+    "${panel_command}.bak" "$command_backup_digest" \
+    "$panel_command" "$command_digest" \
+    "${panel_desktop}.bak" "$desktop_backup_digest" \
+    "$panel_desktop" "$desktop_digest" "$base/runtime" \
+    > "$state/install-manifest.tsv"
+run_uninstall "$base" --keep-prefix FAIL_RM_TARGET="${panel_command}.bak" \
+    > "$base/first.out" 2> "$base/first.err" \
+    || fail "saved-launcher cleanup failure made uninstall fail"
+cmp -s -- "$base/command.before" "$panel_command" \
+    || fail "saved command was not restored before its cleanup failure"
+cmp -s -- "$base/desktop.before" "$panel_desktop" \
+    || fail "saved desktop was not restored"
+[ -f "${panel_command}.bak" ] \
+    || fail "failed saved-command cleanup did not retain its retry copy"
+[ ! -e "${panel_desktop}.bak" ] && [ ! -L "${panel_desktop}.bak" ] \
+    || fail "successful saved-desktop cleanup retained its extra copy"
+[ ! -e "$base/runtime" ] \
+    || fail "saved-launcher cleanup failure retained the configured runtime"
+assert_warning_contract "$base/first.err"
+run_uninstall "$base" --keep-prefix > "$base/retry.out" 2> "$base/retry.err" \
+    || fail "saved-launcher cleanup retry failed"
+if ! cmp -s -- "$base/command.before" "$panel_command" \
+   || ! cmp -s -- "$base/desktop.before" "$panel_desktop"; then
+    fail "saved-launcher cleanup retry changed a restored user launcher"
+fi
+[ ! -e "${panel_command}.bak" ] && [ ! -L "${panel_command}.bak" ] \
+    || fail "saved-launcher cleanup retry retained the extra command copy"
+if grep -q '^!! warning:' "$base/retry.err"; then
+    fail "idempotent saved-launcher cleanup retry emitted a warning"
+fi
+ok "adjacent launcher backups restore user objects and retry idempotently"
+
+# If the canonical launcher changed after installation, neither it nor its exact
+# saved earlier launcher is disposable project state.
+base="$(new_fixture modified-adjacent-launcher)"
+state="$(state_path "$base")"
+panel_desktop="$base/xdg/data/applications/pipeasio-settings.desktop"
+mkdir -p -- "$(dirname "$panel_desktop")"
+printf '[Desktop Entry]\nName=Generated panel\n' > "$panel_desktop"
+generated_digest="$(sha256sum -- "$panel_desktop")"
+generated_digest="${generated_digest%% *}"
+printf '[Desktop Entry]\nName=Saved foreign panel\n' > "${panel_desktop}.bak"
+saved_digest="$(sha256sum -- "${panel_desktop}.bak")"
+saved_digest="${saved_digest%% *}"
+printf 'file\t%s\t%s\nfile\t%s\t%s\n' \
+    "$panel_desktop" "$generated_digest" \
+    "${panel_desktop}.bak" "$saved_digest" \
+    > "$state/install-manifest.tsv"
+printf '[Desktop Entry]\nName=User modified after install\n' > "$panel_desktop"
+cp -- "$panel_desktop" "$base/modified.before"
+cp -- "${panel_desktop}.bak" "$base/saved.before"
+run_uninstall "$base" --keep-prefix > "$base/out" 2> "$base/err" \
+    || fail "modified canonical launcher made uninstall fail"
+if ! cmp -s -- "$base/modified.before" "$panel_desktop" \
+   || ! cmp -s -- "$base/saved.before" "${panel_desktop}.bak"; then
+    fail "modified launcher cleanup deleted or changed foreign data"
+fi
+[ ! -e "$base/runtime" ] \
+    || fail "modified launcher retained the configured runtime"
+[ "$(grep -cF "kept the user-modified launcher at $panel_desktop" "$base/err")" -eq 1 ] \
+    || fail "modified launcher pair did not produce exactly one preservation warning"
+assert_warning_contract "$base/err"
+ok "modified canonical and saved launchers are both preserved with one warning"
+
+# Older installations may have a persistent pre-install copy for both the
+# canonical launcher and a foreign object that already occupied <name>.bak.
+# Those explicit records take precedence over the snapshot-free pair fallback.
+base="$(new_fixture persistent-launcher-prestate)"
+state="$(state_path "$base")"
+panel_desktop="$base/xdg/data/applications/pipeasio-settings.desktop"
+mkdir -p -- "$(dirname "$panel_desktop")" "$state/install-prestate"
+printf '[Desktop Entry]\nName=Generated panel\n' > "$panel_desktop"
+printf '[Desktop Entry]\nName=Displaced canonical\n' > "${panel_desktop}.bak"
+canonical_digest="$(sha256sum -- "$panel_desktop")"
+canonical_digest="${canonical_digest%% *}"
+adjacent_digest="$(sha256sum -- "${panel_desktop}.bak")"
+adjacent_digest="${adjacent_digest%% *}"
+canonical_id="$(printf '%s' "$panel_desktop" | sha256sum | awk '{print $1}')"
+adjacent_id="$(printf '%s' "${panel_desktop}.bak" | sha256sum | awk '{print $1}')"
+printf '[Desktop Entry]\nName=Original canonical\n' \
+    > "$state/install-prestate/$canonical_id"
+printf '[Desktop Entry]\nName=Original foreign backup\n' \
+    > "$state/install-prestate/$adjacent_id"
+printf 'present\t%s\t%s\npresent\t%s\t%s\n' \
+    "$panel_desktop" "$state/install-prestate/$canonical_id" \
+    "${panel_desktop}.bak" "$state/install-prestate/$adjacent_id" \
+    > "$state/install-prestate.tsv"
+printf 'file\t%s\t%s\nfile\t%s\t%s\n' \
+    "$panel_desktop" "$canonical_digest" \
+    "${panel_desktop}.bak" "$adjacent_digest" \
+    > "$state/install-manifest.tsv"
+run_uninstall "$base" --keep-prefix > "$base/out" 2> "$base/err" \
+    || fail "persistent launcher prestate made uninstall fail"
+grep -qxF 'Name=Original canonical' "$panel_desktop" \
+    || fail "persistent prestate did not restore the original canonical launcher"
+grep -qxF 'Name=Original foreign backup' "${panel_desktop}.bak" \
+    || fail "persistent prestate did not restore a pre-existing foreign .bak"
+[ ! -e "$base/runtime" ] \
+    || fail "persistent launcher prestate retained the configured runtime"
+ok "persistent launcher prestate preserves a pre-existing foreign backup"
+
+# A failed optional file removal is judged by its postcondition and reported;
+# it must not be reclassified as a runtime failure.
+base="$(new_fixture integration-removal)"
+desktop="$base/xdg/data/applications/ableton-live.desktop"
+mkdir -p -- "$(dirname "$desktop")"
+printf 'managed desktop bytes\n' > "$desktop"
+desktop_digest="$(sha256sum -- "$desktop")"
+desktop_digest="${desktop_digest%% *}"
+printf 'file\t%s\t%s\n' "$desktop" "$desktop_digest" \
+    > "$(state_path "$base")/install-manifest.tsv"
+run_uninstall "$base" --keep-prefix FAIL_RM_TARGET="$desktop" \
+    > "$base/out" 2> "$base/err" \
+    || fail "project file removal failure made uninstall fail"
+[ -f "$desktop" ] || fail "file-removal failure fixture unexpectedly disappeared"
+[ ! -e "$base/runtime" ] || fail "project file removal failure retained the runtime"
+grep -qF "an Ableton Linux file remains at $desktop" "$base/err" \
+    || fail "remaining project file was not identified"
+assert_warning_contract "$base/err"
+ok "project integration removal failure is warning-only"
+
+# Cache rebuild tools are advisory after the desktop files have been handled.
+base="$(new_fixture desktop-cache)"
+mkdir -p -- "$base/xdg/data/applications"
+run_uninstall "$base" --keep-prefix TEST_DESKTOP_CACHE_RC=71 \
+    > "$base/out" 2> "$base/err" \
+    || fail "desktop cache failure made uninstall fail"
+[ ! -e "$base/runtime" ] || fail "desktop cache failure retained the runtime"
+grep -q 'desktop application cache could not be refreshed' "$base/err" \
+    || fail "desktop cache warning did not identify what remains stale"
+assert_warning_contract "$base/err" no
+ok "desktop cache refresh failure is warning-only"
+
+# Cleanup of the manifest, state tree, and managed config is optional after the
+# runtime has gone. Each injected command failure must leave a retryable object.
+for cleanup_kind in manifest state config; do
+    base="$(new_fixture "cleanup-$cleanup_kind")"
+    state="$(state_path "$base")"
+    target=""
+    failure_setting=""
+    case "$cleanup_kind" in
+        manifest)
+            printf 'runtime\t%s\twine-d2d1-nspa-11.13\n' "$base/runtime" \
+                > "$state/install-manifest.tsv"
+            target="$state/install-manifest.tsv"
+            ;;
+        state)
+            target="$state"
+            failure_setting="FAIL_FIND_TARGET=$target"
+            ;;
+        config)
+            mkdir -p -- "$base/xdg/config/ableton-wine"
+            cat > "$base/xdg/config/ableton-wine/config" <<EOF
+# ableton-linux installer configuration; managed by the installer
+format=1
+runtime_root=$base/runtime
+prefix=$base/prefix
+live_major=
+link_mode=off
+linkd=$base/xdg/data/ableton-wine/ableton-linkd
+EOF
+            target="$base/xdg/config/ableton-wine/config"
+            ;;
+    esac
+    [ -n "$failure_setting" ] || failure_setting="FAIL_RM_TARGET=$target"
+    run_uninstall "$base" --keep-prefix "$failure_setting" \
+        > "$base/out" 2> "$base/err" \
+        || fail "$cleanup_kind cleanup failure made uninstall fail"
+    [ ! -e "$base/runtime" ] \
+        || fail "$cleanup_kind cleanup failure retained the runtime"
+    [ -e "$target" ] || [ -L "$target" ] \
+        || fail "$cleanup_kind cleanup fixture did not remain for retry"
+    if [ "$cleanup_kind" = state ]; then
+        grep -qxF 'owner=ableton-linux' "$state/.ableton-linux-state" \
+            || fail "partial state cleanup removed its retry ownership marker"
+    fi
+    assert_warning_contract "$base/err"
+done
+ok "manifest, state, and configuration cleanup failures are warning-only"
+
+# Optional support-state ownership may change after core removal. That skips
+# recursive support cleanup and reports residue without changing the core result.
+base="$(new_fixture post-core-state-change)"
+state="$(state_path "$base")"
+run_uninstall "$base" --keep-prefix \
+    CORRUPT_STATE_AFTER_TARGET="$base/runtime" \
+    CORRUPT_STATE_FILE="$state/.ableton-linux-state" \
+    > "$base/out" 2> "$base/err" \
+    || fail "post-core support-state ownership change made uninstall fail"
+[ ! -e "$base/runtime" ] || fail "post-core support-state change retained the runtime"
+grep -qxF 'changed during uninstall' "$state/.ableton-linux-state" \
+    || fail "post-core support-state fixture was not retained"
+grep -q 'installer could not confirm that it created their directory' "$base/err" \
+    || fail "post-core support-state warning did not identify why cleanup was skipped"
+assert_warning_contract "$base/err"
+ok "post-core support-state safety failures are warning-only"
+
+# An older runtime from valid optional information is best-effort. Its removal
+# failure cannot displace successful removal of the configured runtime.
+base="$(new_fixture extra-runtime-removal)"
+state="$(state_path "$base")"
+extra_runtime="$base/extra-runtime"
+mkdir -p -- "$extra_runtime"
+printf 'format=1\nname=wine-d2d1-nspa-11.13\n' \
+    > "$extra_runtime/.ableton-linux-runtime"
+printf 'runtime\t%s\twine-d2d1-nspa-11.13\nruntime\t%s\twine-d2d1-nspa-11.13\n' \
+    "$base/runtime" "$extra_runtime" > "$state/install-manifest.tsv"
+run_uninstall "$base" --keep-prefix FAIL_RM_TARGET="$extra_runtime" \
+    > "$base/out" 2> "$base/err" \
+    || fail "older recorded runtime removal failure made uninstall fail"
+[ ! -e "$base/runtime" ] || fail "older runtime failure retained the configured runtime"
+[ -e "$extra_runtime/.ableton-linux-runtime" ] \
+    || fail "older runtime failure fixture unexpectedly disappeared"
+grep -q 'older Wine runtime remains' "$base/err" \
+    || fail "older runtime residue was not identified"
+assert_warning_contract "$base/err"
+ok "older recorded runtime removal failure is warning-only"
+
+# A command can report failure after reaching the requested end state (for
+# example, a wrapper's bookkeeping error). The verified outcome is authoritative.
+base="$(new_fixture runtime-status-only-failure)"
+run_uninstall "$base" --keep-prefix \
+    FAIL_RM_TARGET="$base/runtime" FAIL_RM_REMOVE_FIRST=1 \
+    > "$base/out" 2> "$base/err" \
+    || fail "runtime command status overrode a successful deletion outcome"
+[ ! -e "$base/runtime" ] \
+    || fail "status-only runtime failure fixture did not reach the deletion outcome"
+grep -qxF 'OK: uninstall complete' "$base/out" \
+    || fail "successful runtime deletion outcome was not reported as complete"
+ok "runtime deletion is classified by postcondition, not command status alone"
+
+# Output is presentation, not a removal gate.  A broken stdout consumer must
+# not interrupt the already-authorised runtime/prefix sequence or make its
+# verified completion report failure.
+base="$(new_fixture presentation-output-failure)"
+extra_runtime="$base/extra-runtime"
+mkdir -p -- "$extra_runtime" "$base/prefix"
+printf 'format=1\nname=wine-d2d1-nspa-11.13\n' \
+    > "$extra_runtime/.ableton-linux-runtime"
+printf 'format=1\nprefix=%s\n' "$base/prefix" \
+    > "$base/prefix/.ableton-linux-prefix"
+printf 'registry fixture\n' > "$base/prefix/system.reg"
+printf 'runtime\t%s\twine-d2d1-nspa-11.13\nruntime\t%s\twine-d2d1-nspa-11.13\n' \
+    "$base/runtime" "$extra_runtime" \
+    > "$(state_path "$base")/install-manifest.tsv"
+run_uninstall "$base" --delete-prefix > /dev/full 2> "$base/err" \
+    || fail "presentation output failure made verified removals fail"
+[ ! -e "$base/runtime" ] && [ ! -L "$base/runtime" ] \
+    && [ ! -e "$extra_runtime" ] && [ ! -L "$extra_runtime" ] \
+    && [ ! -e "$base/prefix" ] && [ ! -L "$base/prefix" ] \
+    || fail "presentation output failure interrupted verified removals"
+ok "presentation output cannot interrupt or fail verified removals"
+
+# Ignoring presentation writes must not hide a core deletion failure.
+base="$(new_fixture presentation-output-with-runtime-failure)"
+if run_uninstall "$base" --keep-prefix FAIL_RM_TARGET="$base/runtime" \
+    > /dev/full 2> "$base/err"; then
+    fail "presentation output handling hid a runtime deletion failure"
+fi
+[ -e "$base/runtime" ] \
+    || fail "runtime failure fixture unexpectedly disappeared with broken output"
+grep -q 'runtime removal is incomplete' "$base/err" \
+    || fail "broken output obscured the real runtime deletion failure"
+ok "presentation output handling preserves core deletion failures"
+
+# Runtime and requested-prefix deletion are the core operation and stay fatal.
+base="$(new_fixture runtime-removal)"
+if run_uninstall "$base" --keep-prefix FAIL_RM_TARGET="$base/runtime" \
+    > "$base/out" 2> "$base/err"; then
+    fail "uninstall succeeded while the runtime remained"
+fi
+[ -e "$base/runtime" ] || fail "runtime failure fixture unexpectedly disappeared"
+[ -e "$(state_path "$base")" ] \
+    || fail "runtime failure discarded support files needed to retry"
+grep -q 'runtime removal is incomplete' "$base/err" \
+    || fail "runtime removal failure was not explicit"
+grep -q '^   Retry:' "$base/err" \
+    || fail "runtime removal failure did not print a retry command"
+ok "runtime deletion failure remains fatal"
+
+base="$(new_fixture prefix-removal)"
+mkdir -p -- "$base/prefix"
+printf 'format=1\nprefix=%s\n' "$base/prefix" \
+    > "$base/prefix/.ableton-linux-prefix"
+printf 'registry fixture\n' > "$base/prefix/system.reg"
+if run_uninstall "$base" --delete-prefix FAIL_RM_TARGET="$base/prefix" \
+    > "$base/out" 2> "$base/err"; then
+    fail "uninstall succeeded while the requested prefix remained"
+fi
+[ -e "$base/prefix" ] || fail "prefix failure fixture unexpectedly disappeared"
+[ ! -e "$base/runtime" ] || fail "prefix failure occurred before runtime removal"
+[ -e "$(state_path "$base")" ] \
+    || fail "prefix failure discarded support files needed to retry"
+grep -q 'prefix removal is incomplete' "$base/err" \
+    || fail "prefix removal failure was not explicit"
+grep -q '^   Retry:' "$base/err" \
+    || fail "prefix removal failure did not print a retry command"
+ok "requested-prefix deletion failure remains fatal"
+
+# A suggestive sibling name is never delete authority, but the foreign sibling
+# is optional and cannot veto removal of the exact configured runtime.
+base="$(new_fixture rollback-ownership)"
+mkdir -p -- "$base/runtime-rollback-unrecognised"
+printf 'foreign saved runtime\n' > "$base/runtime-rollback-unrecognised/sentinel"
+run_uninstall "$base" --keep-prefix > "$base/out" 2> "$base/err" \
+    || fail "unmarked saved-runtime sibling made uninstall fail"
+[ ! -e "$base/runtime" ] \
+    || fail "unmarked saved-runtime sibling retained the configured runtime"
+grep -qxF 'foreign saved runtime' "$base/runtime-rollback-unrecognised/sentinel" \
+    || fail "unmarked saved-runtime sibling was removed"
+grep -q 'unrecognised saved Wine runtime was left unchanged' "$base/err" \
+    || fail "saved-runtime preservation warning was not explicit"
+assert_warning_contract "$base/err"
+ok "unrecognised saved-runtime siblings are preserved without vetoing core removal"
+
+printf '1..%d\n' "$pass"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -7,28 +7,35 @@ for lib in "$here/lib/config.sh" "$here/config.sh" \
            "${XDG_DATA_HOME:-$HOME/.local/share}/ableton-wine/lib/config.sh"; do
     if [ -r "$lib" ]; then . "$lib"; break; fi
 done
-declare -F ableton_config_init >/dev/null 2>&1 || { echo "!! uninstall: config helper is missing" >&2; exit 1; }
-ableton_config_init
-if [ -e "$ABLETON_CONFIG_FILE" ] || [ -L "$ABLETON_CONFIG_FILE" ]; then
-    ableton_managed_config_valid "$ABLETON_CONFIG_FILE" || {
-        echo "!! installer configuration is malformed or user-owned; nothing was changed" >&2
-        exit 2
-    }
-fi
+declare -F ableton_config_init >/dev/null 2>&1 || {
+    echo "!! Uninstall support is incomplete. Run the latest installer again, then retry uninstall." >&2
+    exit 1
+}
+# Installer settings are cleanup/retry convenience, not deletion authority.
+# Repair mode salvages valid path values (or accepts explicit caller values);
+# the runtime/prefix markers and registry checks below remain the hard proof.
+ABLETON_CONFIG_LAYOUT_ROOTS='runtime prefix'
+export ABLETON_CONFIG_LAYOUT_ROOTS
+ableton_config_init repair
 for lib in "$here/lib/lifecycle.sh" "$ABLETON_DATA_HOME/lib/lifecycle.sh"; do
     if [ -r "$lib" ]; then . "$lib"; break; fi
 done
-declare -F ableton_prefix_busy >/dev/null 2>&1 || { echo "!! uninstall: lifecycle helper is missing" >&2; exit 1; }
+declare -F ableton_prefix_busy >/dev/null 2>&1 || {
+    echo "!! Uninstall support is incomplete. Run the latest installer again, then retry uninstall." >&2
+    exit 1
+}
 for lib in "$here/lib/manifest.sh" "$ABLETON_DATA_HOME/lib/manifest.sh"; do
     if [ -r "$lib" ]; then . "$lib"; break; fi
 done
 declare -F ableton_legacy_owned_path >/dev/null 2>&1 || {
-    echo "!! uninstall: ownership helper is missing" >&2; exit 1; }
+    echo "!! Uninstall support is incomplete. Run the latest installer again, then retry uninstall." >&2; exit 1; }
 for lib in "$here/lib/pipeasio.sh" "$ABLETON_DATA_HOME/lib/pipeasio.sh"; do
     if [ -r "$lib" ]; then . "$lib"; break; fi
 done
 declare -F ableton_pipeasio_unregister >/dev/null 2>&1 || {
-    echo "!! uninstall: PipeASIO lifecycle helper is missing" >&2; exit 1; }
+    echo "!! PipeASIO removal support is incomplete. Run the latest installer again, then retry uninstall." >&2
+    exit 1
+}
 
 delete_prefix=0
 keep_prefix=0
@@ -55,9 +62,58 @@ EOF
 done
 [ "$delete_prefix" -eq 0 ] || [ "$keep_prefix" -eq 0 ] || { echo "!! --keep-prefix and --delete-prefix conflict" >&2; exit 2; }
 
+retry_mode=--keep-prefix
+[ "$delete_prefix" -eq 0 ] || retry_mode=--delete-prefix
+optional_cleanup_incomplete=0
+retain_retry_support=0
+
+print_uninstall_retry()
+{
+    if [ -n "${ABLETON_INSTALLER_PATH:-}" ]; then
+        printf '   Retry: %q uninstall %s --yes\n' "$ABLETON_INSTALLER_PATH" "$retry_mode" >&2 || true
+    else
+        printf '   Retry: bash %q %s --yes\n' "$here/uninstall.sh" "$retry_mode" >&2 || true
+    fi
+}
+
+warn_optional_remaining()
+{
+    local message="$1" remedy="${2:-}"
+    printf '!! warning: %s\n' "$message" >&2 || true
+    [ -z "$remedy" ] || printf '   %s\n' "$remedy" >&2 || true
+    optional_cleanup_incomplete=1
+    retain_retry_support=1
+    return 0
+}
+
+warn_optional_notice()
+{
+    local message="$1" remedy="${2:-}"
+    printf '!! warning: %s\n' "$message" >&2 || true
+    [ -z "$remedy" ] || printf '   %s\n' "$remedy" >&2 || true
+    optional_cleanup_incomplete=1
+    return 0
+}
+
+# Progress text is not an uninstall precondition.  In particular, a closed
+# terminal or pipe must not stop the verified removals that follow it, or turn
+# a completed removal into a failed command.
+uninstall_note()
+{
+    printf '%s\n' "$@" || true
+}
+
 manifest="$ABLETON_STATE_HOME/install-manifest.tsv"
 prestate="$ABLETON_STATE_HOME/install-prestate.tsv"
 mime_prestate="$ABLETON_STATE_HOME/mime-prestate.tsv"
+uninstall_state_digest()
+{
+    if [ -e "$1" ] || [ -L "$1" ]; then
+        ableton_manifest_digest "$1"
+    else
+        printf 'absent\n'
+    fi
+}
 safe_runtime="$(ableton_path_is_safe_delete_target "$ABLETON_WINE_ROOT")" || {
     echo "!! unsafe runtime target in configuration: $ABLETON_WINE_ROOT" >&2; exit 2; }
 safe_prefix="$(ableton_path_is_safe_delete_target "$ABLETON_WINEPREFIX")" || {
@@ -65,16 +121,48 @@ safe_prefix="$(ableton_path_is_safe_delete_target "$ABLETON_WINEPREFIX")" || {
 [ ! -L "$ABLETON_WINE_ROOT" ] || { echo "!! refusing symlink runtime: $ABLETON_WINE_ROOT" >&2; exit 2; }
 [ ! -L "$ABLETON_WINEPREFIX" ] || { echo "!! refusing symlink prefix: $ABLETON_WINEPREFIX" >&2; exit 2; }
 
-for journal in "$manifest" "$prestate" "$mime_prestate"; do
-    if [ -e "$journal" ] || [ -L "$journal" ]; then
-        [ -f "$journal" ] && [ ! -L "$journal" ] && [ -r "$journal" ] || {
-            echo "!! refusing unsafe or unreadable uninstall state: $journal" >&2
-            exit 2
-        }
+uninstall_paths_overlap()
+{
+    local first="$1" second="$2"
+    [ "$first" = "$second" ] || [[ "$first" = "$second/"* ]] \
+        || [[ "$second" = "$first/"* ]]
+}
+
+state_home_overlaps_core=0
+if uninstall_paths_overlap "$ABLETON_STATE_HOME" "$safe_runtime" \
+   || uninstall_paths_overlap "$ABLETON_STATE_HOME" "$safe_prefix"; then
+    state_home_overlaps_core=1
+fi
+
+if [ "$state_home_overlaps_core" -eq 0 ] \
+   && ableton_install_state_has_active_transaction; then
+    echo "!! An earlier installation stopped before recovery finished. Run the latest installer again before uninstalling." >&2
+    exit 1
+fi
+manifest_present=0
+[ "$state_home_overlaps_core" -eq 1 ] \
+    || { [ ! -e "$manifest" ] && [ ! -L "$manifest" ]; } \
+    || manifest_present=1
+optional_inventory_usable=1
+mime_prestate_usable=1
+if [ "$state_home_overlaps_core" -eq 1 ]; then
+    optional_inventory_usable=0
+    mime_prestate_usable=0
+elif [ -e "$mime_prestate" ] || [ -L "$mime_prestate" ]; then
+    if [ ! -f "$mime_prestate" ] || [ -L "$mime_prestate" ] || [ ! -r "$mime_prestate" ]; then
+        mime_prestate_usable=0
+        warn_optional_remaining \
+            "File-opening defaults were left unchanged because the saved settings at $mime_prestate could not be read safely" \
+            "Move that object aside only after checking that it is not your file."
+    elif ! ableton_validate_mime_prestate "$mime_prestate" >/dev/null 2>&1; then
+        mime_prestate_usable=0
+        warn_optional_remaining \
+            "File-opening defaults were left unchanged because the saved settings at $mime_prestate are not recognised" \
+            "Move that file aside only if you no longer need those saved settings."
     fi
-done
-ableton_validate_install_state_journals || exit 2
-ableton_validate_mime_prestate "$mime_prestate" || exit 2
+else
+    mime_prestate_usable=0
+fi
 
 pr182_custom_link_adoption=0
 if [ "$ABLETON_LINKD" != "$ABLETON_DATA_HOME/ableton-linkd" ] \
@@ -83,14 +171,25 @@ if [ "$ABLETON_LINKD" != "$ABLETON_DATA_HOME/ableton-linkd" ] \
 fi
 
 legacy_state_adoption=0
-if [ -e "$ABLETON_STATE_HOME" ] || [ -L "$ABLETON_STATE_HOME" ]; then
-    if ! { [ -d "$ABLETON_STATE_HOME" ] && [ ! -L "$ABLETON_STATE_HOME" ] \
-           && { ableton_state_marker_valid "$ABLETON_STATE_HOME" \
-                || ableton_legacy_shortcut_state_valid "$ABLETON_STATE_HOME"; }; }; then
-        echo "!! refusing malformed installation state: $ABLETON_STATE_HOME" >&2
-        exit 2
+state_home_usable=1
+if [ "$state_home_overlaps_core" -eq 1 ]; then
+    state_home_usable=0
+    warn_optional_remaining \
+        "Ableton Linux support files were not cleaned separately because their path overlaps the Wine runtime or prefix: $ABLETON_STATE_HOME" \
+        "The requested Wine removal will still continue; inspect any remaining support path afterward."
+elif [ -e "$ABLETON_STATE_HOME" ] || [ -L "$ABLETON_STATE_HOME" ]; then
+    if ableton_state_marker_valid "$ABLETON_STATE_HOME"; then
+        :
+    elif [ -d "$ABLETON_STATE_HOME" ] && [ ! -L "$ABLETON_STATE_HOME" ] \
+         && ableton_legacy_shortcut_state_valid "$ABLETON_STATE_HOME"; then
+        legacy_state_adoption=1
+    else
+        state_home_usable=0
+        optional_inventory_usable=0
+        warn_optional_remaining \
+            "Ableton Linux support files were left unchanged because their directory is not recognised: $ABLETON_STATE_HOME" \
+            "Inspect that directory and move it aside only if you are certain it belongs to this project."
     fi
-    ableton_state_marker_valid "$ABLETON_STATE_HOME" || legacy_state_adoption=1
 fi
 legacy_prefix_adoption=0
 if [ "$delete_prefix" -eq 1 ] && [ -e "$safe_prefix" ]; then
@@ -98,12 +197,12 @@ if [ "$delete_prefix" -eq 1 ] && [ -e "$safe_prefix" ]; then
         if ableton_legacy_default_prefix_valid "$safe_prefix"; then
             legacy_prefix_adoption=1
         else
-        echo "!! refusing to delete unrecognised custom prefix: $safe_prefix" >&2
+        echo "!! The Wine prefix was not deleted because the installer could not confirm that it created it: $safe_prefix" >&2
         exit 2
         fi
     fi
     [ -f "$safe_prefix/system.reg" ] || {
-        echo "!! refusing prefix deletion because system.reg is missing: $safe_prefix" >&2; exit 2; }
+        echo "!! The Wine prefix was not deleted because required registry data is missing: $safe_prefix" >&2; exit 2; }
 fi
 legacy_runtime_adoption=0
 if [ -e "$safe_runtime" ] \
@@ -111,145 +210,199 @@ if [ -e "$safe_runtime" ] \
     if ableton_legacy_default_runtime_valid "$safe_runtime"; then
         legacy_runtime_adoption=1
     else
-        echo "!! refusing to delete unrecognised custom runtime: $safe_runtime" >&2
+        echo "!! The Wine runtime was not deleted because the installer could not confirm that it created it: $safe_runtime" >&2
         exit 2
     fi
 fi
 
-# Validate every lifecycle journal before any service, registry, Link, or file
-# mutation.  This also makes dry-run refuse unsafe state rather than presenting
-# a plan that the real uninstall could not safely execute.
-ableton_validate_install_state_journals || exit 2
-ableton_validate_mime_prestate "$mime_prestate" || exit 2
-
-manifest_before="$(ableton_manifest_digest "$manifest" 2>/dev/null || printf absent)"
-prestate_before="$(ableton_manifest_digest "$prestate" 2>/dev/null || printf absent)"
-mime_prestate_before="$(ableton_manifest_digest "$mime_prestate" 2>/dev/null || printf absent)"
+mime_prestate_before=unavailable
+if [ "$mime_prestate_usable" -eq 1 ]; then
+    if ! mime_prestate_before="$(ableton_manifest_digest "$mime_prestate" 2>/dev/null)"; then
+        mime_prestate_usable=0
+        warn_optional_remaining \
+            "File-opening defaults were left unchanged because the saved settings at $mime_prestate could not be read" \
+            "Check the file permissions before retrying."
+    fi
+fi
 managed_runtimes=("$safe_runtime")
 declare -A managed_runtime_names=(["$safe_runtime"]="$ABLETON_RUNTIME_NAME")
-if [ -r "$manifest" ]; then
-    while IFS=$'\t' read -r kind path detail; do
-        [ "$kind" = runtime ] || continue
-        candidate="$(ableton_path_is_safe_delete_target "$path")" || {
-            echo "!! unsafe runtime in ownership manifest: $path" >&2; exit 2; }
-        [ ! -L "$path" ] || { echo "!! refusing symlink runtime from ownership manifest: $path" >&2; exit 2; }
-        [ "$detail" = "$ABLETON_RUNTIME_NAME" ] || {
-            echo "!! runtime ownership record has an invalid runtime name: $path" >&2; exit 2; }
-        [ ! -e "$candidate" ] || ableton_runtime_marker_valid "$candidate" "$detail" || {
-            echo "!! refusing unmarked runtime from ownership manifest: $candidate" >&2; exit 2; }
-        duplicate=0
-        for path in "${managed_runtimes[@]}"; do
-            if [ "$path" = "$candidate" ]; then
-                duplicate=1
-                [ "${managed_runtime_names[$candidate]}" = "$detail" ] || {
-                    echo "!! conflicting runtime ownership records: $candidate" >&2; exit 2; }
-            fi
-        done
-        if [ "$duplicate" -ne 1 ]; then
-            managed_runtimes+=("$candidate")
-            managed_runtime_names["$candidate"]="$detail"
-        fi
-    done < "$manifest"
-fi
+manifest_runtime_records=()
 
 validate_uninstall_state()
 {
-    local kind path detail extra status backup expected digest type prior candidate
-    local manifest_rows=0
-    local -A claimed=() prestates=() mime_types=()
+    local kind path detail extra status backup expected digest candidate record
+    local path_hash_record path_hash
+    local -A claimed=() prestates=()
+    local -a manifest_lines=() prestate_lines=()
+    [ "$state_home_usable" -eq 1 ] || return 1
+    ableton_validate_install_state_journals >/dev/null 2>&1 || return 1
     if [ -r "$manifest" ]; then
-        while IFS=$'\t' read -r kind path detail extra || [ -n "$kind$path$detail$extra" ]; do
+        if ! mapfile -t manifest_lines < "$manifest"; then
+            echo "!! the installed-file list could not be read" >&2
+            return 1
+        fi
+        for record in "${manifest_lines[@]}"; do
+            if ! IFS=$'\t' read -r kind path detail extra <<< "$record"; then
+                echo "!! the installed-file list is invalid" >&2
+                return 1
+            fi
             if [ -n "$extra" ] || [ -z "$path" ] || ! ableton_manifest_path_ok "$path" \
                || [ -n "${claimed[$path]+x}" ]; then
-                echo "!! installation ownership manifest is invalid or ambiguous" >&2
+                echo "!! the installed-file list is invalid or ambiguous" >&2
                 return 1
             fi
             claimed["$path"]="$kind"
             case "$kind" in
                 file|config|symlink)
-                    [[ "$detail" =~ ^[0-9a-f]{64}$ ]] || {
-                        echo "!! invalid ownership digest for $path" >&2; return 1; } ;;
+                    ableton_managed_path_allowed "$kind" "$path" \
+                        && [[ "$detail" =~ ^[0-9a-f]{64}$ ]] || {
+                        echo "!! invalid installed-file entry for $path" >&2; return 1; } ;;
                 runtime)
                     [ "$detail" = "$ABLETON_RUNTIME_NAME" ] || {
-                        echo "!! invalid runtime ownership record for $path" >&2; return 1; }
+                        echo "!! invalid Wine entry for $path" >&2; return 1; }
                     candidate="$(ableton_path_is_safe_delete_target "$path")" || {
-                        echo "!! unsafe runtime ownership record: $path" >&2; return 1; }
+                        echo "!! unsafe Wine path in the installed-file list: $path" >&2; return 1; }
                     [ "$candidate" = "$path" ] || {
-                        echo "!! non-canonical runtime ownership record: $path" >&2; return 1; }
-                    [ ! -e "$path" ] || ableton_runtime_marker_valid "$path" "$detail" || {
-                        echo "!! invalid runtime ownership marker: $path" >&2; return 1; } ;;
-                *) echo "!! unknown installation ownership record: $kind" >&2; return 1 ;;
+                        echo "!! unexpected Wine path in the installed-file list: $path" >&2; return 1; }
+                    [ ! -e "$path" ] || ableton_runtime_marker_valid "$path" "$detail" \
+                        || { [ "$path" = "$safe_runtime" ] \
+                             && [ "$legacy_runtime_adoption" -eq 1 ] \
+                             && ableton_legacy_default_runtime_valid "$path"; } || {
+                        echo "!! Wine installation is not recognised at $path" >&2; return 1; } ;;
+                *) echo "!! unknown entry in the installed-file list: $kind" >&2; return 1 ;;
             esac
-            manifest_rows=$((manifest_rows + 1))
-        done < "$manifest"
-        [ "$manifest_rows" -gt 0 ] || {
-            echo "!! installation ownership manifest is empty" >&2; return 1; }
+        done
     fi
 
     if [ -e "$prestate" ] || [ -L "$prestate" ]; then
         [ -f "$prestate" ] && [ ! -L "$prestate" ] || {
-            echo "!! pre-install state index is unsafe" >&2; return 1; }
-        while IFS=$'\t' read -r status path backup extra || [ -n "$status$path$backup$extra" ]; do
+            echo "!! the list of saved earlier files is unsafe" >&2; return 1; }
+        if ! mapfile -t prestate_lines < "$prestate"; then
+            echo "!! the list of saved earlier files could not be read" >&2
+            return 1
+        fi
+        for record in "${prestate_lines[@]}"; do
+            if ! IFS=$'\t' read -r status path backup extra <<< "$record"; then
+                echo "!! the list of saved earlier files is invalid" >&2
+                return 1
+            fi
             if [ -n "$extra" ] || [ "$status" != present ] || [ -z "$path" ] \
                || ! ableton_manifest_path_ok "$path" || [ -n "${prestates[$path]+x}" ] \
                || [ -z "${claimed[$path]+x}" ] \
                || { [ "${claimed[$path]}" != file ] \
                     && [ "${claimed[$path]}" != config ] \
                     && [ "${claimed[$path]}" != symlink ]; }; then
-                echo "!! pre-install state is invalid or ambiguous" >&2
+                echo "!! the list of saved earlier files is invalid or ambiguous" >&2
                 return 1
             fi
-            expected="$ABLETON_STATE_HOME/install-prestate/$(printf '%s' "$path" | sha256sum | awk '{print $1}')"
+            path_hash_record="$(printf '%s' "$path" | sha256sum)" || {
+                echo "!! the saved earlier copy of $path could not be verified" >&2
+                return 1
+            }
+            path_hash="${path_hash_record%% *}"
+            [[ "$path_hash" =~ ^[0-9a-f]{64}$ ]] || {
+                echo "!! the saved earlier copy of $path could not be verified" >&2
+                return 1
+            }
+            expected="$ABLETON_STATE_HOME/install-prestate/$path_hash"
             if [ "$backup" != "$expected" ] \
                || { [ ! -f "$backup" ] && [ ! -L "$backup" ]; }; then
-                echo "!! cannot safely restore the recorded pre-install file $path" >&2
+                echo "!! the saved earlier copy of $path cannot be restored safely" >&2
                 return 1
             fi
             digest="$(ableton_manifest_digest "$backup" 2>/dev/null || true)"
             [ -n "$digest" ] || {
-                echo "!! cannot read the recorded pre-install file $path" >&2
+                echo "!! the saved earlier copy of $path cannot be read" >&2
                 return 1
             }
             prestates["$path"]="$backup"
-        done < "$prestate"
+        done
     fi
 
-    if [ -r "$mime_prestate" ]; then
-        while IFS=$'\t' read -r type prior extra || [ -n "$type$prior$extra" ]; do
-            [ -z "$extra" ] && [ -n "$type" ] && [ -z "${mime_types[$type]+x}" ] || {
-                echo "!! MIME restoration state is invalid or ambiguous" >&2; return 1; }
-            case "$type" in
-                x-scheme-handler/ableton|application/x-wine-extension-auz|\
-                application/x-ableton-live-set|application/x-ableton-live-clip|\
-                application/x-ableton-live-pack|application/x-ableton-live-max-device|\
-                x-scheme-handler/c74max) ;;
-                *) echo "!! MIME restoration state has an unknown type: $type" >&2; return 1 ;;
-            esac
-            [ -z "$prior" ] || [[ "$prior" =~ ^[A-Za-z0-9_.+-]+[.]desktop$ ]] || {
-                echo "!! MIME restoration state has an invalid desktop entry" >&2; return 1; }
-            mime_types["$type"]=1
-        done < "$mime_prestate"
-    fi
     return 0
 }
 
-validate_uninstall_state || {
-    echo "!! uninstall state is inconsistent; nothing was changed" >&2
-    exit 1
+leave_optional_inventory_untouched()
+{
+    [ "$optional_inventory_usable" -eq 1 ] || return 0
+    optional_inventory_usable=0
+    manifest_runtime_records=()
+    managed_runtimes=("$safe_runtime")
+    warn_optional_remaining \
+        "Desktop shortcuts, file-opening settings, and older Wine runtimes were left unchanged because the installer's file list could not be trusted" \
+        "Inspect $manifest and $prestate, then retry after moving aside only a file you know is damaged."
 }
 
-if [ "$dry_run" -eq 1 ]; then
-    echo "PLAN: uninstall project-owned state"
-    printf '  remove marked runtime tree(s) and marked rollback siblings: %s\n  ownership manifest: %s\n' \
-        "${managed_runtimes[*]}" "$manifest"
-    if [ -r "$manifest" ]; then cut -f2 "$manifest" | sed 's/^/  owned file: /'; else echo "  legacy owned integration paths"; fi
-    printf '  restore MIME defaults from: %s/mime-prestate.tsv\n' "$ABLETON_STATE_HOME"
-    printf '  remove managed config/state after owned files: %s, %s\n' "$ABLETON_CONFIG_FILE" "$ABLETON_STATE_HOME"
-    if [ "$delete_prefix" -eq 0 ] && [ -f "$safe_prefix/system.reg" ]; then
-        printf '  unregister PipeASIO from retained prefix: %s\n' "$safe_prefix"
+if [ "$optional_inventory_usable" -eq 1 ] \
+   && ! validate_uninstall_state >/dev/null 2>&1; then
+    leave_optional_inventory_untouched
+fi
+
+manifest_before=unavailable
+prestate_before=unavailable
+if [ "$optional_inventory_usable" -eq 1 ]; then
+    if ! manifest_before="$(uninstall_state_digest "$manifest" 2>/dev/null)" \
+       || ! prestate_before="$(uninstall_state_digest "$prestate" 2>/dev/null)"; then
+        leave_optional_inventory_untouched
     fi
-    "$here/setup-link.sh" plan-disable
-    [ "$delete_prefix" -eq 0 ] || printf '  delete validated prefix: %s\n' "$safe_prefix"
+fi
+
+if [ "$optional_inventory_usable" -eq 1 ] && [ -r "$manifest" ]; then
+    if ! mapfile -t manifest_runtime_records < "$manifest"; then
+        leave_optional_inventory_untouched
+    else
+        inventory_runtime_invalid=0
+        for manifest_record in "${manifest_runtime_records[@]}"; do
+            if ! IFS=$'\t' read -r kind path detail extra <<< "$manifest_record" \
+               || [ -n "$extra" ]; then
+                inventory_runtime_invalid=1
+                break
+            fi
+            [ "$kind" = runtime ] || continue
+            [ "$path" != "$safe_runtime" ] || continue
+            if ! candidate="$(ableton_path_is_safe_delete_target "$path")" \
+               || [ "$candidate" != "$path" ] || [ -L "$path" ] \
+               || [ "$detail" != "$ABLETON_RUNTIME_NAME" ] \
+               || { [ -e "$candidate" ] \
+                    && ! ableton_runtime_marker_valid "$candidate" "$detail"; }; then
+                inventory_runtime_invalid=1
+                break
+            fi
+            managed_runtimes+=("$candidate")
+            managed_runtime_names["$candidate"]="$detail"
+        done
+        if [ "$inventory_runtime_invalid" -eq 1 ]; then
+            leave_optional_inventory_untouched
+        fi
+    fi
+fi
+
+if [ "$dry_run" -eq 1 ]; then
+    echo "PLAN: uninstall Ableton Linux"
+    printf '  remove the installed Wine runtime and saved previous versions: %s\n' \
+        "${managed_runtimes[*]}"
+    if [ "$optional_inventory_usable" -eq 0 ]; then
+        echo "  leave desktop shortcuts, file-opening settings, and older Wine runtimes unchanged"
+    else
+        echo "  remove Ableton Linux launchers, icons, file-opening support, and diagnostic tools"
+    fi
+    if [ "$mime_prestate_usable" -eq 1 ]; then
+        echo "  restore the file-opening defaults that were in use before installation"
+    elif [ "$optional_inventory_usable" -eq 1 ]; then
+        echo "  clear only file-opening defaults that name Ableton Linux"
+    else
+        echo "  leave file-opening defaults unchanged"
+    fi
+    echo "  remove installer settings and support files"
+    if [ "$delete_prefix" -eq 0 ] && [ -f "$safe_prefix/system.reg" ]; then
+        printf '  remove PipeASIO from the kept Wine prefix: %s\n' "$safe_prefix"
+    fi
+    if ! "$here/setup-link.sh" plan-disable; then
+        warn_optional_notice \
+            "the Link shutdown plan could not be produced; Link settings may remain enabled" \
+            "Close any Ableton Link helper before retrying."
+    fi
+    [ "$delete_prefix" -eq 0 ] || printf '  delete the Wine prefix, including Live and its authorisation: %s\n' "$safe_prefix"
     exit 0
 fi
 
@@ -291,14 +444,19 @@ fi
 # A previous configured runtime may also remain in the ownership manifest.
 # Never delete it while any process still executes from it; those clients are
 # outside the currently selected runtime coordinator and must be closed first.
+declare -A skipped_managed_runtimes=()
 for candidate in "${managed_runtimes[@]}"; do
     [ "$candidate" != "$safe_runtime" ] || continue
+    [ -z "${skipped_managed_runtimes[$candidate]+x}" ] || continue
     for proc in /proc/[0-9]*; do
         pid="${proc#/proc/}"
         exe="$(readlink -f "$proc/exe" 2>/dev/null || true)"
         case "$exe" in "$candidate"/*)
-            echo "!! previously managed runtime $candidate is still in use by PID $pid; close it before uninstalling" >&2
-            exit 1 ;;
+            skipped_managed_runtimes["$candidate"]=1
+            warn_optional_remaining \
+                "an older Wine runtime was left unchanged because PID $pid is using it: $candidate" \
+                "Close that program before retrying if you want this older runtime removed."
+            break ;;
         esac
     done
 done
@@ -307,33 +465,52 @@ done
 # installer state.  Once serialized, verify that the inspected installation did
 # not change while this process was waiting for the lock.
 ableton_install_lock_acquire
-[ "$manifest_before" = "$(ableton_manifest_digest "$manifest" 2>/dev/null || printf absent)" ] || {
-    echo "!! installation ownership changed; retry uninstall" >&2
+if [ "$state_home_overlaps_core" -eq 0 ] \
+   && ableton_install_state_has_active_transaction; then
+    echo "!! unfinished installer recovery appeared while uninstall was waiting; finish or roll it back first" >&2
     exit 1
-}
-[ "$prestate_before" = "$(ableton_manifest_digest "$prestate" 2>/dev/null || printf absent)" ] || {
-    echo "!! pre-install restoration state changed; retry uninstall" >&2
-    exit 1
-}
-[ "$mime_prestate_before" = "$(ableton_manifest_digest "$mime_prestate" 2>/dev/null || printf absent)" ] || {
-    echo "!! MIME restoration state changed; retry uninstall" >&2
-    exit 1
-}
-# The lock serializes project installers, but it may have been contended while
-# consent was gathered.  Re-run the full byte-level and relationship checks,
-# not only the digests, before adopting ownership or stopping anything.
-ableton_validate_install_state_journals || exit 1
-ableton_validate_mime_prestate "$mime_prestate" || exit 1
-validate_uninstall_state || {
-    echo "!! uninstall state changed or became inconsistent; retry uninstall" >&2
-    exit 1
-}
-[ ! -e "$ABLETON_STATE_HOME" ] || ableton_state_marker_valid "$ABLETON_STATE_HOME" \
-    || { [ "$legacy_state_adoption" -eq 1 ] \
-         && ableton_legacy_shortcut_state_valid "$ABLETON_STATE_HOME"; } || {
-    echo "!! installation state ownership changed; retry uninstall" >&2
-    exit 1
-}
+fi
+if [ "$optional_inventory_usable" -eq 1 ]; then
+    manifest_after=unavailable
+    prestate_after=unavailable
+    if ! manifest_after="$(uninstall_state_digest "$manifest" 2>/dev/null)" \
+       || ! prestate_after="$(uninstall_state_digest "$prestate" 2>/dev/null)" \
+       || [ "$manifest_before" != "$manifest_after" ] \
+       || [ "$prestate_before" != "$prestate_after" ] \
+       || ! validate_uninstall_state >/dev/null 2>&1; then
+        leave_optional_inventory_untouched
+    fi
+fi
+if [ "$mime_prestate_usable" -eq 1 ]; then
+    if ! mime_prestate_after="$(ableton_manifest_digest "$mime_prestate" 2>/dev/null)"; then
+        mime_prestate_usable=0
+        warn_optional_remaining \
+            "File-opening defaults were left unchanged because the saved settings at $mime_prestate could not be read again" \
+            "Check the file permissions before retrying."
+    elif [ "$mime_prestate_before" != "$mime_prestate_after" ] \
+       || ! ableton_validate_mime_prestate "$mime_prestate" >/dev/null 2>&1; then
+        mime_prestate_usable=0
+        warn_optional_remaining \
+            "File-opening defaults were left unchanged because their saved settings changed while uninstall was starting: $mime_prestate" \
+            "Review that file, then retry if you still want the old defaults restored."
+    fi
+fi
+if [ "$state_home_usable" -eq 1 ] \
+   && { [ -e "$ABLETON_STATE_HOME" ] || [ -L "$ABLETON_STATE_HOME" ]; } \
+   && ! ableton_state_marker_valid "$ABLETON_STATE_HOME" \
+   && ! { [ "$legacy_state_adoption" -eq 1 ] \
+          && ableton_legacy_shortcut_state_valid "$ABLETON_STATE_HOME"; }; then
+    if [ "$legacy_runtime_adoption" -eq 1 ] || [ "$legacy_prefix_adoption" -eq 1 ]; then
+        echo "!! The Ableton Linux support directory changed while uninstall was starting, so the older runtime or prefix was left unchanged. Run uninstall again." >&2
+        exit 1
+    fi
+    state_home_usable=0
+    legacy_state_adoption=0
+    leave_optional_inventory_untouched
+    warn_optional_remaining \
+        "Ableton Linux support files were left unchanged because their directory changed while uninstall was starting: $ABLETON_STATE_HOME" \
+        "Inspect that directory before retrying."
+fi
 [ ! -L "$ABLETON_WINE_ROOT" ] && [ ! -L "$ABLETON_WINEPREFIX" ] || {
     echo "!! installation paths changed; retry uninstall" >&2
     exit 1
@@ -342,35 +519,49 @@ validate_uninstall_state || {
     || ableton_runtime_marker_valid "$safe_runtime" "$ABLETON_RUNTIME_NAME" \
     || { [ "$legacy_runtime_adoption" -eq 1 ] \
          && ableton_legacy_default_runtime_valid "$safe_runtime"; } || {
-    echo "!! runtime ownership changed; retry uninstall" >&2
+    echo "!! The Wine runtime changed or is no longer recognised; nothing was deleted. Run uninstall again." >&2
     exit 1
 }
 if [ "$delete_prefix" -eq 1 ] && [ -e "$safe_prefix" ]; then
     ableton_prefix_marker_valid "$safe_prefix" "$safe_prefix" \
         || { [ "$legacy_prefix_adoption" -eq 1 ] \
              && ableton_legacy_default_prefix_valid "$safe_prefix"; } || {
-        echo "!! prefix ownership changed; retry uninstall" >&2
+        echo "!! The Wine prefix changed or is no longer recognised; nothing was deleted. Run uninstall again." >&2
         exit 1
     }
 fi
 for candidate in "${managed_runtimes[@]}"; do
+    [ "$candidate" = "$safe_runtime" ] || [ -z "${skipped_managed_runtimes[$candidate]+x}" ] \
+        || continue
     [ ! -e "$candidate" ] \
         || ableton_runtime_marker_valid "$candidate" "${managed_runtime_names[$candidate]}" \
         || { [ "$candidate" = "$safe_runtime" ] \
              && [ "$legacy_runtime_adoption" -eq 1 ] \
              && ableton_legacy_default_runtime_valid "$candidate"; } || {
-        echo "!! runtime ownership changed; retry uninstall: $candidate" >&2
-        exit 1
+        if [ "$candidate" = "$safe_runtime" ]; then
+            echo "!! The Wine runtime at $candidate changed or is no longer recognised; nothing was deleted. Run uninstall again." >&2
+            exit 1
+        fi
+        skipped_managed_runtimes["$candidate"]=1
+        warn_optional_remaining \
+            "an older Wine runtime was left unchanged because the installer no longer recognises it: $candidate" \
+            "Inspect that runtime before retrying."
     }
 done
-if [ "$legacy_state_adoption" -eq 1 ]; then
-    ableton_mark_state_home || {
-        echo "!! legacy installation state could not be adopted safely" >&2
-        exit 1
-    }
+if [ "$legacy_state_adoption" -eq 1 ] \
+   && [ "$legacy_runtime_adoption" -eq 0 ] && [ "$legacy_prefix_adoption" -eq 0 ]; then
+    if ! ableton_mark_state_home; then
+        state_home_usable=0
+        legacy_state_adoption=0
+        leave_optional_inventory_untouched
+        warn_optional_remaining \
+            "legacy shortcut support files were left unchanged because their directory could not be prepared safely" \
+            "Inspect $ABLETON_STATE_HOME before retrying."
+    fi
 fi
 uninstall_adoption_transaction=""
 uninstall_adoption_active=0
+uninstall_adoption_core_complete=0
 uninstall_adoption_cleanup()
 {
     local rc=$? restore_rc=0
@@ -378,19 +569,35 @@ uninstall_adoption_cleanup()
     if [ "$uninstall_adoption_active" -eq 1 ] && [ "$rc" -ne 0 ]; then
         ableton_txn_rollback_files "$uninstall_adoption_transaction" || restore_rc=1
         if [ "$restore_rc" -eq 0 ]; then
-            rm -f -- "$uninstall_adoption_transaction/active" || restore_rc=1
+            rm -f -- "$uninstall_adoption_transaction/active" 2>/dev/null || true
+            if [ -e "$uninstall_adoption_transaction/active" ] \
+               || [ -L "$uninstall_adoption_transaction/active" ]; then
+                restore_rc=1
+            fi
         fi
         if [ "$restore_rc" -eq 0 ]; then
-            rm -rf -- "$uninstall_adoption_transaction" || restore_rc=1
+            rm -rf -- "$uninstall_adoption_transaction" 2>/dev/null || true
+            if [ -e "$uninstall_adoption_transaction" ] \
+               || [ -L "$uninstall_adoption_transaction" ]; then
+                restore_rc=1
+            fi
         fi
         if [ "$restore_rc" -ne 0 ]; then
-            echo "!! legacy ownership-marker restoration or transaction cleanup is incomplete; inspect $uninstall_adoption_transaction" >&2
+            echo "!! Uninstall stopped and the older installation may still need repair. Keep the files at $uninstall_adoption_transaction and report the problem before retrying." >&2
+            print_uninstall_retry
         fi
     fi
     exit "$rc"
 }
 if [ "$legacy_runtime_adoption" -eq 1 ] || [ "$legacy_prefix_adoption" -eq 1 ]; then
-    mkdir -p -- "$ABLETON_STATE_HOME/transactions"
+    # The adoption transaction itself creates project state. Establish that
+    # directory's ownership before creating transactions beneath it, otherwise
+    # a legacy install with no prior state would later look like foreign state
+    # created by the uninstall itself.
+    ableton_prepare_transactions_dir || {
+        echo "!! The older Ableton Linux installation could not be prepared safely, so nothing was deleted." >&2
+        exit 1
+    }
     uninstall_adoption_transaction="$(mktemp -d "$ABLETON_STATE_HOME/transactions/uninstall-adopt.XXXXXX")"
     ABLETON_TRANSACTION_DIR="$uninstall_adoption_transaction"
     export ABLETON_TRANSACTION_DIR
@@ -427,8 +634,11 @@ for candidate in "${managed_runtimes[@]}"; do
         pid="${proc#/proc/}"
         exe="$(readlink -f "$proc/exe" 2>/dev/null || true)"
         case "$exe" in "$candidate"/*)
-            echo "!! previously managed runtime $candidate became busy; retry uninstall" >&2
-            exit 1 ;;
+            skipped_managed_runtimes["$candidate"]=1
+            warn_optional_remaining \
+                "an older Wine runtime was left unchanged because PID $pid began using it: $candidate" \
+                "Close that program before retrying if you want this older runtime removed."
+            break ;;
         esac
     done
 done
@@ -440,21 +650,115 @@ done
 if [ "$uninstall_adoption_active" -eq 1 ]; then
     uninstall_adoption_active=0
     trap - EXIT
-    if ! rm -f -- "$uninstall_adoption_transaction/active" \
-       || ! rm -rf -- "$uninstall_adoption_transaction" \
-       || [ -e "$uninstall_adoption_transaction" ] \
-       || [ -L "$uninstall_adoption_transaction" ]; then
-        echo "!! legacy ownership was adopted, but migration cleanup is incomplete; retry uninstall" >&2
-        exit 1
+    if ableton_mark_transaction_core_complete "$uninstall_adoption_transaction" \
+        2>/dev/null; then
+        uninstall_adoption_core_complete=1
+    fi
+    rm -f -- "$uninstall_adoption_transaction/active" 2>/dev/null || true
+    rm -rf -- "$uninstall_adoption_transaction" 2>/dev/null || true
+    if [ -e "$uninstall_adoption_transaction" ] || [ -L "$uninstall_adoption_transaction" ]; then
+        if [ "$uninstall_adoption_core_complete" -eq 1 ] \
+           || { [ ! -e "$uninstall_adoption_transaction/active" ] \
+                && [ ! -L "$uninstall_adoption_transaction/active" ]; }; then
+            warn_optional_notice \
+                "temporary legacy-install cleanup remains at $uninstall_adoption_transaction" \
+                "Check its permissions; the recognised installation is already safe to retry."
+        else
+            warn_optional_remaining \
+                "temporary legacy-install cleanup remains active at $uninstall_adoption_transaction" \
+                "Keep those files for inspection before retrying."
+        fi
     fi
 fi
 
-echo "== stop project-owned services and processes =="
+# Resolve every recursive runtime target before deleting any of them. A failed
+# or partial directory scan must not look like an empty rollback inventory.
+managed_rollbacks=()
+declare -A managed_rollback_names=()
+declare -A managed_rollback_owners=()
+declare -A skipped_managed_rollbacks=()
+runtime_inventory=""
+if ! runtime_inventory="$(mktemp "${TMPDIR:-/tmp}/ableton-uninstall-runtimes.XXXXXX")"; then
+    warn_optional_notice \
+        "older saved Wine runtimes could not be inspected because a temporary uninstall file could not be created" \
+        "Remove any older saved runtimes manually, or retry after checking the temporary-directory permissions."
+fi
+if [ -n "$runtime_inventory" ]; then
+    for candidate in "${managed_runtimes[@]}"; do
+        [ -z "${skipped_managed_runtimes[$candidate]+x}" ] || continue
+        if ! runtime_parent="$(dirname "$candidate")" \
+           || ! runtime_base="$(basename "$candidate")"; then
+            warn_optional_remaining \
+                "older saved Wine runtimes related to $candidate could not be located" \
+                "Retry after checking that the standard path tools are working."
+            continue
+        fi
+        if [ -e "$runtime_parent" ] || [ -L "$runtime_parent" ]; then
+            if [ ! -d "$runtime_parent" ] || [ -L "$runtime_parent" ]; then
+                warn_optional_remaining \
+                    "older saved Wine runtimes were left unchanged because their parent directory is not safe to inspect: $runtime_parent" \
+                    "Inspect that path before retrying."
+                continue
+            fi
+        else
+            continue
+        fi
+        if ! : > "$runtime_inventory"; then
+            warn_optional_notice \
+                "older saved Wine runtimes could not be inspected because the temporary uninstall file is not writable: $runtime_inventory" \
+                "Check that file and the temporary-directory permissions before retrying."
+            break
+        fi
+        if ! find "$runtime_parent" -maxdepth 1 -mindepth 1 -type d -print0 \
+            > "$runtime_inventory" 2>/dev/null; then
+            warn_optional_remaining \
+                "older saved Wine runtimes were left unchanged because $runtime_parent could not be inspected" \
+                "Check the directory permissions before retrying."
+            continue
+        fi
+        while IFS= read -r -d '' old_runtime; do
+            if ! old_runtime_base="$(basename "$old_runtime")"; then
+                warn_optional_remaining \
+                    "an older saved Wine runtime could not be identified and was left unchanged: $old_runtime" \
+                    "Inspect that path before retrying."
+                continue
+            fi
+            if [[ "$old_runtime_base" != "$runtime_base-rollback-"* \
+               && "$old_runtime_base" != "$runtime_base.failed-"* \
+               && "$old_runtime_base" != "$runtime_base.transaction-"* ]]; then
+                continue
+            fi
+            if ! old_runtime_safe="$(ableton_path_is_safe_delete_target "$old_runtime")" \
+               || [ "$old_runtime_safe" != "$old_runtime" ] || [ -L "$old_runtime" ] \
+               || ! ableton_runtime_marker_valid \
+                    "$old_runtime" "${managed_runtime_names[$candidate]}"; then
+                warn_optional_remaining \
+                    "an unrecognised saved Wine runtime was left unchanged at $old_runtime" \
+                    "Inspect it and remove it manually only if you are certain it belongs to this project."
+                continue
+            fi
+            managed_rollbacks+=("$old_runtime")
+            managed_rollback_names["$old_runtime"]="${managed_runtime_names[$candidate]}"
+            managed_rollback_owners["$old_runtime"]="$candidate"
+        done < "$runtime_inventory"
+    done
+    rm -f -- "$runtime_inventory" 2>/dev/null || true
+    if [ -e "$runtime_inventory" ] || [ -L "$runtime_inventory" ]; then
+        warn_optional_notice \
+            "a temporary uninstall file remains at $runtime_inventory" \
+            "Check its permissions, then remove it or retry uninstall."
+    fi
+fi
+
+uninstall_note "== stop Ableton Linux background services =="
 uninstall_partial=0
-# A MIME failure must not reach the gate that guards the runtime removal, so
-# this folds it into uninstall_partial only at the final gate.
-mime_partial=0
-"$here/setup-link.sh" disable
+mime_backend_unavailable=0
+if [ "$optional_inventory_usable" -eq 1 ] \
+   && ! "$here/setup-link.sh" disable; then
+    warn_optional_remaining \
+        "Ableton Link integration may still be enabled" \
+        "Close any Link helper and check the user service before retrying."
+fi
 # Not "busy && stop": under set -euo pipefail a straggler that survives the stop
 # makes the compound fail, and the script exits here - after the trap is cleared,
 # silently, skipping the PipeASIO unregister, the shortcut restore, the MIME
@@ -465,10 +769,15 @@ if ableton_prefix_busy "$safe_runtime" "$safe_prefix"; then
     # before any rm -rf, so marking the uninstall partial is what stops a live
     # client having its runtime - and, under --delete-prefix, its prefix - removed
     # from underneath it.  None of the deletion sites re-check for processes.
-    ableton_stop_prefix "$safe_runtime" "$safe_prefix" || {
-        echo "!! a program in the prefix outlived the stop; keeping the runtime and prefix" >&2
+    ableton_stop_prefix "$safe_runtime" "$safe_prefix" || true
+    if ableton_prefix_busy "$safe_runtime" "$safe_prefix"; then
+        echo "!! A Wine program is still running, so the Wine runtime and prefix were left unchanged." >&2
         uninstall_partial=1
-    }
+    fi
+fi
+if [ "$uninstall_partial" -eq 1 ]; then
+    echo "!! close the remaining Wine program, then run uninstall again" >&2
+    exit 1
 fi
 
 # A retained prefix must not keep a CLSID pointing into a runtime that is about
@@ -488,23 +797,35 @@ if [ "$delete_prefix" -eq 0 ] && [ -f "$safe_prefix/system.reg" ]; then
     {
         ableton_prefix_wait "$safe_runtime" "$safe_prefix"
     }
-    echo "== unregister PipeASIO from the retained prefix =="
+    uninstall_note "== unregister PipeASIO from the retained prefix =="
     ableton_pipeasio_unregister uninstall_wine uninstall_wineserver_wait
 fi
 
 shortcut_helper="$ABLETON_DATA_HOME/shortcut-hold.sh"
 shortcut_state="$ABLETON_STATE_HOME/hold-v2"
 legacy_shortcut_state="$safe_prefix/.ableton-shortcut-hold"
-if [ -e "$shortcut_state" ] || [ -e "$legacy_shortcut_state" ]; then
+if [ "$optional_inventory_usable" -eq 1 ] \
+   && { [ -e "$shortcut_state" ] || [ -e "$legacy_shortcut_state" ]; }; then
     if [ -r "$shortcut_helper" ] && command -v gsettings >/dev/null 2>&1; then
         # prepare with holding disabled performs both V1 migration and V2 crash
         # recovery, while preserving any shortcut the user changed meanwhile.
-        . "$shortcut_helper"
-        ABLETON_SHORTCUTS=preserve ableton_shortcuts_prepare "" "$legacy_shortcut_state" 0
+        if ! ableton_legacy_owned_path "$shortcut_helper" \
+           || ! . "$shortcut_helper" 2>/dev/null \
+           || ! declare -F ableton_shortcuts_prepare >/dev/null 2>&1; then
+            warn_optional_remaining \
+                "GNOME shortcut restoration was skipped because its project helper could not be used: $shortcut_helper" \
+                "Keep the saved shortcut values, repair or reinstall that helper, then retry."
+        elif ! ABLETON_SHORTCUTS=preserve \
+             ableton_shortcuts_prepare "" "$legacy_shortcut_state" 0; then
+            warn_optional_remaining \
+                "GNOME shortcut restoration did not finish; saved values remain under $ABLETON_STATE_HOME" \
+                "Close Live and make sure gsettings is available before retrying."
+        fi
     fi
     if [ -e "$shortcut_state" ] || [ -e "$legacy_shortcut_state" ]; then
-        echo "!! shortcut recovery state could not be fully restored; keeping installer state for retry" >&2
-        uninstall_partial=1
+        warn_optional_remaining \
+            "GNOME shortcut restoration is incomplete; saved values remain at ${shortcut_state}${legacy_shortcut_state:+ or $legacy_shortcut_state}" \
+            "Close Live and make sure gsettings can update your desktop shortcuts."
     fi
 fi
 
@@ -524,115 +845,444 @@ live_entry_launcher_updated()
     ableton_legacy_owned_path "$path"
 }
 
+# A launcher replacement keeps the displaced object beside the generated
+# launcher as <name>.bak.  New installations deliberately do not duplicate that
+# object in the support directory, so the adjacent copy is the user's recovery
+# copy.  Resolve the two manifest records together: deleting them independently
+# would delete both the generated launcher and the object it replaced.
+restore_adjacent_launcher_backup()
+{
+    local path="$1" path_digest="$2" saved="$3" saved_digest="$4"
+    local saved_prestate="${5:-}" saved_prestate_digest="${6:-}"
+    local current="" saved_current="" restored="" project_launcher=0
+
+    if [ -e "$path" ] || [ -L "$path" ]; then
+        current="$(ableton_manifest_digest "$path" 2>/dev/null || true)"
+    fi
+    if [ -e "$saved" ] || [ -L "$saved" ]; then
+        saved_current="$(ableton_manifest_digest "$saved" 2>/dev/null || true)"
+    fi
+
+    # A previous attempt may have restored the exact saved launcher and then
+    # failed to remove its adjacent copy.  Finish that retry without mistaking
+    # the restored launcher for an unrecognised modification.
+    if [ -n "$current" ] && [ "$current" = "$saved_digest" ]; then
+        if [ -n "$saved_prestate" ]; then
+            restore_adjacent_backup_prestate \
+                "$saved" "$saved_prestate" "$saved_prestate_digest" "$saved_digest"
+            return 0
+        fi
+        if [ "$saved_current" = "$saved_digest" ]; then
+            rm -f -- "$saved" 2>/dev/null || true
+            if [ -e "$saved" ] || [ -L "$saved" ]; then
+                warn_optional_remaining \
+                    "the earlier launcher is restored at $path, but its extra saved copy remains at $saved" \
+                    "Check the saved copy's permissions before retrying."
+            else
+                uninstall_note "kept restored launcher $path"
+            fi
+        elif [ ! -e "$saved" ] && [ ! -L "$saved" ]; then
+            uninstall_note "kept restored launcher $path"
+        else
+            warn_optional_remaining \
+                "kept the restored launcher at $path and a changed saved copy at $saved" \
+                "Review the changed saved copy before moving or deleting it."
+        fi
+        return 0
+    fi
+
+    if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+        project_launcher=1
+    elif [ -n "$current" ] && [ "$current" = "$path_digest" ]; then
+        project_launcher=1
+    elif live_entry_launcher_updated "$path" \
+         || ableton_legacy_owned_path "$path"; then
+        project_launcher=1
+    fi
+
+    if [ "$project_launcher" -ne 1 ]; then
+        warn_optional_remaining \
+            "kept the user-modified launcher at $path and its saved earlier launcher at $saved" \
+            "Review both files and move your preferred launcher into place before retrying."
+        return 0
+    fi
+    if [ -z "$saved_current" ] || [ "$saved_current" != "$saved_digest" ]; then
+        warn_optional_remaining \
+            "the project launcher at $path was left unchanged because its saved earlier launcher is missing or changed: $saved" \
+            "Restore or review the saved launcher before retrying."
+        return 0
+    fi
+
+    ableton_atomic_restore_object "$saved" "$path" 2>/dev/null || true
+    restored="$(ableton_manifest_digest "$path" 2>/dev/null || true)"
+    if [ "$restored" != "$saved_digest" ]; then
+        warn_optional_remaining \
+            "the earlier launcher at $saved could not be restored at $path; both files were kept" \
+            "Check the destination permissions before retrying."
+        return 0
+    fi
+
+    if [ -n "$saved_prestate" ]; then
+        restore_adjacent_backup_prestate \
+            "$saved" "$saved_prestate" "$saved_prestate_digest" "$saved_digest"
+        return 0
+    fi
+
+    rm -f -- "$saved" 2>/dev/null || true
+    if [ -e "$saved" ] || [ -L "$saved" ]; then
+        warn_optional_remaining \
+            "the earlier launcher was restored at $path, but its extra saved copy remains at $saved" \
+            "Check the saved copy's permissions before retrying."
+    else
+        uninstall_note "restored earlier launcher $path"
+    fi
+    return 0
+}
+
+# After the adjacent launcher has returned to its canonical path, put back a
+# foreign object that occupied <launcher>.bak before installation. The current
+# adjacent object may be replaced only when it is the managed displaced
+# launcher; any other bytes are preserved alongside the durable saved copy.
+restore_adjacent_backup_prestate()
+{
+    local path="$1" backup="$2" backup_digest="$3" replaceable_digest="$4"
+    local current=""
+    if [ -e "$path" ] || [ -L "$path" ]; then
+        current="$(ableton_manifest_digest "$path" 2>/dev/null || true)"
+    fi
+    if [ "$current" = "$backup_digest" ]; then
+        uninstall_note "kept your already-restored earlier file at $path"
+        return 0
+    fi
+    if [ -n "$current" ] && [ "$current" != "$replaceable_digest" ]; then
+        warn_optional_remaining \
+            "kept a changed saved launcher at $path and its earlier copy at $backup" \
+            "Review both files and keep the one you want before retrying."
+        return 0
+    fi
+    ableton_atomic_restore_object "$backup" "$path" 2>/dev/null || true
+    if [ "$(ableton_manifest_digest "$path" 2>/dev/null || true)" != "$backup_digest" ]; then
+        warn_optional_remaining \
+            "the earlier file was not restored at $path; its saved copy remains at $backup" \
+            "Check the destination permissions before retrying."
+    else
+        uninstall_note "restored your earlier file at $path"
+    fi
+    return 0
+}
+
 remove_owned_manifest_files()
 {
-    local kind path digest current backup backup_digest backup_expected backup_count
-    local prestate="$ABLETON_STATE_HOME/install-prestate.tsv" rc=0
+    local kind path digest extra current backup backup_digest backup_expected backup_count record
+    local launcher saved_path prestate_status prestate_path prestate_backup prestate_digest
+    local prestate="$ABLETON_STATE_HOME/install-prestate.tsv" path_hash_record path_hash
+    local -a owned_records=() prestate_records=()
+    local -A owned_kinds=() owned_digests=() prestate_paths=()
+    local -A prestate_backups=() prestate_digests=()
+    local -A launcher_backups=() backup_launchers=()
     [ -r "$manifest" ] || return 1
-    while IFS=$'\t' read -r kind path digest; do
+    if ! mapfile -t owned_records < "$manifest"; then
+        echo "!! The list of installed support files could not be read; no other support files were removed." >&2
+        return 1
+    fi
+    # Build the complete relation before mutating either member.  Pairing is a
+    # fallback only for current snapshot-free installs; an older persistent
+    # pre-install record remains authoritative for both paths.
+    for record in "${owned_records[@]}"; do
+        if ! IFS=$'\t' read -r kind path digest extra <<< "$record" \
+           || [ -n "$extra" ]; then
+            echo "!! The list of installed support files is not recognised; no other support files were removed." >&2
+            return 1
+        fi
         case "$kind" in
             file|config|symlink)
+                owned_kinds["$path"]="$kind"
+                owned_digests["$path"]="$digest" ;;
+            runtime) ;;
+        esac
+    done
+    if [ -r "$prestate" ]; then
+        if ! mapfile -t prestate_records < "$prestate"; then
+            echo "!! The saved copies of files replaced during installation could not be read; no other support files were removed." >&2
+            return 1
+        fi
+        for record in "${prestate_records[@]}"; do
+            if ! IFS=$'\t' read -r prestate_status prestate_path prestate_backup extra \
+                 <<< "$record" \
+               || [ -n "$extra" ] || [ "$prestate_status" != present ]; then
+                echo "!! The saved copies of files replaced during installation are not recognised; no other support files were removed." >&2
+                return 1
+            fi
+            prestate_digest="$(ableton_manifest_digest "$prestate_backup" 2>/dev/null || true)"
+            if [ -z "$prestate_digest" ]; then
+                echo "!! A saved earlier file could not be read; no other support files were removed." >&2
+                return 1
+            fi
+            prestate_paths["$prestate_path"]=1
+            prestate_backups["$prestate_path"]="$prestate_backup"
+            prestate_digests["$prestate_path"]="$prestate_digest"
+        done
+    fi
+    for saved_path in "${!owned_kinds[@]}"; do
+        case "$saved_path" in *.bak) ;; *) continue ;; esac
+        launcher="${saved_path%.bak}"
+        [ -n "${owned_kinds[$launcher]+x}" ] || continue
+        ableton_launcher_path_allowed "$launcher" || continue
+        case "${owned_kinds[$launcher]}:${owned_kinds[$saved_path]}" in
+            file:file|file:symlink|symlink:file|symlink:symlink) ;;
+            *) continue ;;
+        esac
+        [ -z "${prestate_paths[$launcher]+x}" ] || continue
+        # A launcher from an older release can be byte-identical to the new
+        # one while differing only in mode. Both manifest rows then have the
+        # same digest, so there is no distinct foreign object to resurrect.
+        # Let the normal per-record cleanup remove them (and independently
+        # restore anything that previously occupied the adjacent path). This
+        # also remains correct when a previous uninstall already removed one
+        # member of the pair.
+        [ "${owned_digests[$launcher]}" != "${owned_digests[$saved_path]}" ] \
+            || continue
+        launcher_backups["$launcher"]="$saved_path"
+        backup_launchers["$saved_path"]="$launcher"
+    done
+    for record in "${owned_records[@]}"; do
+        if ! IFS=$'\t' read -r kind path digest extra <<< "$record" \
+           || [ -n "$extra" ]; then
+            echo "!! The list of installed support files is not recognised; no other support files were removed." >&2
+            return 1
+        fi
+        case "$kind" in
+            file|config|symlink)
+                # The canonical record resolves a snapshot-free launcher pair.
+                # Skip the adjacent row so it can never be deleted first.
+                [ -z "${backup_launchers[$path]+x}" ] || continue
+                if [ -n "${launcher_backups[$path]+x}" ]; then
+                    saved_path="${launcher_backups[$path]}"
+                    restore_adjacent_launcher_backup \
+                        "$path" "$digest" "$saved_path" "${owned_digests[$saved_path]}" \
+                        "${prestate_backups[$saved_path]-}" \
+                        "${prestate_digests[$saved_path]-}"
+                    continue
+                fi
                 backup=""
                 if [ -r "$prestate" ]; then
                     backup_count="$(awk -F '\t' -v p="$path" \
-                        '$1=="present" && $2==p { n++ } END { print n+0 }' "$prestate")"
-                    backup="$(awk -F '\t' -v p="$path" '$1=="present" && $2==p { print $3; exit }' "$prestate")"
+                        '$1=="present" && $2==p { n++ } END { print n+0 }' "$prestate")" || {
+                        echo "!! The saved copies of replaced files could not be checked; no other support files were removed." >&2
+                        return 1
+                    }
+                    backup="$(awk -F '\t' -v p="$path" \
+                        '$1=="present" && $2==p { print $3; exit }' "$prestate")" || {
+                        echo "!! The saved earlier copy of $path could not be checked; no other support files were removed." >&2
+                        return 1
+                    }
+                    case "$backup_count" in ''|*[!0-9]*)
+                        echo "!! The saved earlier copy of $path is not recognised; no other support files were removed." >&2
+                        return 1 ;;
+                    esac
                     if [ "$backup_count" -gt 1 ]; then
-                        echo "!! pre-install state is ambiguous for $path" >&2
-                        rc=1; uninstall_partial=1; continue
+                        echo "!! More than one earlier copy was recorded for $path, so it was left unchanged." >&2
+                        return 1
                     fi
                 fi
                 if [ -n "$backup" ]; then
-                    backup_expected="$ABLETON_STATE_HOME/install-prestate/$(printf '%s' "$path" | sha256sum | awk '{print $1}')"
+                    path_hash_record="$(printf '%s' "$path" | sha256sum)" || {
+                        echo "!! The saved earlier copy of $path could not be verified; no other support files were removed." >&2
+                        return 1
+                    }
+                    path_hash="${path_hash_record%% *}"
+                    [[ "$path_hash" =~ ^[0-9a-f]{64}$ ]] || {
+                        echo "!! The saved earlier copy of $path could not be verified; no other support files were removed." >&2
+                        return 1
+                    }
+                    backup_expected="$ABLETON_STATE_HOME/install-prestate/$path_hash"
                     if [ "$backup" != "$backup_expected" ] \
                        || { [ ! -f "$backup" ] && [ ! -L "$backup" ]; }; then
-                        echo "!! cannot safely restore the recorded pre-install file $path" >&2
-                        rc=1; uninstall_partial=1; continue
+                        echo "!! The earlier copy of $path could not be restored safely; no other support files were removed." >&2
+                        return 1
                     fi
                     backup_digest="$(ableton_manifest_digest "$backup" 2>/dev/null || true)"
                     if [ -z "$backup_digest" ]; then
-                        echo "!! cannot read the recorded pre-install file $path" >&2
-                        rc=1; uninstall_partial=1; continue
+                        echo "!! The earlier copy of $path could not be read; no other support files were removed." >&2
+                        return 1
                     fi
                 fi
                 if [ ! -e "$path" ] && [ ! -L "$path" ]; then
                     if [ -n "$backup" ]; then
-                        if ! ableton_atomic_restore_object "$backup" "$path" \
-                           || [ "$(ableton_manifest_digest "$path" 2>/dev/null || true)" != "$backup_digest" ]; then
-                            echo "!! could not restore pre-install file $path" >&2
-                            rc=1; uninstall_partial=1
+                        ableton_atomic_restore_object "$backup" "$path" || true
+                        if [ "$(ableton_manifest_digest "$path" 2>/dev/null || true)" != "$backup_digest" ]; then
+                            warn_optional_remaining \
+                                "the earlier file was not restored at $path; its saved copy remains at $backup" \
+                                "Check the destination permissions before retrying."
                         else
-                            echo "restored pre-install file $path"
+                            uninstall_note "restored your earlier file at $path"
                         fi
                     fi
                     continue
                 fi
                 current="$(ableton_manifest_digest "$path" 2>/dev/null || true)"
-                if [ "$current" = "$digest" ] || live_entry_launcher_updated "$path"; then
+                if [ "$current" = "$digest" ] || live_entry_launcher_updated "$path" \
+                   || ableton_legacy_owned_path "$path"; then
                     if [ -n "$backup" ]; then
-                        if ! ableton_atomic_restore_object "$backup" "$path" \
-                           || [ "$(ableton_manifest_digest "$path" 2>/dev/null || true)" != "$backup_digest" ]; then
-                            echo "!! managed file could not be replaced by its pre-install file: $path" >&2
-                            rc=1; uninstall_partial=1
+                        ableton_atomic_restore_object "$backup" "$path" || true
+                        if [ "$(ableton_manifest_digest "$path" 2>/dev/null || true)" != "$backup_digest" ]; then
+                            warn_optional_remaining \
+                                "the Ableton Linux file at $path could not be replaced by its saved earlier copy at $backup" \
+                                "Check both paths and their permissions before retrying."
                         else
-                            echo "restored pre-install file $path"
+                            uninstall_note "restored your earlier file at $path"
                         fi
                     else
-                        if ! rm -f -- "$path" || [ -e "$path" ] || [ -L "$path" ]; then
-                            echo "!! could not remove managed file $path" >&2
-                            rc=1; uninstall_partial=1
+                        rm -f -- "$path" 2>/dev/null || true
+                        if [ -e "$path" ] || [ -L "$path" ]; then
+                            warn_optional_remaining \
+                                "an Ableton Linux file remains at $path" \
+                                "Check the file permissions before retrying."
                         else
-                            echo "removed $path"
+                            uninstall_note "removed $path"
                         fi
                     fi
                 elif [ -n "$backup" ] && [ "$current" = "$backup_digest" ]; then
                     # A prior partial uninstall may already have restored this
                     # exact pre-install object before another path failed.
                     # Treat that as completed work so a retry can finish.
-                    echo "kept already-restored pre-install file $path"
+                    uninstall_note "kept your already-restored earlier file at $path"
                 else
                     if [ "$kind" = config ]; then
-                        echo "kept user-modified configuration $path"
+                        warn_optional_remaining \
+                            "kept user-modified configuration at $path" \
+                            "Move or delete it yourself only if you no longer need those settings."
                     elif [ "$kind" = symlink ]; then
-                        echo "kept user-owned link $path"
+                        warn_optional_remaining \
+                            "kept a link at $path because it was changed or points somewhere else" \
+                            "Remove it yourself only if you recognise it as obsolete."
                     elif [ "$pr182_custom_link_adoption" -eq 1 ] \
                          && [ "$path" = "$ABLETON_LINKD" ]; then
-                        echo "kept modified former PR #182 Link binary $path"
+                        warn_optional_remaining \
+                            "kept a modified custom Ableton Link helper at $path" \
+                            "Remove it yourself only if you no longer use that custom Link helper."
                     else
-                        echo "kept modified file $path" >&2
-                        uninstall_partial=1
+                        warn_optional_remaining \
+                            "kept an unrecognised or user-modified file at $path" \
+                            "Move it aside only if you are certain it belongs to this project."
                     fi
                 fi ;;
             runtime) ;;
         esac
-    done < "$manifest"
-    return "$rc"
+    done
+    return 0
 }
 
 remove_legacy_files()
 {
     local data_root apps icons mime path source relative
+    local legacy_data_root legacy_version legacy_version_digest=""
+    local legacy_project_proven=0
     data_root="${XDG_DATA_HOME:-$HOME/.local/share}"
     apps="$data_root/applications"; icons="$data_root/icons/hicolor"; mime="$data_root/mime/packages"
+    legacy_data_root="$(ableton_realpath_m "$HOME/.local/share/ableton-wine")" || legacy_data_root=""
+    legacy_version="$legacy_data_root/VERSION"
+    if [ -n "$legacy_data_root" ] && ableton_legacy_project_evidence; then
+        legacy_project_proven=1
+        legacy_version_digest="$(ableton_manifest_digest "$legacy_version" 2>/dev/null || true)"
+    fi
 
     legacy_remove_if_owned()
     {
-        local target="$1" original="${2:-}"
+        local target="$1" original="${2:-}" owned_data_home="${3:-}" owned=0
         [ -e "$target" ] || [ -L "$target" ] || return 0
-        if ableton_legacy_owned_path "$target" \
-           || { [ -n "$original" ] && [ -f "$original" ] && cmp -s -- "$original" "$target"; }; then
-            rm -f -- "$target"
-            echo "removed legacy project file $target"
+        if [ -n "$owned_data_home" ]; then
+            ABLETON_DATA_HOME="$owned_data_home" \
+                ableton_legacy_owned_path "$target" && owned=1
+        elif ableton_legacy_owned_path "$target"; then
+            owned=1
+        fi
+        if [ "$owned" -eq 1 ] \
+           || { [ -n "$original" ] && [ -f "$original" ] \
+                && [ ! -L "$target" ] && cmp -s -- "$original" "$target"; }; then
+            rm -f -- "$target" 2>/dev/null || true
+            if [ -e "$target" ] || [ -L "$target" ]; then
+                warn_optional_remaining \
+                    "an Ableton Linux file from an older release remains at $target" \
+                    "Check its permissions before retrying."
+            else
+                uninstall_note "removed an Ableton Linux file from an older release: $target"
+            fi
         else
             # Wine and other packages install files under these names, and this
             # branch has no digest to tell one of those from a file of ours that
             # the user changed.  Stop rather than guess.
-            echo "kept unrecognised or modified legacy file $target" >&2
-            echo "   this project did not install it, or you changed it. Move or delete" >&2
-            echo "   it, then run uninstall again to finish." >&2
-            uninstall_partial=1
+            warn_optional_remaining \
+                "kept an unrecognised or modified file at $target" \
+                "Move it aside only if you are certain it belongs to this project."
         fi
     }
+
+    # Old installers wrote these files to the historical HOME path even when
+    # XDG_DATA_HOME pointed elsewhere.  Delete only byte-identical packaged
+    # helpers after the launcher/VERSION pair has proved that this is one of
+    # those installations. A locally edited or merely same-named file stays.
+    legacy_remove_if_exact()
+    {
+        local target="$1" original exact=0
+        shift
+        [ -e "$target" ] || [ -L "$target" ] || return 0
+        if [ -f "$target" ] && [ ! -L "$target" ]; then
+            for original in "$@"; do
+                if [ -f "$original" ] && [ ! -L "$original" ] \
+                   && cmp -s -- "$original" "$target"; then
+                    exact=1
+                    break
+                fi
+            done
+        fi
+        if [ "$exact" -eq 1 ]; then
+            rm -f -- "$target" 2>/dev/null || true
+            if [ -e "$target" ] || [ -L "$target" ]; then
+                warn_optional_remaining \
+                    "an Ableton Linux file from an older release remains at $target" \
+                    "Check its permissions before retrying."
+            else
+                uninstall_note "removed an Ableton Linux file from an older release: $target"
+            fi
+        else
+            warn_optional_remaining \
+                "kept a modified or unrecognised older support file at $target" \
+                "Remove it manually only if you no longer need it."
+        fi
+    }
+
+    if [ "$legacy_project_proven" -eq 1 ]; then
+        legacy_remove_if_exact "$legacy_data_root/detect-scale.sh" \
+            "$here/detect-scale.sh"
+        legacy_remove_if_exact "$legacy_data_root/detect-theme.sh" \
+            "$here/detect-theme.sh"
+        legacy_remove_if_exact "$legacy_data_root/shortcut-hold.sh" \
+            "$here/shortcut-hold.sh"
+        legacy_remove_if_exact "$legacy_data_root/check-ntsync.sh" \
+            "$here/check-ntsync.sh"
+        legacy_remove_if_exact "$legacy_data_root/setup-link.sh" \
+            "$here/setup-link.sh"
+        legacy_remove_if_exact "$legacy_data_root/ableton-linkctl" \
+            "$here/ableton-linkctl"
+        legacy_remove_if_exact "$legacy_data_root/ableton-linkd.service" \
+            "$here/ableton-linkd.service"
+        legacy_remove_if_exact "$legacy_data_root/setsyscolors.exe" \
+            "$here/setsyscolors.exe" "$here/../tools/setsyscolors.exe"
+        legacy_remove_if_exact "$legacy_data_root/learnheal.exe" \
+            "$here/learnheal.exe" "$here/../tools/learnheal.exe"
+        legacy_remove_if_exact "$legacy_data_root/ableton-linkd" \
+            "$here/ableton-linkd" "$here/../bin/ableton-linkd" \
+            "$here/../dist/ableton-linkd"
+        legacy_remove_if_owned "$legacy_data_root/$ABLETON_PROTOCOL_DESKTOP_ID" \
+            "" "$legacy_data_root"
+        legacy_remove_if_owned "$legacy_data_root/$ABLETON_AUZ_DESKTOP_ID" \
+            "" "$legacy_data_root"
+        legacy_remove_if_owned "$legacy_data_root/wine-protocol-ableton.desktop" \
+            "" "$legacy_data_root"
+        legacy_remove_if_owned "$legacy_data_root/wine-extension-auz.desktop" \
+            "" "$legacy_data_root"
+    fi
 
     for path in \
         "$ABLETON_BIN_HOME/ableton-live" "$ABLETON_BIN_HOME/max9" \
@@ -654,6 +1304,28 @@ remove_legacy_files()
         relative="${source#"$here/../desktop/icons/"}"
         legacy_remove_if_owned "$icons/$relative" "$source"
     done
+    if [ "$legacy_project_proven" -eq 1 ] \
+       && [ -n "$legacy_version_digest" ] \
+       && [ -f "$legacy_version" ] && [ ! -L "$legacy_version" ]; then
+        if [ "$(ableton_manifest_digest "$legacy_version" 2>/dev/null || true)" \
+             = "$legacy_version_digest" ]; then
+            rm -f -- "$legacy_version" 2>/dev/null || true
+            if [ -e "$legacy_version" ] || [ -L "$legacy_version" ]; then
+                warn_optional_remaining \
+                    "the older Ableton Linux version record remains at $legacy_version" \
+                    "Check its permissions before retrying."
+            else
+                uninstall_note "removed the older Ableton Linux version record: $legacy_version"
+            fi
+        else
+            warn_optional_remaining \
+                "kept the older Ableton Linux version record because it changed during uninstall: $legacy_version" \
+                "Inspect it and remove it manually only if you recognise it."
+        fi
+    fi
+    if [ "$legacy_project_proven" -eq 1 ]; then
+        rmdir -- "$legacy_data_root" 2>/dev/null || true
+    fi
 }
 
 # PipeASIO 1.5 panel projections from the pre-manifest installer are adopted
@@ -661,22 +1333,34 @@ remove_legacy_files()
 # before removing the legacy VERSION/runtime evidence used by that check.
 remove_legacy_panel_files()
 {
-    local path
+    local path manifest_count
     for path in \
         "$ABLETON_BIN_HOME/pipeasio-settings" \
         "${XDG_DATA_HOME:-$HOME/.local/share}/applications/pipeasio-settings.desktop" \
         "${XDG_DATA_HOME:-$HOME/.local/share}/icons/hicolor/scalable/apps/pipeasio.svg"; do
         [ -e "$path" ] || [ -L "$path" ] || continue
-        if [ -r "$manifest" ] && awk -F '\t' -v p="$path" \
-            '$2==p && ($1=="file" || $1=="config" || $1=="symlink") { found=1 } END { exit !found }' \
-            "$manifest"; then
-            continue
+        if [ -r "$manifest" ]; then
+            manifest_count="$(awk -F '\t' -v p="$path" \
+                '$2==p && ($1=="file" || $1=="config" || $1=="symlink") { n++ } END { print n+0 }' \
+                "$manifest")" || return 1
+            case "$manifest_count" in ''|*[!0-9]*)
+                return 1 ;;
+            esac
+            [ "$manifest_count" -eq 0 ] || continue
         fi
         if ableton_legacy_owned_path "$path"; then
-            rm -f -- "$path"
-            echo "removed legacy PipeASIO panel file $path"
+            rm -f -- "$path" 2>/dev/null || true
+            if [ -e "$path" ] || [ -L "$path" ]; then
+                warn_optional_remaining \
+                    "a PipeASIO Settings file from an older release remains at $path" \
+                    "Check its permissions before retrying."
+            else
+                uninstall_note "removed a PipeASIO Settings file from an older release: $path"
+            fi
         else
-            echo "kept independently installed PipeASIO panel file $path"
+            warn_optional_remaining \
+                "kept an independently installed PipeASIO panel file at $path" \
+                "Remove it yourself only if you no longer use that panel installation."
         fi
     done
 }
@@ -700,12 +1384,23 @@ mime_explicit_default()
     ' "$file"
 }
 
+discard_mime_scratch()
+{
+    local tmp="$1"
+    rm -f -- "$tmp" 2>/dev/null || true
+    if [ -e "$tmp" ] || [ -L "$tmp" ]; then
+        warn_optional_notice \
+            "a temporary file-opening settings file remains at $tmp" \
+            "Check its permissions, then remove it or retry uninstall."
+    fi
+}
+
 # Drop one type's default.  Group aware for the same reason as the reader: an
 # "[Added Associations]" line is the user's own list of applications that may
 # open the file, and this project never wrote it.
 mime_clear_default()
 {
-    local file="$1" type="$2" tmp
+    local file="$1" type="$2" tmp explicit_after
     [ -f "$file" ] || return 0
     tmp="$(mktemp "$(dirname "$file")/.mimeapps.XXXXXX")" || return 1
     if ! awk -v t="$type" '
@@ -716,18 +1411,23 @@ mime_clear_default()
         }
         { print }
     ' "$file" > "$tmp"; then
-        rm -f -- "$tmp"
+        discard_mime_scratch "$tmp"
         return 1
     fi
     # Copy the original mode so mv is fully atomic and mode-preserving.  The old
     # sed -i also renamed into place; cat > "$file" truncates first, so a kill
     # mid-write leaves the user's list empty.  Surviving a symlinked
     # mimeapps.list is a bonus, not the main reason.
-    if ! chmod --reference="$file" "$tmp" || ! mv -f -- "$tmp" "$file"; then
-        echo "!! could not restore mimeapps.list from $tmp" >&2
-        return 1
+    if chmod --reference="$file" "$tmp"; then
+        mv -f -- "$tmp" "$file" 2>/dev/null || true
     fi
-    return 0
+    if explicit_after="$(mime_explicit_default "$file" "$type" 2>/dev/null)" \
+       && ! mime_id_is_managed "$explicit_after"; then
+        discard_mime_scratch "$tmp"
+        return 0
+    fi
+    discard_mime_scratch "$tmp"
+    return 1
 }
 
 mime_id_is_managed()
@@ -741,6 +1441,20 @@ mime_id_is_managed()
     return 1
 }
 
+mime_type_label()
+{
+    case "$1" in
+        x-scheme-handler/ableton) printf '%s\n' 'Ableton browser links' ;;
+        application/x-wine-extension-auz) printf '%s\n' 'Ableton authorisation files (.auz)' ;;
+        application/x-ableton-live-set) printf '%s\n' 'Live Sets (.als)' ;;
+        application/x-ableton-live-clip) printf '%s\n' 'Live Clips (.alc)' ;;
+        application/x-ableton-live-pack) printf '%s\n' 'Live Packs (.alp)' ;;
+        application/x-ableton-live-max-device) printf '%s\n' 'Max for Live devices (.amxd)' ;;
+        x-scheme-handler/c74max) printf '%s\n' 'Max callback links' ;;
+        *) printf '%s\n' 'an Ableton file type' ;;
+    esac
+}
+
 # Restoration takes two passes: one needs our desktop entries present, the other
 # needs them gone.
 #
@@ -749,39 +1463,53 @@ mime_id_is_managed()
 # by re-reading mimeapps.list, because a query still resolves the live entries.
 clear_mime_defaults()
 {
-    local type prior explicit current mimeapps
-    [ -r "$restore_mime" ] && command -v xdg-mime >/dev/null 2>&1 || return 0
+    local type prior extra explicit current mimeapps record type_label
+    [ "${#mime_records[@]}" -gt 0 ] || return 0
+    if ! command -v xdg-mime >/dev/null 2>&1; then
+        mime_backend_unavailable=1
+        warn_optional_remaining \
+            "some Ableton file-opening defaults could not be cleared because the xdg-utils tool is missing" \
+            "Install the xdg-utils package before retrying."
+        return 0
+    fi
     mimeapps="${XDG_CONFIG_HOME:-$HOME/.config}/mimeapps.list"
-    echo "== restore MIME defaults =="
-    while IFS=$'\t' read -r type prior; do
+    uninstall_note "== restore previous file-opening defaults =="
+    for record in "${mime_records[@]}"; do
+        IFS=$'\t' read -r type prior extra <<< "$record"
         [ -n "$type" ] || continue
+        type_label="$(mime_type_label "$type")"
         if ! current="$(xdg-mime query default "$type" 2>/dev/null)"; then
-            echo "!! could not inspect the MIME default for $type" >&2
-            mime_partial=1
+            warn_optional_remaining \
+                "the current app for $type_label could not be checked and may still point to Ableton Linux" \
+                "Install xdg-utils or check that it can read your desktop settings, then retry."
             continue
         fi
         if ! explicit="$(mime_explicit_default "$mimeapps" "$type")"; then
-            echo "!! could not read the MIME defaults list for $type" >&2
-            mime_partial=1
+            warn_optional_remaining \
+                "the setting for $type_label was left unchanged because $mimeapps could not be read" \
+                "Check the file permissions before retrying."
             continue
         fi
         mime_id_is_managed "$explicit" || mime_id_is_managed "$current" || continue
         if mime_id_is_managed "$explicit" \
            && ! mime_clear_default "$mimeapps" "$type"; then
-            echo "!! could not clear the MIME default for $type" >&2
-            mime_partial=1
+            warn_optional_remaining \
+                "Ableton Linux is still set to open $type_label in $mimeapps" \
+                "Check the file permissions before retrying."
             continue
         fi
         if ! explicit="$(mime_explicit_default "$mimeapps" "$type")"; then
-            echo "!! could not verify the MIME default for $type" >&2
-            mime_partial=1
+            warn_optional_remaining \
+                "the setting for $type_label could not be verified in $mimeapps" \
+                "Check the file permissions before retrying."
             continue
         fi
         if mime_id_is_managed "$explicit"; then
-            echo "!! the managed MIME default for $type is still active" >&2
-            mime_partial=1
+            warn_optional_remaining \
+                "Ableton Linux is still set to open $type_label in $mimeapps" \
+                "Remove that default or make the file writable before retrying."
         fi
-    done < "$restore_mime"
+    done
     return 0
 }
 
@@ -792,14 +1520,19 @@ clear_mime_defaults()
 # back as an explicit line the user never had.
 reconcile_mime_defaults()
 {
-    local type prior current explicit mimeapps
-    [ -r "$restore_mime" ] && command -v xdg-mime >/dev/null 2>&1 || return 0
+    local type prior extra current explicit mimeapps record type_label
+    [ "$mime_prestate_usable" -eq 1 ] && [ -r "$restore_mime" ] || return 0
+    [ "$mime_backend_unavailable" -eq 0 ] \
+        && command -v xdg-mime >/dev/null 2>&1 || return 0
     mimeapps="${XDG_CONFIG_HOME:-$HOME/.config}/mimeapps.list"
-    while IFS=$'\t' read -r type prior; do
+    for record in "${mime_records[@]}"; do
+        IFS=$'\t' read -r type prior extra <<< "$record"
         [ -n "$type" ] || continue
+        type_label="$(mime_type_label "$type")"
         if ! current="$(xdg-mime query default "$type" 2>/dev/null)"; then
-            echo "!! could not inspect the MIME default for $type" >&2
-            mime_partial=1
+            warn_optional_remaining \
+                "the current app for $type_label could not be checked after Ableton Linux files were removed" \
+                "Install xdg-utils or check that it can read your desktop settings, then retry."
             continue
         fi
         # A prior that is itself a managed id names a file this run deleted, so
@@ -811,115 +1544,445 @@ reconcile_mime_defaults()
                 # of these names can only be a file this run deliberately left
                 # alone.  Where it points is the user's business, and the first
                 # pass already proved no explicit line of ours survives.
-                echo "$type still opens with $current, which this project did not install"
+                uninstall_note "$type_label still uses an app that Ableton Linux did not install; leaving it unchanged"
             fi
             continue
         fi
         [ "$current" != "$prior" ] || continue
-        if ! xdg-mime default "$prior" "$type"; then
-            echo "!! could not restore the MIME default for $type" >&2
-            mime_partial=1
-            continue
-        fi
+        xdg-mime default "$prior" "$type" >/dev/null 2>&1 || true
         if ! explicit="$(mime_explicit_default "$mimeapps" "$type")" \
            || [ "$explicit" != "$prior" ]; then
-            echo "!! could not restore the MIME default for $type" >&2
-            mime_partial=1
+            warn_optional_remaining \
+                "the previous app for $type_label could not be restored" \
+                "Check that $mimeapps is writable, then retry uninstall."
         fi
-    done < "$restore_mime"
+    done
     return 0
 }
 
 restore_mime="$ABLETON_STATE_HOME/mime-prestate.tsv"
+mime_records=()
+if [ "$mime_prestate_usable" -eq 1 ]; then
+    if ! mapfile -t mime_records < "$restore_mime"; then
+        mime_prestate_usable=0
+        mime_records=()
+        warn_optional_remaining \
+            "File-opening defaults were left unchanged because the saved settings at $restore_mime could not be read" \
+            "Check the file permissions before retrying."
+    else
+        declare -A mime_record_types=()
+        for mime_record in "${mime_records[@]}"; do
+            IFS=$'\t' read -r mime_type mime_prior mime_extra <<< "$mime_record"
+            mime_record_valid=1
+            [ -z "$mime_extra" ] && [ -n "$mime_type" ] \
+                && [ -z "${mime_record_types[$mime_type]+x}" ] \
+                || mime_record_valid=0
+            case "$mime_type" in
+                x-scheme-handler/ableton|application/x-wine-extension-auz|\
+                application/x-ableton-live-set|application/x-ableton-live-clip|\
+                application/x-ableton-live-pack|application/x-ableton-live-max-device|\
+                x-scheme-handler/c74max) ;;
+                *) mime_record_valid=0 ;;
+            esac
+            [ -z "$mime_prior" ] \
+                || [[ "$mime_prior" =~ ^[A-Za-z0-9_.+-]+[.]desktop$ ]] \
+                || mime_record_valid=0
+            if [ "$mime_record_valid" -ne 1 ]; then
+                mime_prestate_usable=0
+                mime_records=()
+                warn_optional_remaining \
+                    "File-opening defaults were left unchanged because their saved settings changed before they could be used: $restore_mime" \
+                    "Review that file, then retry if you still want the old defaults restored."
+                break
+            fi
+            mime_record_types["$mime_type"]=1
+        done
+    fi
+fi
+mime_cleanup_authorized="$mime_prestate_usable"
+if [ "$optional_inventory_usable" -eq 0 ]; then
+    mime_cleanup_authorized=0
+    mime_records=()
+elif [ "$mime_cleanup_authorized" -eq 0 ]; then
+    apps="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+    for manifest_record in "${manifest_runtime_records[@]}"; do
+        IFS=$'\t' read -r manifest_kind manifest_path _ <<< "$manifest_record"
+        case "$manifest_kind:$manifest_path" in
+            file:"$apps/ableton-live.desktop"|file:"$apps/max9.desktop"|\
+            file:"$apps/$ABLETON_PROTOCOL_DESKTOP_ID"|\
+            file:"$apps/$ABLETON_AUZ_DESKTOP_ID"|\
+            file:"$apps/wine-protocol-ableton.desktop"|\
+            file:"$apps/wine-extension-auz.desktop"|\
+            file:"$apps/wine-protocol-c74max.desktop")
+                mime_cleanup_authorized=1
+                break ;;
+        esac
+    done
+fi
+if [ "$optional_inventory_usable" -eq 1 ] \
+   && [ "$mime_cleanup_authorized" -eq 0 ]; then
+    for mime_project_entry in \
+        "${XDG_DATA_HOME:-$HOME/.local/share}/applications/ableton-live.desktop" \
+        "${XDG_DATA_HOME:-$HOME/.local/share}/applications/max9.desktop" \
+        "${XDG_DATA_HOME:-$HOME/.local/share}/applications/$ABLETON_PROTOCOL_DESKTOP_ID" \
+        "${XDG_DATA_HOME:-$HOME/.local/share}/applications/$ABLETON_AUZ_DESKTOP_ID" \
+        "${XDG_DATA_HOME:-$HOME/.local/share}/applications/wine-protocol-c74max.desktop"; do
+        if ableton_legacy_owned_path "$mime_project_entry"; then
+            mime_cleanup_authorized=1
+            break
+        fi
+    done
+fi
+if [ "$mime_cleanup_authorized" -eq 1 ] && [ "${#mime_records[@]}" -eq 0 ]; then
+    # Current installs own their default-handler IDs authoritatively and do not
+    # retain the default they replaced. Remove only our exact IDs; every other
+    # mimeapps.list line stays byte-for-byte in place.
+    mime_records=(
+        $'x-scheme-handler/ableton\t'
+        $'application/x-wine-extension-auz\t'
+        $'application/x-ableton-live-set\t'
+        $'application/x-ableton-live-clip\t'
+        $'application/x-ableton-live-pack\t'
+        $'application/x-ableton-live-max-device\t'
+        $'x-scheme-handler/c74max\t'
+    )
+fi
 clear_mime_defaults
-echo "== remove owned runtime and integration =="
-remove_legacy_panel_files
-if [ -r "$manifest" ]; then
-    if ! remove_owned_manifest_files; then uninstall_partial=1; fi
-else
+uninstall_note "== remove the Wine runtime, launchers, and support files =="
+if [ "$optional_inventory_usable" -eq 1 ]; then
+    if ! remove_legacy_panel_files; then
+        warn_optional_remaining \
+            "PipeASIO Settings shortcuts were left unchanged because the installer could not confirm that it created them" \
+            "Inspect those shortcuts and retry after repairing the installer's file list."
+    fi
+fi
+if [ "$manifest_present" -eq 1 ] && [ "$optional_inventory_usable" -eq 1 ]; then
+    if ! remove_owned_manifest_files; then
+        leave_optional_inventory_untouched
+        warn_optional_remaining \
+            "some Ableton Linux launchers or support files were left unchanged because the installer could not confirm that it created them" \
+            "Inspect the remaining files and retry after repairing the installer's file list."
+    fi
+elif [ "$manifest_present" -eq 0 ] && [ "$optional_inventory_usable" -eq 1 ]; then
     remove_legacy_files
 fi
-if [ "$uninstall_partial" -eq 1 ]; then
-    echo "!! uninstall could not restore every managed file; runtime and ownership state were retained" >&2
-    exit 1
+
+# Revalidate every recursive target as one complete set immediately before the
+# first tree deletion. Integration cleanup above is intentionally non-fatal,
+# but it must never weaken the ownership proof for a runtime removal.
+if [ "$delete_prefix" -eq 1 ] \
+   && { [ -e "$safe_prefix" ] || [ -L "$safe_prefix" ]; }; then
+    prefix_safe="$(ableton_path_is_safe_delete_target "$safe_prefix")" || {
+        echo "!! refusing an unsafe prefix target: $safe_prefix" >&2
+        exit 1
+    }
+    if [ "$prefix_safe" != "$safe_prefix" ] || [ -L "$safe_prefix" ] \
+       || ! ableton_prefix_marker_valid "$safe_prefix" "$safe_prefix"; then
+        echo "!! The Wine prefix at $safe_prefix changed or is no longer recognised; the runtime and prefix were left unchanged." >&2
+        exit 1
+    fi
 fi
 for candidate in "${managed_runtimes[@]}"; do
-    if [ -e "$candidate" ]; then
-        if ! ableton_runtime_marker_valid "$candidate" "${managed_runtime_names[$candidate]}"; then
-            echo "!! kept runtime with an invalid ownership marker: $candidate" >&2
-            uninstall_partial=1
-        elif ! rm -rf -- "$candidate" || [ -e "$candidate" ] || [ -L "$candidate" ]; then
-            echo "!! could not remove managed runtime $candidate" >&2
-            uninstall_partial=1
-        else
-            echo "removed $candidate"
+    [ -z "${skipped_managed_runtimes[$candidate]+x}" ] || continue
+    [ ! -e "$candidate" ] && [ ! -L "$candidate" ] && continue
+    candidate_safe=""
+    candidate_target_valid=1
+    candidate_safe="$(ableton_path_is_safe_delete_target "$candidate")" \
+        || candidate_target_valid=0
+    if [ "$candidate_target_valid" -ne 1 ] \
+       || [ "$candidate_safe" != "$candidate" ] || [ -L "$candidate" ] \
+       || ! ableton_runtime_marker_valid "$candidate" "${managed_runtime_names[$candidate]}"; then
+        if [ "$candidate" = "$safe_runtime" ]; then
+            echo "!! The Wine runtime at $candidate changed or is no longer recognised; the runtime and prefix were left unchanged." >&2
+            exit 1
         fi
+        skipped_managed_runtimes["$candidate"]=1
+        warn_optional_remaining \
+            "an older Wine runtime was left unchanged because its location is no longer recognised: $candidate" \
+            "Inspect that runtime before retrying."
     fi
-    # Dated rollbacks and failed candidates are project-owned siblings.  Do
-    # not traverse symlinks and require a Wine binary or marker before deletion.
-    runtime_parent="$(dirname "$candidate")"
-    runtime_base="$(basename "$candidate")"
-    while IFS= read -r -d '' old_runtime; do
-        [ -n "$old_runtime" ] || continue
-        old_runtime_base="$(basename "$old_runtime")"
-        if [[ "$old_runtime_base" != "$runtime_base-rollback-"* \
-           && "$old_runtime_base" != "$runtime_base.failed-"* \
-           && "$old_runtime_base" != "$runtime_base.transaction-"* ]]; then
-            continue
-        fi
-        [ ! -L "$old_runtime" ] || { echo "kept symlink rollback $old_runtime" >&2; continue; }
-        ableton_runtime_marker_valid "$old_runtime" "${managed_runtime_names[$candidate]}" || {
-            echo "kept rollback with an invalid ownership marker: $old_runtime" >&2
-            continue
-        }
-        if ! rm -rf -- "$old_runtime" || [ -e "$old_runtime" ] || [ -L "$old_runtime" ]; then
-            echo "!! could not remove managed rollback $old_runtime" >&2
-            uninstall_partial=1
-        else
-            echo "removed $old_runtime"
-        fi
-    done < <(find "$runtime_parent" -maxdepth 1 -mindepth 1 -type d -print0 2>/dev/null)
+done
+for old_runtime in "${managed_rollbacks[@]}"; do
+    if [ "$optional_inventory_usable" -eq 0 ] \
+       && [ "${managed_rollback_owners[$old_runtime]}" != "$safe_runtime" ]; then
+        skipped_managed_rollbacks["$old_runtime"]=1
+        continue
+    fi
+    [ ! -e "$old_runtime" ] && [ ! -L "$old_runtime" ] && continue
+    old_runtime_safe=""
+    old_runtime_target_valid=1
+    old_runtime_safe="$(ableton_path_is_safe_delete_target "$old_runtime")" \
+        || old_runtime_target_valid=0
+    if [ "$old_runtime_target_valid" -ne 1 ] \
+       || [ "$old_runtime_safe" != "$old_runtime" ] || [ -L "$old_runtime" ] \
+       || [ -z "${managed_rollback_names[$old_runtime]:-}" ] \
+       || ! ableton_runtime_marker_valid \
+            "$old_runtime" "${managed_rollback_names[$old_runtime]}"; then
+        skipped_managed_rollbacks["$old_runtime"]=1
+        warn_optional_remaining \
+            "an older saved Wine runtime was left unchanged because its target is no longer recognised: $old_runtime" \
+            "Inspect that runtime before retrying."
+    fi
 done
 
-update-mime-database "${XDG_DATA_HOME:-$HOME/.local/share}/mime" >/dev/null 2>&1 || true
-update-desktop-database "${XDG_DATA_HOME:-$HOME/.local/share}/applications" >/dev/null 2>&1 || true
-reconcile_mime_defaults
-
-if [ "$delete_prefix" -eq 1 ] && [ -e "$safe_prefix" ]; then
-    if ! ableton_prefix_marker_valid "$safe_prefix" "$safe_prefix"; then
-        echo "!! kept prefix with an invalid ownership marker: $safe_prefix" >&2
-        uninstall_partial=1
-    elif ! rm -rf -- "$safe_prefix" || [ -e "$safe_prefix" ] || [ -L "$safe_prefix" ]; then
-        echo "!! could not remove managed prefix $safe_prefix" >&2
-        uninstall_partial=1
-    else
-        echo "removed $safe_prefix"
+for candidate in "${managed_runtimes[@]}"; do
+    [ -z "${skipped_managed_runtimes[$candidate]+x}" ] || continue
+    if [ -e "$candidate" ] || [ -L "$candidate" ]; then
+        candidate_safe=""
+        candidate_target_valid=1
+        candidate_safe="$(ableton_path_is_safe_delete_target "$candidate")" \
+            || candidate_target_valid=0
+        if [ "$candidate_target_valid" -ne 1 ] \
+           || [ "$candidate_safe" != "$candidate" ] || [ -L "$candidate" ] \
+           || ! ableton_runtime_marker_valid \
+                "$candidate" "${managed_runtime_names[$candidate]}"; then
+            if [ "$candidate" = "$safe_runtime" ]; then
+                echo "!! The Wine runtime at $candidate changed or is no longer recognised; it was left unchanged and deletion stopped." >&2
+                exit 1
+            fi
+            skipped_managed_runtimes["$candidate"]=1
+            warn_optional_remaining \
+                "an older Wine runtime was left unchanged because its location changed before removal: $candidate" \
+                "Inspect that runtime before retrying."
+            continue
+        fi
+        rm -rf -- "$candidate" 2>/dev/null || true
+        if [ -e "$candidate" ] || [ -L "$candidate" ]; then
+            if [ "$candidate" = "$safe_runtime" ]; then
+                echo "!! could not remove configured runtime $candidate" >&2
+                uninstall_partial=1
+            else
+                warn_optional_remaining \
+                    "an older Wine runtime remains at $candidate" \
+                    "Check its permissions before retrying."
+            fi
+        else
+            uninstall_note "removed $candidate"
+        fi
     fi
-elif [ -e "$safe_prefix" ] || [ -L "$safe_prefix" ]; then
-    echo "kept Wine prefix $safe_prefix"
-else
-    echo "no Wine prefix to remove at $safe_prefix"
-fi
+done
+for old_runtime in "${managed_rollbacks[@]}"; do
+    [ -z "${skipped_managed_rollbacks[$old_runtime]+x}" ] || continue
+    if [ -e "$old_runtime" ] || [ -L "$old_runtime" ]; then
+        old_runtime_safe=""
+        old_runtime_target_valid=1
+        old_runtime_safe="$(ableton_path_is_safe_delete_target "$old_runtime")" \
+            || old_runtime_target_valid=0
+        if [ "$old_runtime_target_valid" -ne 1 ] \
+           || [ "$old_runtime_safe" != "$old_runtime" ] || [ -L "$old_runtime" ] \
+           || ! ableton_runtime_marker_valid \
+                "$old_runtime" "${managed_rollback_names[$old_runtime]}"; then
+            warn_optional_remaining \
+                "an older saved Wine runtime was left unchanged because its target changed before removal: $old_runtime" \
+                "Inspect that runtime before retrying."
+            continue
+        fi
+        rm -rf -- "$old_runtime" 2>/dev/null || true
+        if [ -e "$old_runtime" ] || [ -L "$old_runtime" ]; then
+            warn_optional_remaining \
+                "an older saved Wine runtime remains at $old_runtime" \
+                "Check its permissions before retrying."
+        else
+            uninstall_note "removed $old_runtime"
+        fi
+    fi
+done
 
-if [ "$mime_partial" -eq 1 ]; then uninstall_partial=1; fi
 if [ "$uninstall_partial" -eq 1 ]; then
-    echo "!! uninstall left modified managed files in place; ownership state was retained" >&2
+    echo "!! runtime removal is incomplete; prefix and uninstall support files were retained" >&2
+    print_uninstall_retry
     exit 1
 fi
-if ableton_managed_config_valid "$ABLETON_CONFIG_FILE"; then
-    rm -f -- "$ABLETON_CONFIG_FILE"
+
+mime_cache_dir="${XDG_DATA_HOME:-$HOME/.local/share}/mime"
+if [ -d "$mime_cache_dir" ]; then
+    if ! command -v update-mime-database >/dev/null 2>&1; then
+        warn_optional_notice \
+            "the desktop file-type cache was not refreshed under $mime_cache_dir" \
+            "Install shared-mime-info, then rerun uninstall or update-mime-database for that directory."
+    elif ! update-mime-database "$mime_cache_dir" >/dev/null 2>&1; then
+        warn_optional_notice \
+            "the desktop file-type cache could not be refreshed under $mime_cache_dir" \
+            "Check the directory permissions, then rerun uninstall or update-mime-database for that directory."
+    fi
 fi
+desktop_cache_dir="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+if [ -d "$desktop_cache_dir" ]; then
+    if ! command -v update-desktop-database >/dev/null 2>&1; then
+        warn_optional_notice \
+            "the desktop application cache was not refreshed under $desktop_cache_dir" \
+            "Install desktop-file-utils, then rerun uninstall or update-desktop-database for that directory."
+    elif ! update-desktop-database "$desktop_cache_dir" >/dev/null 2>&1; then
+        warn_optional_notice \
+            "the desktop application cache could not be refreshed under $desktop_cache_dir" \
+            "Check the directory permissions, then rerun uninstall or update-desktop-database for that directory."
+    fi
+fi
+reconcile_mime_defaults
+
+if [ "$delete_prefix" -eq 1 ] \
+   && { [ -e "$safe_prefix" ] || [ -L "$safe_prefix" ]; }; then
+    prefix_safe="$(ableton_path_is_safe_delete_target "$safe_prefix")" || {
+        echo "!! refusing an unsafe prefix target: $safe_prefix" >&2
+        exit 1
+    }
+    if [ "$prefix_safe" != "$safe_prefix" ] || [ -L "$safe_prefix" ] \
+       || ! ableton_prefix_marker_valid "$safe_prefix" "$safe_prefix"; then
+        echo "!! The Wine prefix at $safe_prefix changed or is no longer recognised; it was left unchanged." >&2
+        exit 1
+    fi
+    rm -rf -- "$safe_prefix" 2>/dev/null || true
+    if [ -e "$safe_prefix" ] || [ -L "$safe_prefix" ]; then
+        echo "!! The Wine prefix could not be removed: $safe_prefix" >&2
+        uninstall_partial=1
+    else
+        uninstall_note "removed $safe_prefix"
+    fi
+elif [ -e "$safe_prefix" ] || [ -L "$safe_prefix" ]; then
+    uninstall_note "kept Wine prefix $safe_prefix"
+else
+    uninstall_note "no Wine prefix to remove at $safe_prefix"
+fi
+
+if [ "$uninstall_partial" -eq 1 ]; then
+    echo "!! prefix removal is incomplete; uninstall support files were retained" >&2
+    print_uninstall_retry
+    exit 1
+fi
+
 safe_cache="$(ableton_path_is_safe_delete_target "$ABLETON_CACHE_HOME")" || safe_cache=""
 [ ! -L "$ABLETON_CACHE_HOME" ] || safe_cache=""
-[ -z "$safe_cache" ] || rmdir -- "$safe_cache" 2>/dev/null || true
-rm -f -- "$manifest" "$restore_mime"
-rmdir -- "$ABLETON_CONFIG_HOME" "$ABLETON_DATA_HOME/lib" "$ABLETON_DATA_HOME" 2>/dev/null || true
-safe_state="$(ableton_path_is_safe_delete_target "$ABLETON_STATE_HOME")" || safe_state=""
-[ ! -L "$ABLETON_STATE_HOME" ] || safe_state=""
-if [ -n "$safe_state" ] \
-   && ableton_state_marker_valid "$safe_state"; then
-    rm -rf -- "$safe_state"
-elif [ -n "$safe_state" ]; then
-    rmdir -- "$safe_state/transactions" "$safe_state/logs" "$safe_state/run" "$safe_state" 2>/dev/null || true
+if [ -n "$safe_cache" ]; then
+    rmdir -- "$safe_cache" 2>/dev/null || true
+    if [ -e "$safe_cache" ] || [ -L "$safe_cache" ]; then
+        warn_optional_notice \
+            "the Ableton Linux cache directory remains at $safe_cache" \
+            "Remove it after checking that it contains no files you need."
+    fi
+elif [ -e "$ABLETON_CACHE_HOME" ] || [ -L "$ABLETON_CACHE_HOME" ]; then
+    warn_optional_notice \
+        "the project cache path was left unchanged because it is not a safe empty directory: $ABLETON_CACHE_HOME" \
+        "Inspect that path and remove it manually only if you recognise it."
 fi
-echo "OK: uninstall complete"
+
+# Keep enough project support information for a direct retry whenever an
+# earlier optional operation left something behind. Otherwise retire each
+# support object by outcome, never by a cleanup command's status alone.
+if [ "$retain_retry_support" -eq 0 ]; then
+    rm -f -- "$restore_mime" 2>/dev/null || true
+    if [ -e "$restore_mime" ] || [ -L "$restore_mime" ]; then
+        warn_optional_remaining \
+            "saved file-opening settings remain at $restore_mime" \
+            "Check the file permissions before retrying."
+    fi
+fi
+if [ "$retain_retry_support" -eq 0 ]; then
+    rm -f -- "$manifest" 2>/dev/null || true
+    if [ -e "$manifest" ] || [ -L "$manifest" ]; then
+        warn_optional_remaining \
+            "the Ableton Linux file list remains at $manifest" \
+            "Check the file permissions before retrying."
+    fi
+fi
+
+if [ "$retain_retry_support" -eq 0 ]; then
+    # Managed-file failures have already retained the manifest above.  A data
+    # directory can stay nonempty because uninstall just restored the user's
+    # earlier files (or because it contains unrelated files).  Preserve those
+    # contents without inventing a cleanup failure or retaining stale recovery
+    # state forever.
+    rmdir -- "$ABLETON_DATA_HOME/lib" "$ABLETON_DATA_HOME" 2>/dev/null || true
+fi
+
+if [ "$retain_retry_support" -eq 0 ] \
+   && { [ -e "$ABLETON_CONFIG_FILE" ] || [ -L "$ABLETON_CONFIG_FILE" ]; }; then
+    if ableton_managed_config_valid "$ABLETON_CONFIG_FILE"; then
+        rm -f -- "$ABLETON_CONFIG_FILE" 2>/dev/null || true
+        if [ -e "$ABLETON_CONFIG_FILE" ] || [ -L "$ABLETON_CONFIG_FILE" ]; then
+            warn_optional_remaining \
+                "installer settings remain at $ABLETON_CONFIG_FILE" \
+                "Check the file permissions before retrying."
+        fi
+    else
+        warn_optional_remaining \
+            "installer settings at $ABLETON_CONFIG_FILE changed during uninstall and were preserved" \
+            "Inspect them and remove them manually only if you recognise them as Ableton Linux settings."
+    fi
+fi
+if [ "$retain_retry_support" -eq 0 ]; then
+    # As with the data directory, unrelated files beside the managed settings
+    # are not failed uninstall work and do not need installer recovery records.
+    rmdir -- "$ABLETON_CONFIG_HOME" 2>/dev/null || true
+fi
+
+if [ "$retain_retry_support" -eq 0 ] \
+   && { [ -e "$ABLETON_STATE_HOME" ] || [ -L "$ABLETON_STATE_HOME" ]; }; then
+    safe_state=""
+    if ! safe_state="$(ableton_path_is_safe_delete_target "$ABLETON_STATE_HOME")"; then
+        warn_optional_remaining \
+            "Ableton Linux support files were left unchanged because their directory is not safe to remove: $ABLETON_STATE_HOME" \
+            "Inspect that path and remove it manually only if you recognise it."
+    elif [ "$safe_state" != "$ABLETON_STATE_HOME" ] || [ -L "$ABLETON_STATE_HOME" ] \
+         || ! ableton_state_marker_valid "$safe_state"; then
+        warn_optional_remaining \
+            "Ableton Linux support files were left unchanged because the installer could not confirm that it created their directory: $ABLETON_STATE_HOME" \
+            "Inspect that directory before retrying."
+    else
+        state_marker="$safe_state/.ableton-linux-state"
+        # Keep the ownership marker until every other entry is gone. A partial
+        # recursive cleanup therefore remains safe and directly retryable.
+        find "$safe_state" -depth -mindepth 1 ! -path "$state_marker" \
+            -delete >/dev/null 2>&1 || true
+        if ! state_remaining="$(find "$safe_state" -mindepth 1 \
+                ! -path "$state_marker" -printf x -quit 2>/dev/null)"; then
+            warn_optional_remaining \
+                "Ableton Linux support files could not be fully checked after cleanup at $safe_state" \
+                "Check the directory permissions and contents before retrying."
+        elif [ -n "$state_remaining" ]; then
+            warn_optional_remaining \
+                "Ableton Linux support files remain at $safe_state" \
+                "Check the remaining files and directory permissions before retrying."
+        elif ! ableton_state_marker_valid "$safe_state"; then
+            warn_optional_remaining \
+                "the Ableton Linux support directory changed during cleanup and was kept at $safe_state" \
+                "Inspect that directory before retrying."
+        else
+            rm -f -- "$state_marker" 2>/dev/null || true
+            if [ -e "$state_marker" ] || [ -L "$state_marker" ]; then
+                warn_optional_remaining \
+                    "the final Ableton Linux support record remains at $state_marker" \
+                    "Check the file permissions before retrying."
+            else
+                rmdir -- "$safe_state" 2>/dev/null || true
+                if [ -e "$safe_state" ] || [ -L "$safe_state" ]; then
+                    if [ -d "$safe_state" ] && [ ! -L "$safe_state" ]; then
+                        state_marker_tmp="$(mktemp "$safe_state/.state-marker.XXXXXX" 2>/dev/null || true)"
+                        if [ -n "$state_marker_tmp" ]; then
+                            if ! printf 'format=1\nowner=ableton-linux\n' > "$state_marker_tmp" \
+                               || ! chmod 600 "$state_marker_tmp" \
+                               || ! mv -T -n -- "$state_marker_tmp" "$state_marker"; then
+                                rm -f -- "$state_marker_tmp" 2>/dev/null || true
+                            fi
+                        fi
+                    fi
+                    if ableton_state_marker_valid "$safe_state"; then
+                        warn_optional_remaining \
+                            "the empty Ableton Linux support directory remains at $safe_state" \
+                            "Check the parent-directory permissions before retrying."
+                    else
+                        warn_optional_remaining \
+                            "an empty Ableton Linux support path remains at $safe_state and could not be prepared for an automatic retry" \
+                            "Inspect it, then remove that empty path manually."
+                    fi
+                fi
+            fi
+        fi
+    fi
+fi
+
+if [ "$optional_cleanup_incomplete" -eq 1 ]; then
+    uninstall_note "OK: runtime and requested prefix removal completed; the warnings above describe optional items that remain"
+else
+    uninstall_note "OK: uninstall complete"
+fi
+[ "$retain_retry_support" -eq 0 ] || print_uninstall_retry


### PR DESCRIPTION
Caught some shitass regressions in the installer, so rather than make things clever again, this PR simplifies how the installer decides that an install succeeded or not. 

tl;dr we can now only 'fail' when we encounter a problem with the Wire  runtime, the prefix, a user's Live installation, or PipeASIO registration. All of these are represented as one result.

Everything else is secondary, and use separate repair steps when something goes wrong. We now warn users when the secondary part of the installer encounters a problem rather than eating shit like a full blown cringelord.

This PR will fix #280 and numerous DMs I've received that read exactly like #280.