### PR TITLE
feat(launcher): add guidance for clearing stale transactions

### DIFF
--- a/scripts/ableton-live
+++ b/scripts/ableton-live
@@ -470,6 +470,8 @@ if ableton_install_state_has_active_transaction; then
     [ -n "$active_transaction" ] || active_transaction="$ABLETON_STATE_HOME/transactions"
     echo "ableton-live: an earlier install stopped before it restored the Wine runtime or prefix." >&2
     echo "ableton-live: keep the recovery files at $active_transaction and report the problem before launching Live." >&2
+    echo "ableton-live: To unblock the launcher after reporting, remove the recovery directory:" >&2
+    echo "ableton-live:   rm -rf \"$active_transaction\"" >&2
     ableton_install_lock_release || true
     exit 1
 fi

--- a/scripts/max9
+++ b/scripts/max9
@@ -83,6 +83,8 @@ if ableton_install_state_has_active_transaction; then
     [ -n "$active_transaction" ] || active_transaction="$ABLETON_STATE_HOME/transactions"
     echo "max9: an earlier install stopped before it restored the Wine runtime or prefix." >&2
     echo "max9: keep the recovery files at $active_transaction and report the problem before launching Max." >&2
+    echo "max9: To unblock the launcher after reporting, remove the recovery directory:" >&2
+    echo "max9:   rm -rf \"$active_transaction\"" >&2
     ableton_install_lock_release || true
     exit 1
 fi


### PR DESCRIPTION
When an installation is interrupted, the launcher blocks execution with a message asking the user to report the problem. This commit adds a follow-up instruction showing how to remove the recovery directory to unblock the launcher. This will help future users quickly resolve the issue after reporting it.

_Note: This contribution is a translation created with the help of AI._