### PR TITLE
Make the build audit locale-independent

### DIFF
--- a/scripts/build-audit.sh
+++ b/scripts/build-audit.sh
@@ -2,6 +2,9 @@
 # Audit a runtime artifact against the frozen patch stack (patches/SERIES.sha256): patch file hashes,
 # build stamp, per-patch binary fingerprints. Arg: tarball, tree, or --freeze; defaults to newest dist/*.tar.zst.
 set -euo pipefail
+# readelf localises its output, so the DT_NEEDED checks below - which match the
+# English literal "Shared library: [...]" - fail on any non-English system.
+export LC_ALL=C.UTF-8
 here="$(cd "$(dirname "$0")" && pwd)"
 root="$(cd "$here/.." && pwd)"
 NAME="wine-d2d1-nspa-11.13"


### PR DESCRIPTION
`readelf` translates its output, so the `DT_NEEDED` checks in `build-audit.sh` — which match the English literal `Shared library: [...]` — never match on a non-English system. The audit then reports five failures that read like missing libraries:

```
libusb-1.0.so DT_NEEDED           FAIL host libusb-1.0.so.0 not linked
pipeasio.dll.so DT_NEEDED         FAIL host libpipewire-0.3.so.0 not linked
pipewire-version-probe DT_NEEDED  FAIL unexpected libraries:
pipeasio-settings FAIL            libQt6Widgets.so.6 not linked
winegstreamer.so DT_NEEDED        FAIL host libgstreamer-1.0.so.0 not linked
```

Every one of those libraries is present and correctly linked. German `readelf` just prints `Gemeinsame Bibliothek [libgstreamer-1.0.so.0]`.

What makes it awkward to diagnose is that the **same build passes its in-container audit** (locale is C there) and fails the host audit that runs afterwards. So `build.sh` refuses the artifact at step 5 of 7, pointing at a layer that is not the problem — my first assumption was that the container was missing dev packages, which it is not.

**Fix:** `export LC_ALL=C.UTF-8`, matching `scripts/install.sh`, `scripts/make-installer.sh` and `scripts/setup-run-header.sh`, which already do this. `build-audit.sh` sets `LC_ALL=C` for one `sort` call but not globally.

**Verified** on Ubuntu with `LANG=de_DE.UTF-8`, auditing the same artifact:

| | before | after |
|---|---:|---:|
| failed checks | 5 of 183 | 0 of the DT_NEEDED ones |

(The single remaining failure in my run is `BUILD-INFO source tree`, which is expected — I audited from a worktree carrying this patch, so the tree hash legitimately differs from the recorded one.)

Context: I hit this while building your stack to try to reproduce #87 on a different setup. Given how many German-speaking Ableton users there are, this likely affects more people than it appears — the failure mode sends you looking for missing packages.